### PR TITLE
Adds TS aliases

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -28,6 +28,32 @@
  * under the License.
  */
 
+/**
+ * For new files created by OpenSearch Contributors
+ */
+const OSD_NEW_HEADER = `
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+`;
+
+/**
+ * For modified files and files with external open source code
+ */
+const OSD_HEADER = `
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+`;
+
 const APACHE_2_0_LICENSE_HEADER = `
 /*
  * Licensed to Elasticsearch B.V. under one or more contributor
@@ -85,9 +111,9 @@ module.exports = {
     'local/href-with-rel': 'error',
     'local/forward-ref': 'error',
     'local/require-license-header': [
-      'warn',
+      'error',
       {
-        license: APACHE_2_0_LICENSE_HEADER,
+        licenses: [OSD_NEW_HEADER, OSD_HEADER],
       },
     ],
     'no-use-before-define': 'off',

--- a/i18ntokens.json
+++ b/i18ntokens.json
@@ -5,11 +5,11 @@
     "highlighting": "string",
     "loc": {
       "start": {
-        "line": 263,
+        "line": 274,
         "column": 14
       },
       "end": {
-        "line": 263,
+        "line": 274,
         "column": 74
       }
     },
@@ -21,11 +21,11 @@
     "highlighting": "string",
     "loc": {
       "start": {
-        "line": 676,
+        "line": 687,
         "column": 10
       },
       "end": {
-        "line": 686,
+        "line": 697,
         "column": 12
       }
     },
@@ -37,11 +37,11 @@
     "highlighting": "string",
     "loc": {
       "start": {
-        "line": 695,
+        "line": 706,
         "column": 12
       },
       "end": {
-        "line": 706,
+        "line": 717,
         "column": 14
       }
     },
@@ -53,11 +53,11 @@
     "highlighting": "string",
     "loc": {
       "start": {
-        "line": 710,
+        "line": 721,
         "column": 12
       },
       "end": {
-        "line": 720,
+        "line": 731,
         "column": 14
       }
     },
@@ -69,11 +69,11 @@
     "highlighting": "string",
     "loc": {
       "start": {
-        "line": 725,
+        "line": 736,
         "column": 10
       },
       "end": {
-        "line": 731,
+        "line": 742,
         "column": 12
       }
     },
@@ -85,11 +85,11 @@
     "highlighting": "string",
     "loc": {
       "start": {
-        "line": 771,
+        "line": 782,
         "column": 6
       },
       "end": {
-        "line": 771,
+        "line": 782,
         "column": 77
       }
     },
@@ -101,11 +101,11 @@
     "highlighting": "string",
     "loc": {
       "start": {
-        "line": 1168,
+        "line": 1179,
         "column": 8
       },
       "end": {
-        "line": 1168,
+        "line": 1179,
         "column": 79
       }
     },
@@ -117,11 +117,11 @@
     "highlighting": "string",
     "loc": {
       "start": {
-        "line": 1389,
+        "line": 1400,
         "column": 10
       },
       "end": {
-        "line": 1393,
+        "line": 1404,
         "column": 12
       }
     },
@@ -133,11 +133,11 @@
     "highlighting": "string",
     "loc": {
       "start": {
-        "line": 178,
+        "line": 189,
         "column": 6
       },
       "end": {
-        "line": 178,
+        "line": 189,
         "column": 80
       }
     },
@@ -149,11 +149,11 @@
     "highlighting": "string",
     "loc": {
       "start": {
-        "line": 195,
+        "line": 206,
         "column": 6
       },
       "end": {
-        "line": 195,
+        "line": 206,
         "column": 80
       }
     },
@@ -165,11 +165,11 @@
     "highlighting": "string",
     "loc": {
       "start": {
-        "line": 180,
+        "line": 191,
         "column": 8
       },
       "end": {
-        "line": 182,
+        "line": 193,
         "column": 40
       }
     },
@@ -181,11 +181,11 @@
     "highlighting": "string",
     "loc": {
       "start": {
-        "line": 206,
+        "line": 217,
         "column": 14
       },
       "end": {
-        "line": 210,
+        "line": 221,
         "column": 16
       }
     },
@@ -197,11 +197,11 @@
     "highlighting": "string",
     "loc": {
       "start": {
-        "line": 212,
+        "line": 223,
         "column": 14
       },
       "end": {
-        "line": 215,
+        "line": 226,
         "column": 16
       }
     },
@@ -213,11 +213,11 @@
     "highlighting": "string",
     "loc": {
       "start": {
-        "line": 136,
+        "line": 147,
         "column": 6
       },
       "end": {
-        "line": 138,
+        "line": 149,
         "column": 45
       }
     },
@@ -229,11 +229,11 @@
     "highlighting": "string",
     "loc": {
       "start": {
-        "line": 82,
+        "line": 93,
         "column": 11
       },
       "end": {
-        "line": 82,
+        "line": 93,
         "column": 72
       }
     },
@@ -245,11 +245,11 @@
     "highlighting": "string",
     "loc": {
       "start": {
-        "line": 84,
+        "line": 95,
         "column": 11
       },
       "end": {
-        "line": 84,
+        "line": 95,
         "column": 78
       }
     },
@@ -261,11 +261,11 @@
     "highlighting": "string",
     "loc": {
       "start": {
-        "line": 86,
+        "line": 97,
         "column": 11
       },
       "end": {
-        "line": 86,
+        "line": 97,
         "column": 68
       }
     },
@@ -277,11 +277,11 @@
     "highlighting": "string",
     "loc": {
       "start": {
-        "line": 263,
+        "line": 274,
         "column": 12
       },
       "end": {
-        "line": 266,
+        "line": 277,
         "column": 14
       }
     },
@@ -293,11 +293,11 @@
     "highlighting": "string",
     "loc": {
       "start": {
-        "line": 268,
+        "line": 279,
         "column": 12
       },
       "end": {
-        "line": 271,
+        "line": 282,
         "column": 14
       }
     },
@@ -309,11 +309,11 @@
     "highlighting": "string",
     "loc": {
       "start": {
-        "line": 277,
+        "line": 288,
         "column": 12
       },
       "end": {
-        "line": 280,
+        "line": 291,
         "column": 14
       }
     },
@@ -325,11 +325,11 @@
     "highlighting": "string",
     "loc": {
       "start": {
-        "line": 282,
+        "line": 293,
         "column": 12
       },
       "end": {
-        "line": 285,
+        "line": 296,
         "column": 14
       }
     },
@@ -341,11 +341,11 @@
     "highlighting": "string",
     "loc": {
       "start": {
-        "line": 326,
+        "line": 337,
         "column": 10
       },
       "end": {
-        "line": 326,
+        "line": 337,
         "column": 66
       }
     },
@@ -357,11 +357,11 @@
     "highlighting": "string",
     "loc": {
       "start": {
-        "line": 351,
+        "line": 362,
         "column": 6
       },
       "end": {
-        "line": 356,
+        "line": 367,
         "column": 42
       }
     },
@@ -373,11 +373,11 @@
     "highlighting": "string",
     "loc": {
       "start": {
-        "line": 351,
+        "line": 362,
         "column": 6
       },
       "end": {
-        "line": 356,
+        "line": 367,
         "column": 42
       }
     },
@@ -389,11 +389,11 @@
     "highlighting": "string",
     "loc": {
       "start": {
-        "line": 453,
+        "line": 464,
         "column": 4
       },
       "end": {
-        "line": 459,
+        "line": 470,
         "column": 71
       }
     },
@@ -405,11 +405,11 @@
     "highlighting": "string",
     "loc": {
       "start": {
-        "line": 453,
+        "line": 464,
         "column": 4
       },
       "end": {
-        "line": 459,
+        "line": 470,
         "column": 71
       }
     },
@@ -421,11 +421,11 @@
     "highlighting": "string",
     "loc": {
       "start": {
-        "line": 453,
+        "line": 464,
         "column": 4
       },
       "end": {
-        "line": 459,
+        "line": 470,
         "column": 71
       }
     },
@@ -437,11 +437,11 @@
     "highlighting": "string",
     "loc": {
       "start": {
-        "line": 524,
+        "line": 535,
         "column": 14
       },
       "end": {
-        "line": 527,
+        "line": 538,
         "column": 55
       }
     },
@@ -453,11 +453,11 @@
     "highlighting": "string",
     "loc": {
       "start": {
-        "line": 552,
+        "line": 563,
         "column": 10
       },
       "end": {
-        "line": 554,
+        "line": 565,
         "column": 52
       }
     },
@@ -469,11 +469,11 @@
     "highlighting": "string",
     "loc": {
       "start": {
-        "line": 611,
+        "line": 622,
         "column": 10
       },
       "end": {
-        "line": 621,
+        "line": 632,
         "column": 15
       }
     },
@@ -485,11 +485,11 @@
     "highlighting": "string",
     "loc": {
       "start": {
-        "line": 611,
+        "line": 622,
         "column": 10
       },
       "end": {
-        "line": 621,
+        "line": 632,
         "column": 15
       }
     },
@@ -501,11 +501,11 @@
     "highlighting": "string",
     "loc": {
       "start": {
-        "line": 611,
+        "line": 622,
         "column": 10
       },
       "end": {
-        "line": 621,
+        "line": 632,
         "column": 15
       }
     },
@@ -517,11 +517,11 @@
     "highlighting": "string",
     "loc": {
       "start": {
-        "line": 673,
+        "line": 684,
         "column": 14
       },
       "end": {
-        "line": 678,
+        "line": 689,
         "column": 16
       }
     },
@@ -533,11 +533,11 @@
     "highlighting": "string",
     "loc": {
       "start": {
-        "line": 277,
+        "line": 288,
         "column": 8
       },
       "end": {
-        "line": 285,
+        "line": 296,
         "column": 13
       }
     },
@@ -549,11 +549,11 @@
     "highlighting": "string",
     "loc": {
       "start": {
-        "line": 277,
+        "line": 288,
         "column": 8
       },
       "end": {
-        "line": 285,
+        "line": 296,
         "column": 13
       }
     },
@@ -565,11 +565,11 @@
     "highlighting": "string",
     "loc": {
       "start": {
-        "line": 321,
+        "line": 332,
         "column": 12
       },
       "end": {
-        "line": 326,
+        "line": 337,
         "column": 14
       }
     },
@@ -581,11 +581,11 @@
     "highlighting": "string",
     "loc": {
       "start": {
-        "line": 331,
+        "line": 342,
         "column": 12
       },
       "end": {
-        "line": 336,
+        "line": 347,
         "column": 65
       }
     },
@@ -597,11 +597,11 @@
     "highlighting": "string",
     "loc": {
       "start": {
-        "line": 331,
+        "line": 342,
         "column": 12
       },
       "end": {
-        "line": 336,
+        "line": 347,
         "column": 65
       }
     },
@@ -613,11 +613,11 @@
     "highlighting": "string",
     "loc": {
       "start": {
-        "line": 361,
+        "line": 372,
         "column": 16
       },
       "end": {
-        "line": 363,
+        "line": 374,
         "column": 45
       }
     },
@@ -629,11 +629,11 @@
     "highlighting": "string",
     "loc": {
       "start": {
-        "line": 521,
+        "line": 532,
         "column": 10
       },
       "end": {
-        "line": 529,
+        "line": 540,
         "column": 12
       }
     },
@@ -645,11 +645,11 @@
     "highlighting": "string",
     "loc": {
       "start": {
-        "line": 59,
+        "line": 70,
         "column": 10
       },
       "end": {
-        "line": 62,
+        "line": 73,
         "column": 12
       }
     },
@@ -661,11 +661,11 @@
     "highlighting": "string",
     "loc": {
       "start": {
-        "line": 163,
+        "line": 174,
         "column": 6
       },
       "end": {
-        "line": 165,
+        "line": 176,
         "column": 64
       }
     },
@@ -677,11 +677,11 @@
     "highlighting": "string",
     "loc": {
       "start": {
-        "line": 188,
+        "line": 199,
         "column": 16
       },
       "end": {
-        "line": 191,
+        "line": 202,
         "column": 18
       }
     },
@@ -693,11 +693,11 @@
     "highlighting": "string",
     "loc": {
       "start": {
-        "line": 80,
+        "line": 91,
         "column": 8
       },
       "end": {
-        "line": 83,
+        "line": 94,
         "column": 32
       }
     },
@@ -709,11 +709,11 @@
     "highlighting": "string",
     "loc": {
       "start": {
-        "line": 331,
+        "line": 342,
         "column": 12
       },
       "end": {
-        "line": 334,
+        "line": 345,
         "column": 14
       }
     },
@@ -725,11 +725,11 @@
     "highlighting": "string",
     "loc": {
       "start": {
-        "line": 344,
+        "line": 355,
         "column": 16
       },
       "end": {
-        "line": 348,
+        "line": 359,
         "column": 18
       }
     },
@@ -741,11 +741,11 @@
     "highlighting": "string",
     "loc": {
       "start": {
-        "line": 362,
+        "line": 373,
         "column": 16
       },
       "end": {
-        "line": 368,
+        "line": 379,
         "column": 18
       }
     },
@@ -757,11 +757,11 @@
     "highlighting": "string",
     "loc": {
       "start": {
-        "line": 397,
+        "line": 408,
         "column": 20
       },
       "end": {
-        "line": 403,
+        "line": 414,
         "column": 22
       }
     },
@@ -773,11 +773,11 @@
     "highlighting": "string",
     "loc": {
       "start": {
-        "line": 414,
+        "line": 425,
         "column": 12
       },
       "end": {
-        "line": 418,
+        "line": 429,
         "column": 14
       }
     },
@@ -789,11 +789,11 @@
     "highlighting": "string",
     "loc": {
       "start": {
-        "line": 425,
+        "line": 436,
         "column": 10
       },
       "end": {
-        "line": 428,
+        "line": 439,
         "column": 12
       }
     },
@@ -805,11 +805,11 @@
     "highlighting": "string",
     "loc": {
       "start": {
-        "line": 434,
+        "line": 445,
         "column": 10
       },
       "end": {
-        "line": 437,
+        "line": 448,
         "column": 12
       }
     },
@@ -821,11 +821,11 @@
     "highlighting": "string",
     "loc": {
       "start": {
-        "line": 434,
+        "line": 445,
         "column": 6
       },
       "end": {
-        "line": 436,
+        "line": 447,
         "column": 38
       }
     },
@@ -837,11 +837,11 @@
     "highlighting": "string",
     "loc": {
       "start": {
-        "line": 469,
+        "line": 480,
         "column": 14
       },
       "end": {
-        "line": 473,
+        "line": 484,
         "column": 16
       }
     },
@@ -853,11 +853,11 @@
     "highlighting": "string",
     "loc": {
       "start": {
-        "line": 475,
+        "line": 486,
         "column": 14
       },
       "end": {
-        "line": 478,
+        "line": 489,
         "column": 16
       }
     },
@@ -869,11 +869,11 @@
     "highlighting": "string",
     "loc": {
       "start": {
-        "line": 118,
+        "line": 129,
         "column": 8
       },
       "end": {
-        "line": 118,
+        "line": 129,
         "column": 77
       }
     },
@@ -885,11 +885,11 @@
     "highlighting": "string",
     "loc": {
       "start": {
-        "line": 142,
+        "line": 153,
         "column": 8
       },
       "end": {
-        "line": 146,
+        "line": 157,
         "column": 10
       }
     },
@@ -901,11 +901,11 @@
     "highlighting": "string",
     "loc": {
       "start": {
-        "line": 171,
+        "line": 182,
         "column": 8
       },
       "end": {
-        "line": 175,
+        "line": 186,
         "column": 10
       }
     },
@@ -917,11 +917,11 @@
     "highlighting": "string",
     "loc": {
       "start": {
-        "line": 196,
+        "line": 207,
         "column": 13
       },
       "end": {
-        "line": 196,
+        "line": 207,
         "column": 78
       }
     },
@@ -933,11 +933,11 @@
     "highlighting": "string",
     "loc": {
       "start": {
-        "line": 213,
+        "line": 224,
         "column": 8
       },
       "end": {
-        "line": 213,
+        "line": 224,
         "column": 75
       }
     },
@@ -949,11 +949,11 @@
     "highlighting": "string",
     "loc": {
       "start": {
-        "line": 135,
+        "line": 146,
         "column": 4
       },
       "end": {
-        "line": 135,
+        "line": 146,
         "column": 66
       }
     },
@@ -965,11 +965,11 @@
     "highlighting": "string",
     "loc": {
       "start": {
-        "line": 140,
+        "line": 151,
         "column": 6
       },
       "end": {
-        "line": 144,
+        "line": 155,
         "column": 8
       }
     },
@@ -981,11 +981,11 @@
     "highlighting": "string",
     "loc": {
       "start": {
-        "line": 148,
+        "line": 159,
         "column": 6
       },
       "end": {
-        "line": 152,
+        "line": 163,
         "column": 8
       }
     },
@@ -997,11 +997,11 @@
     "highlighting": "string",
     "loc": {
       "start": {
-        "line": 178,
+        "line": 189,
         "column": 12
       },
       "end": {
-        "line": 183,
+        "line": 194,
         "column": 54
       }
     },
@@ -1013,11 +1013,11 @@
     "highlighting": "string",
     "loc": {
       "start": {
-        "line": 178,
+        "line": 189,
         "column": 12
       },
       "end": {
-        "line": 183,
+        "line": 194,
         "column": 54
       }
     },
@@ -1029,11 +1029,11 @@
     "highlighting": "string",
     "loc": {
       "start": {
-        "line": 275,
+        "line": 286,
         "column": 16
       },
       "end": {
-        "line": 278,
+        "line": 289,
         "column": 18
       }
     },
@@ -1045,11 +1045,11 @@
     "highlighting": "string",
     "loc": {
       "start": {
-        "line": 286,
+        "line": 297,
         "column": 16
       },
       "end": {
-        "line": 286,
+        "line": 297,
         "column": 80
       }
     },
@@ -1061,11 +1061,11 @@
     "highlighting": "string",
     "loc": {
       "start": {
-        "line": 50,
+        "line": 61,
         "column": 2
       },
       "end": {
-        "line": 50,
+        "line": 61,
         "column": 76
       }
     },
@@ -1077,11 +1077,11 @@
     "highlighting": "string",
     "loc": {
       "start": {
-        "line": 53,
+        "line": 64,
         "column": 2
       },
       "end": {
-        "line": 53,
+        "line": 64,
         "column": 77
       }
     },
@@ -1093,11 +1093,11 @@
     "highlighting": "string",
     "loc": {
       "start": {
-        "line": 101,
+        "line": 112,
         "column": 14
       },
       "end": {
-        "line": 103,
+        "line": 114,
         "column": 52
       }
     },
@@ -1109,11 +1109,11 @@
     "highlighting": "string",
     "loc": {
       "start": {
-        "line": 118,
+        "line": 129,
         "column": 14
       },
       "end": {
-        "line": 120,
+        "line": 131,
         "column": 54
       }
     },
@@ -1125,11 +1125,11 @@
     "highlighting": "string",
     "loc": {
       "start": {
-        "line": 154,
+        "line": 165,
         "column": 14
       },
       "end": {
-        "line": 156,
+        "line": 167,
         "column": 60
       }
     },
@@ -1141,11 +1141,11 @@
     "highlighting": "string",
     "loc": {
       "start": {
-        "line": 147,
+        "line": 158,
         "column": 8
       },
       "end": {
-        "line": 149,
+        "line": 160,
         "column": 54
       }
     },
@@ -1157,11 +1157,11 @@
     "highlighting": "string",
     "loc": {
       "start": {
-        "line": 147,
+        "line": 158,
         "column": 8
       },
       "end": {
-        "line": 149,
+        "line": 160,
         "column": 54
       }
     },
@@ -1173,11 +1173,11 @@
     "highlighting": "string",
     "loc": {
       "start": {
-        "line": 194,
+        "line": 205,
         "column": 12
       },
       "end": {
-        "line": 197,
+        "line": 208,
         "column": 14
       }
     },
@@ -1189,11 +1189,11 @@
     "highlighting": "string",
     "loc": {
       "start": {
-        "line": 224,
+        "line": 235,
         "column": 22
       },
       "end": {
-        "line": 227,
+        "line": 238,
         "column": 24
       }
     },
@@ -1205,11 +1205,11 @@
     "highlighting": "string",
     "loc": {
       "start": {
-        "line": 230,
+        "line": 241,
         "column": 18
       },
       "end": {
-        "line": 232,
+        "line": 243,
         "column": 40
       }
     },
@@ -1221,11 +1221,11 @@
     "highlighting": "string",
     "loc": {
       "start": {
-        "line": 307,
+        "line": 318,
         "column": 18
       },
       "end": {
-        "line": 310,
+        "line": 321,
         "column": 20
       }
     },
@@ -1237,11 +1237,11 @@
     "highlighting": "string",
     "loc": {
       "start": {
-        "line": 49,
+        "line": 60,
         "column": 4
       },
       "end": {
-        "line": 52,
+        "line": 63,
         "column": 65
       }
     },
@@ -1253,11 +1253,11 @@
     "highlighting": "string",
     "loc": {
       "start": {
-        "line": 140,
+        "line": 151,
         "column": 8
       },
       "end": {
-        "line": 142,
+        "line": 153,
         "column": 39
       }
     },
@@ -1269,11 +1269,11 @@
     "highlighting": "string",
     "loc": {
       "start": {
-        "line": 140,
+        "line": 151,
         "column": 8
       },
       "end": {
-        "line": 142,
+        "line": 153,
         "column": 39
       }
     },
@@ -1285,11 +1285,11 @@
     "highlighting": "string",
     "loc": {
       "start": {
-        "line": 86,
+        "line": 97,
         "column": 32
       },
       "end": {
-        "line": 89,
+        "line": 100,
         "column": 3
       }
     },
@@ -1301,11 +1301,11 @@
     "highlighting": "string",
     "loc": {
       "start": {
-        "line": 106,
+        "line": 117,
         "column": 6
       },
       "end": {
-        "line": 109,
+        "line": 120,
         "column": 8
       }
     },
@@ -1317,11 +1317,11 @@
     "highlighting": "string",
     "loc": {
       "start": {
-        "line": 112,
+        "line": 123,
         "column": 6
       },
       "end": {
-        "line": 115,
+        "line": 126,
         "column": 8
       }
     },
@@ -1333,11 +1333,11 @@
     "highlighting": "string",
     "loc": {
       "start": {
-        "line": 147,
+        "line": 158,
         "column": 6
       },
       "end": {
-        "line": 150,
+        "line": 161,
         "column": 8
       }
     },
@@ -1349,11 +1349,11 @@
     "highlighting": "string",
     "loc": {
       "start": {
-        "line": 153,
+        "line": 164,
         "column": 6
       },
       "end": {
-        "line": 156,
+        "line": 167,
         "column": 8
       }
     },
@@ -1365,11 +1365,11 @@
     "highlighting": "string",
     "loc": {
       "start": {
-        "line": 185,
+        "line": 196,
         "column": 6
       },
       "end": {
-        "line": 185,
+        "line": 196,
         "column": 77
       }
     },
@@ -1381,11 +1381,11 @@
     "highlighting": "string",
     "loc": {
       "start": {
-        "line": 188,
+        "line": 199,
         "column": 6
       },
       "end": {
-        "line": 188,
+        "line": 199,
         "column": 78
       }
     },
@@ -1397,11 +1397,11 @@
     "highlighting": "string",
     "loc": {
       "start": {
-        "line": 222,
+        "line": 233,
         "column": 6
       },
       "end": {
-        "line": 222,
+        "line": 233,
         "column": 80
       }
     },
@@ -1413,11 +1413,11 @@
     "highlighting": "string",
     "loc": {
       "start": {
-        "line": 225,
+        "line": 236,
         "column": 6
       },
       "end": {
-        "line": 228,
+        "line": 239,
         "column": 8
       }
     },
@@ -1429,11 +1429,11 @@
     "highlighting": "string",
     "loc": {
       "start": {
-        "line": 253,
+        "line": 264,
         "column": 6
       },
       "end": {
-        "line": 256,
+        "line": 267,
         "column": 8
       }
     },
@@ -1445,11 +1445,11 @@
     "highlighting": "string",
     "loc": {
       "start": {
-        "line": 259,
+        "line": 270,
         "column": 6
       },
       "end": {
-        "line": 262,
+        "line": 273,
         "column": 8
       }
     },
@@ -1461,11 +1461,11 @@
     "highlighting": "string",
     "loc": {
       "start": {
-        "line": 264,
+        "line": 275,
         "column": 4
       },
       "end": {
-        "line": 267,
+        "line": 278,
         "column": 46
       }
     },
@@ -1477,11 +1477,11 @@
     "highlighting": "string",
     "loc": {
       "start": {
-        "line": 270,
+        "line": 281,
         "column": 10
       },
       "end": {
-        "line": 272,
+        "line": 283,
         "column": 52
       }
     },
@@ -1493,11 +1493,11 @@
     "highlighting": "string",
     "loc": {
       "start": {
-        "line": 979,
+        "line": 990,
         "column": 4
       },
       "end": {
-        "line": 984,
+        "line": 995,
         "column": 53
       }
     },
@@ -1509,11 +1509,11 @@
     "highlighting": "string",
     "loc": {
       "start": {
-        "line": 979,
+        "line": 990,
         "column": 4
       },
       "end": {
-        "line": 984,
+        "line": 995,
         "column": 53
       }
     },
@@ -1525,11 +1525,11 @@
     "highlighting": "string",
     "loc": {
       "start": {
-        "line": 1020,
+        "line": 1031,
         "column": 20
       },
       "end": {
-        "line": 1030,
+        "line": 1041,
         "column": 3
       }
     },
@@ -1541,11 +1541,11 @@
     "highlighting": "string",
     "loc": {
       "start": {
-        "line": 1032,
+        "line": 1043,
         "column": 25
       },
       "end": {
-        "line": 1041,
+        "line": 1052,
         "column": 3
       }
     },
@@ -1557,11 +1557,11 @@
     "highlighting": "string",
     "loc": {
       "start": {
-        "line": 1160,
+        "line": 1171,
         "column": 18
       },
       "end": {
-        "line": 1163,
+        "line": 1174,
         "column": 20
       }
     },
@@ -1573,11 +1573,11 @@
     "highlighting": "string",
     "loc": {
       "start": {
-        "line": 92,
+        "line": 103,
         "column": 10
       },
       "end": {
-        "line": 92,
+        "line": 103,
         "column": 75
       }
     },
@@ -1589,11 +1589,11 @@
     "highlighting": "string",
     "loc": {
       "start": {
-        "line": 95,
+        "line": 106,
         "column": 6
       },
       "end": {
-        "line": 107,
+        "line": 118,
         "column": 11
       }
     },
@@ -1605,11 +1605,11 @@
     "highlighting": "string",
     "loc": {
       "start": {
-        "line": 95,
+        "line": 106,
         "column": 6
       },
       "end": {
-        "line": 107,
+        "line": 118,
         "column": 11
       }
     },
@@ -1621,11 +1621,11 @@
     "highlighting": "string",
     "loc": {
       "start": {
-        "line": 95,
+        "line": 106,
         "column": 6
       },
       "end": {
-        "line": 107,
+        "line": 118,
         "column": 11
       }
     },
@@ -1637,11 +1637,11 @@
     "highlighting": "string",
     "loc": {
       "start": {
-        "line": 95,
+        "line": 106,
         "column": 6
       },
       "end": {
-        "line": 107,
+        "line": 118,
         "column": 11
       }
     },
@@ -1653,11 +1653,11 @@
     "highlighting": "string",
     "loc": {
       "start": {
-        "line": 135,
+        "line": 146,
         "column": 12
       },
       "end": {
-        "line": 140,
+        "line": 151,
         "column": 62
       }
     },
@@ -1669,11 +1669,11 @@
     "highlighting": "string",
     "loc": {
       "start": {
-        "line": 135,
+        "line": 146,
         "column": 12
       },
       "end": {
-        "line": 140,
+        "line": 151,
         "column": 62
       }
     },
@@ -1685,11 +1685,11 @@
     "highlighting": "string",
     "loc": {
       "start": {
-        "line": 159,
+        "line": 170,
         "column": 12
       },
       "end": {
-        "line": 161,
+        "line": 172,
         "column": 43
       }
     },
@@ -1701,11 +1701,11 @@
     "highlighting": "string",
     "loc": {
       "start": {
-        "line": 178,
+        "line": 189,
         "column": 8
       },
       "end": {
-        "line": 181,
+        "line": 192,
         "column": 75
       }
     },
@@ -1717,11 +1717,11 @@
     "highlighting": "string",
     "loc": {
       "start": {
-        "line": 199,
+        "line": 210,
         "column": 14
       },
       "end": {
-        "line": 203,
+        "line": 214,
         "column": 16
       }
     },
@@ -1733,11 +1733,11 @@
     "highlighting": "string",
     "loc": {
       "start": {
-        "line": 209,
+        "line": 220,
         "column": 12
       },
       "end": {
-        "line": 213,
+        "line": 224,
         "column": 14
       }
     },
@@ -1749,11 +1749,11 @@
     "highlighting": "string",
     "loc": {
       "start": {
-        "line": 64,
+        "line": 75,
         "column": 10
       },
       "end": {
-        "line": 67,
+        "line": 78,
         "column": 12
       }
     },
@@ -1765,11 +1765,11 @@
     "highlighting": "string",
     "loc": {
       "start": {
-        "line": 183,
+        "line": 194,
         "column": 8
       },
       "end": {
-        "line": 185,
+        "line": 196,
         "column": 46
       }
     },
@@ -1781,11 +1781,11 @@
     "highlighting": "string",
     "loc": {
       "start": {
-        "line": 202,
+        "line": 213,
         "column": 12
       },
       "end": {
-        "line": 204,
+        "line": 215,
         "column": 37
       }
     },
@@ -1797,11 +1797,11 @@
     "highlighting": "string",
     "loc": {
       "start": {
-        "line": 215,
+        "line": 226,
         "column": 16
       },
       "end": {
-        "line": 217,
+        "line": 228,
         "column": 49
       }
     },
@@ -1813,11 +1813,11 @@
     "highlighting": "string",
     "loc": {
       "start": {
-        "line": 230,
+        "line": 241,
         "column": 16
       },
       "end": {
-        "line": 232,
+        "line": 243,
         "column": 45
       }
     },
@@ -1829,11 +1829,11 @@
     "highlighting": "string",
     "loc": {
       "start": {
-        "line": 250,
+        "line": 261,
         "column": 12
       },
       "end": {
-        "line": 250,
+        "line": 261,
         "column": 76
       }
     },
@@ -1845,11 +1845,11 @@
     "highlighting": "string",
     "loc": {
       "start": {
-        "line": 265,
+        "line": 276,
         "column": 12
       },
       "end": {
-        "line": 265,
+        "line": 276,
         "column": 76
       }
     },
@@ -1861,11 +1861,11 @@
     "highlighting": "string",
     "loc": {
       "start": {
-        "line": 279,
+        "line": 290,
         "column": 12
       },
       "end": {
-        "line": 279,
+        "line": 290,
         "column": 74
       }
     },
@@ -1877,11 +1877,11 @@
     "highlighting": "string",
     "loc": {
       "start": {
-        "line": 300,
+        "line": 311,
         "column": 14
       },
       "end": {
-        "line": 300,
+        "line": 311,
         "column": 76
       }
     },
@@ -1893,11 +1893,11 @@
     "highlighting": "string",
     "loc": {
       "start": {
-        "line": 307,
+        "line": 318,
         "column": 12
       },
       "end": {
-        "line": 315,
+        "line": 326,
         "column": 14
       }
     },
@@ -1909,11 +1909,11 @@
     "highlighting": "string",
     "loc": {
       "start": {
-        "line": 70,
+        "line": 81,
         "column": 10
       },
       "end": {
-        "line": 73,
+        "line": 84,
         "column": 12
       }
     },
@@ -1925,11 +1925,11 @@
     "highlighting": "string",
     "loc": {
       "start": {
-        "line": 190,
+        "line": 201,
         "column": 12
       },
       "end": {
-        "line": 193,
+        "line": 204,
         "column": 14
       }
     },
@@ -1941,11 +1941,11 @@
     "highlighting": "string",
     "loc": {
       "start": {
-        "line": 231,
+        "line": 242,
         "column": 16
       },
       "end": {
-        "line": 231,
+        "line": 242,
         "column": 76
       }
     },
@@ -1957,11 +1957,11 @@
     "highlighting": "string",
     "loc": {
       "start": {
-        "line": 233,
+        "line": 244,
         "column": 16
       },
       "end": {
-        "line": 233,
+        "line": 244,
         "column": 74
       }
     },
@@ -1973,11 +1973,11 @@
     "highlighting": "string",
     "loc": {
       "start": {
-        "line": 240,
+        "line": 251,
         "column": 12
       },
       "end": {
-        "line": 247,
+        "line": 258,
         "column": 14
       }
     },
@@ -1989,11 +1989,11 @@
     "highlighting": "string",
     "loc": {
       "start": {
-        "line": 418,
+        "line": 429,
         "column": 14
       },
       "end": {
-        "line": 421,
+        "line": 432,
         "column": 16
       }
     },
@@ -2005,11 +2005,11 @@
     "highlighting": "string",
     "loc": {
       "start": {
-        "line": 116,
+        "line": 127,
         "column": 6
       },
       "end": {
-        "line": 119,
+        "line": 130,
         "column": 8
       }
     },
@@ -2021,11 +2021,11 @@
     "highlighting": "string",
     "loc": {
       "start": {
-        "line": 123,
+        "line": 134,
         "column": 8
       },
       "end": {
-        "line": 126,
+        "line": 137,
         "column": 10
       }
     },
@@ -2037,11 +2037,11 @@
     "highlighting": "string",
     "loc": {
       "start": {
-        "line": 128,
+        "line": 139,
         "column": 8
       },
       "end": {
-        "line": 131,
+        "line": 142,
         "column": 10
       }
     },
@@ -2053,11 +2053,11 @@
     "highlighting": "string",
     "loc": {
       "start": {
-        "line": 138,
+        "line": 149,
         "column": 8
       },
       "end": {
-        "line": 141,
+        "line": 152,
         "column": 10
       }
     },
@@ -2069,11 +2069,11 @@
     "highlighting": "string",
     "loc": {
       "start": {
-        "line": 145,
+        "line": 156,
         "column": 8
       },
       "end": {
-        "line": 148,
+        "line": 159,
         "column": 10
       }
     },
@@ -2085,11 +2085,11 @@
     "highlighting": "string",
     "loc": {
       "start": {
-        "line": 123,
+        "line": 134,
         "column": 8
       },
       "end": {
-        "line": 129,
+        "line": 140,
         "column": 55
       }
     },
@@ -2101,11 +2101,11 @@
     "highlighting": "string",
     "loc": {
       "start": {
-        "line": 338,
+        "line": 349,
         "column": 8
       },
       "end": {
-        "line": 338,
+        "line": 349,
         "column": 78
       }
     },
@@ -2117,11 +2117,11 @@
     "highlighting": "string",
     "loc": {
       "start": {
-        "line": 99,
+        "line": 110,
         "column": 49
       },
       "end": {
-        "line": 105,
+        "line": 116,
         "column": 3
       }
     },
@@ -2133,11 +2133,11 @@
     "highlighting": "string",
     "loc": {
       "start": {
-        "line": 99,
+        "line": 110,
         "column": 49
       },
       "end": {
-        "line": 105,
+        "line": 116,
         "column": 3
       }
     },
@@ -2149,11 +2149,11 @@
     "highlighting": "string",
     "loc": {
       "start": {
-        "line": 128,
+        "line": 139,
         "column": 6
       },
       "end": {
-        "line": 133,
+        "line": 144,
         "column": 62
       }
     },
@@ -2165,11 +2165,11 @@
     "highlighting": "string",
     "loc": {
       "start": {
-        "line": 128,
+        "line": 139,
         "column": 6
       },
       "end": {
-        "line": 133,
+        "line": 144,
         "column": 62
       }
     },
@@ -2181,11 +2181,11 @@
     "highlighting": "string",
     "loc": {
       "start": {
-        "line": 198,
+        "line": 209,
         "column": 18
       },
       "end": {
-        "line": 201,
+        "line": 212,
         "column": 20
       }
     },
@@ -2197,11 +2197,11 @@
     "highlighting": "string",
     "loc": {
       "start": {
-        "line": 52,
+        "line": 63,
         "column": 4
       },
       "end": {
-        "line": 54,
+        "line": 65,
         "column": 28
       }
     },
@@ -2213,11 +2213,11 @@
     "highlighting": "string",
     "loc": {
       "start": {
-        "line": 83,
+        "line": 94,
         "column": 6
       },
       "end": {
-        "line": 85,
+        "line": 96,
         "column": 57
       }
     },
@@ -2229,11 +2229,11 @@
     "highlighting": "string",
     "loc": {
       "start": {
-        "line": 147,
+        "line": 158,
         "column": 12
       },
       "end": {
-        "line": 151,
+        "line": 162,
         "column": 14
       }
     },
@@ -2245,11 +2245,11 @@
     "highlighting": "string",
     "loc": {
       "start": {
-        "line": 319,
+        "line": 330,
         "column": 12
       },
       "end": {
-        "line": 324,
+        "line": 335,
         "column": 14
       }
     },
@@ -2261,11 +2261,11 @@
     "highlighting": "string",
     "loc": {
       "start": {
-        "line": 114,
+        "line": 125,
         "column": 4
       },
       "end": {
-        "line": 114,
+        "line": 125,
         "column": 75
       }
     },
@@ -2277,11 +2277,11 @@
     "highlighting": "string",
     "loc": {
       "start": {
-        "line": 127,
+        "line": 138,
         "column": 4
       },
       "end": {
-        "line": 127,
+        "line": 138,
         "column": 69
       }
     },
@@ -2293,11 +2293,11 @@
     "highlighting": "string",
     "loc": {
       "start": {
-        "line": 222,
+        "line": 233,
         "column": 26
       },
       "end": {
-        "line": 226,
+        "line": 237,
         "column": 15
       }
     },
@@ -2309,11 +2309,11 @@
     "highlighting": "string",
     "loc": {
       "start": {
-        "line": 250,
+        "line": 261,
         "column": 26
       },
       "end": {
-        "line": 254,
+        "line": 265,
         "column": 3
       }
     },
@@ -2325,11 +2325,11 @@
     "highlighting": "string",
     "loc": {
       "start": {
-        "line": 123,
+        "line": 134,
         "column": 20
       },
       "end": {
-        "line": 123,
+        "line": 134,
         "column": 77
       }
     },
@@ -2341,11 +2341,11 @@
     "highlighting": "string",
     "loc": {
       "start": {
-        "line": 133,
+        "line": 144,
         "column": 10
       },
       "end": {
-        "line": 136,
+        "line": 147,
         "column": 12
       }
     },
@@ -2357,11 +2357,11 @@
     "highlighting": "string",
     "loc": {
       "start": {
-        "line": 132,
+        "line": 143,
         "column": 4
       },
       "end": {
-        "line": 137,
+        "line": 148,
         "column": 44
       }
     },
@@ -2373,11 +2373,11 @@
     "highlighting": "string",
     "loc": {
       "start": {
-        "line": 132,
+        "line": 143,
         "column": 4
       },
       "end": {
-        "line": 137,
+        "line": 148,
         "column": 44
       }
     },
@@ -2389,11 +2389,11 @@
     "highlighting": "string",
     "loc": {
       "start": {
-        "line": 89,
+        "line": 100,
         "column": 20
       },
       "end": {
-        "line": 92,
+        "line": 103,
         "column": 5
       }
     },
@@ -2405,11 +2405,11 @@
     "highlighting": "string",
     "loc": {
       "start": {
-        "line": 93,
+        "line": 104,
         "column": 21
       },
       "end": {
-        "line": 96,
+        "line": 107,
         "column": 5
       }
     },
@@ -2421,11 +2421,11 @@
     "highlighting": "string",
     "loc": {
       "start": {
-        "line": 97,
+        "line": 108,
         "column": 25
       },
       "end": {
-        "line": 100,
+        "line": 111,
         "column": 5
       }
     },
@@ -2437,11 +2437,11 @@
     "highlighting": "string",
     "loc": {
       "start": {
-        "line": 101,
+        "line": 112,
         "column": 24
       },
       "end": {
-        "line": 105,
+        "line": 116,
         "column": 5
       }
     },
@@ -2453,11 +2453,11 @@
     "highlighting": "string",
     "loc": {
       "start": {
-        "line": 106,
+        "line": 117,
         "column": 22
       },
       "end": {
-        "line": 109,
+        "line": 120,
         "column": 5
       }
     },
@@ -2469,11 +2469,11 @@
     "highlighting": "string",
     "loc": {
       "start": {
-        "line": 110,
+        "line": 121,
         "column": 22
       },
       "end": {
-        "line": 113,
+        "line": 124,
         "column": 5
       }
     },
@@ -2485,11 +2485,11 @@
     "highlighting": "string",
     "loc": {
       "start": {
-        "line": 169,
+        "line": 180,
         "column": 12
       },
       "end": {
-        "line": 172,
+        "line": 183,
         "column": 14
       }
     },
@@ -2501,11 +2501,11 @@
     "highlighting": "string",
     "loc": {
       "start": {
-        "line": 203,
+        "line": 214,
         "column": 16
       },
       "end": {
-        "line": 206,
+        "line": 217,
         "column": 18
       }
     },
@@ -2517,11 +2517,11 @@
     "highlighting": "string",
     "loc": {
       "start": {
-        "line": 212,
+        "line": 223,
         "column": 14
       },
       "end": {
-        "line": 220,
+        "line": 231,
         "column": 19
       }
     },
@@ -2533,11 +2533,11 @@
     "highlighting": "string",
     "loc": {
       "start": {
-        "line": 212,
+        "line": 223,
         "column": 14
       },
       "end": {
-        "line": 220,
+        "line": 231,
         "column": 19
       }
     },
@@ -2549,11 +2549,11 @@
     "highlighting": "string",
     "loc": {
       "start": {
-        "line": 251,
+        "line": 262,
         "column": 14
       },
       "end": {
-        "line": 254,
+        "line": 265,
         "column": 16
       }
     },
@@ -2565,11 +2565,11 @@
     "highlighting": "string",
     "loc": {
       "start": {
-        "line": 193,
+        "line": 204,
         "column": 12
       },
       "end": {
-        "line": 193,
+        "line": 204,
         "column": 80
       }
     },
@@ -2581,11 +2581,11 @@
     "highlighting": "string",
     "loc": {
       "start": {
-        "line": 201,
+        "line": 212,
         "column": 12
       },
       "end": {
-        "line": 204,
+        "line": 215,
         "column": 14
       }
     },
@@ -2597,11 +2597,11 @@
     "highlighting": "string",
     "loc": {
       "start": {
-        "line": 98,
+        "line": 109,
         "column": 10
       },
       "end": {
-        "line": 100,
+        "line": 111,
         "column": 47
       }
     },
@@ -2613,11 +2613,11 @@
     "highlighting": "string",
     "loc": {
       "start": {
-        "line": 44,
+        "line": 55,
         "column": 30
       },
       "end": {
-        "line": 48,
+        "line": 59,
         "column": 3
       }
     },
@@ -2629,11 +2629,11 @@
     "highlighting": "string",
     "loc": {
       "start": {
-        "line": 50,
+        "line": 61,
         "column": 39
       },
       "end": {
-        "line": 57,
+        "line": 68,
         "column": 3
       }
     },
@@ -2645,11 +2645,11 @@
     "highlighting": "string",
     "loc": {
       "start": {
-        "line": 59,
+        "line": 70,
         "column": 28
       },
       "end": {
-        "line": 62,
+        "line": 73,
         "column": 3
       }
     },
@@ -2661,11 +2661,11 @@
     "highlighting": "string",
     "loc": {
       "start": {
-        "line": 146,
+        "line": 157,
         "column": 14
       },
       "end": {
-        "line": 151,
+        "line": 162,
         "column": 19
       }
     },
@@ -2677,11 +2677,11 @@
     "highlighting": "string",
     "loc": {
       "start": {
-        "line": 55,
+        "line": 66,
         "column": 25
       },
       "end": {
-        "line": 61,
+        "line": 72,
         "column": 3
       }
     },
@@ -2693,11 +2693,11 @@
     "highlighting": "string",
     "loc": {
       "start": {
-        "line": 63,
+        "line": 74,
         "column": 27
       },
       "end": {
-        "line": 69,
+        "line": 80,
         "column": 3
       }
     },
@@ -2709,11 +2709,11 @@
     "highlighting": "string",
     "loc": {
       "start": {
-        "line": 71,
+        "line": 82,
         "column": 21
       },
       "end": {
-        "line": 74,
+        "line": 85,
         "column": 3
       }
     },
@@ -2725,11 +2725,11 @@
     "highlighting": "string",
     "loc": {
       "start": {
-        "line": 76,
+        "line": 87,
         "column": 23
       },
       "end": {
-        "line": 79,
+        "line": 90,
         "column": 3
       }
     },
@@ -2741,11 +2741,11 @@
     "highlighting": "string",
     "loc": {
       "start": {
-        "line": 50,
+        "line": 61,
         "column": 19
       },
       "end": {
-        "line": 56,
+        "line": 67,
         "column": 3
       }
     },
@@ -2757,11 +2757,11 @@
     "highlighting": "string",
     "loc": {
       "start": {
-        "line": 58,
+        "line": 69,
         "column": 21
       },
       "end": {
-        "line": 64,
+        "line": 75,
         "column": 3
       }
     },
@@ -2773,11 +2773,11 @@
     "highlighting": "string",
     "loc": {
       "start": {
-        "line": 65,
+        "line": 76,
         "column": 20
       },
       "end": {
-        "line": 65,
+        "line": 76,
         "column": 75
       }
     },
@@ -2789,11 +2789,11 @@
     "highlighting": "string",
     "loc": {
       "start": {
-        "line": 66,
+        "line": 77,
         "column": 22
       },
       "end": {
-        "line": 69,
+        "line": 80,
         "column": 3
       }
     },
@@ -2805,11 +2805,11 @@
     "highlighting": "string",
     "loc": {
       "start": {
-        "line": 80,
+        "line": 91,
         "column": 4
       },
       "end": {
-        "line": 83,
+        "line": 94,
         "column": 60
       }
     },
@@ -2821,11 +2821,11 @@
     "highlighting": "string",
     "loc": {
       "start": {
-        "line": 85,
+        "line": 96,
         "column": 8
       },
       "end": {
-        "line": 88,
+        "line": 99,
         "column": 40
       }
     },
@@ -2837,11 +2837,11 @@
     "highlighting": "string",
     "loc": {
       "start": {
-        "line": 138,
+        "line": 149,
         "column": 4
       },
       "end": {
-        "line": 141,
+        "line": 152,
         "column": 36
       }
     },
@@ -2853,11 +2853,11 @@
     "highlighting": "string",
     "loc": {
       "start": {
-        "line": 143,
+        "line": 154,
         "column": 8
       },
       "end": {
-        "line": 145,
+        "line": 156,
         "column": 34
       }
     },
@@ -2869,11 +2869,11 @@
     "highlighting": "string",
     "loc": {
       "start": {
-        "line": 170,
+        "line": 181,
         "column": 8
       },
       "end": {
-        "line": 174,
+        "line": 185,
         "column": 50
       }
     },
@@ -2885,11 +2885,11 @@
     "highlighting": "string",
     "loc": {
       "start": {
-        "line": 198,
+        "line": 209,
         "column": 8
       },
       "end": {
-        "line": 202,
+        "line": 213,
         "column": 79
       }
     },
@@ -2901,11 +2901,11 @@
     "highlighting": "string",
     "loc": {
       "start": {
-        "line": 230,
+        "line": 241,
         "column": 4
       },
       "end": {
-        "line": 233,
+        "line": 244,
         "column": 40
       }
     },
@@ -2917,11 +2917,11 @@
     "highlighting": "string",
     "loc": {
       "start": {
-        "line": 235,
+        "line": 246,
         "column": 8
       },
       "end": {
-        "line": 235,
+        "line": 246,
         "column": 76
       }
     },
@@ -2933,11 +2933,11 @@
     "highlighting": "string",
     "loc": {
       "start": {
-        "line": 268,
+        "line": 279,
         "column": 12
       },
       "end": {
-        "line": 275,
+        "line": 286,
         "column": 14
       }
     },
@@ -2949,11 +2949,11 @@
     "highlighting": "string",
     "loc": {
       "start": {
-        "line": 758,
+        "line": 769,
         "column": 14
       },
       "end": {
-        "line": 761,
+        "line": 772,
         "column": 16
       }
     },
@@ -2965,11 +2965,11 @@
     "highlighting": "string",
     "loc": {
       "start": {
-        "line": 205,
+        "line": 216,
         "column": 6
       },
       "end": {
-        "line": 211,
+        "line": 222,
         "column": 8
       }
     },
@@ -2981,11 +2981,11 @@
     "highlighting": "string",
     "loc": {
       "start": {
-        "line": 124,
+        "line": 135,
         "column": 4
       },
       "end": {
-        "line": 132,
+        "line": 143,
         "column": 9
       }
     },
@@ -2997,11 +2997,11 @@
     "highlighting": "string",
     "loc": {
       "start": {
-        "line": 124,
+        "line": 135,
         "column": 4
       },
       "end": {
-        "line": 132,
+        "line": 143,
         "column": 9
       }
     },
@@ -3013,11 +3013,11 @@
     "highlighting": "string",
     "loc": {
       "start": {
-        "line": 345,
+        "line": 356,
         "column": 32
       },
       "end": {
-        "line": 348,
+        "line": 359,
         "column": 3
       }
     },
@@ -3029,11 +3029,11 @@
     "highlighting": "string",
     "loc": {
       "start": {
-        "line": 121,
+        "line": 132,
         "column": 12
       },
       "end": {
-        "line": 124,
+        "line": 135,
         "column": 14
       }
     },
@@ -3042,22 +3042,6 @@
   {
     "token": "ouiSelectableListItem.includedOptionInstructions",
     "defString": "To exclude this option, press enter.",
-    "highlighting": "string",
-    "loc": {
-      "start": {
-        "line": 131,
-        "column": 12
-      },
-      "end": {
-        "line": 134,
-        "column": 14
-      }
-    },
-    "filepath": "src/components/selectable/selectable_list/selectable_list_item.tsx"
-  },
-  {
-    "token": "ouiSelectableListItem.excludedOption",
-    "defString": "Excluded option.",
     "highlighting": "string",
     "loc": {
       "start": {
@@ -3072,16 +3056,32 @@
     "filepath": "src/components/selectable/selectable_list/selectable_list_item.tsx"
   },
   {
+    "token": "ouiSelectableListItem.excludedOption",
+    "defString": "Excluded option.",
+    "highlighting": "string",
+    "loc": {
+      "start": {
+        "line": 153,
+        "column": 12
+      },
+      "end": {
+        "line": 156,
+        "column": 14
+      }
+    },
+    "filepath": "src/components/selectable/selectable_list/selectable_list_item.tsx"
+  },
+  {
     "token": "ouiSelectableListItem.excludedOptionInstructions",
     "defString": "To deselect this option, press enter.",
     "highlighting": "string",
     "loc": {
       "start": {
-        "line": 152,
+        "line": 163,
         "column": 12
       },
       "end": {
-        "line": 155,
+        "line": 166,
         "column": 14
       }
     },
@@ -3093,11 +3093,11 @@
     "highlighting": "string",
     "loc": {
       "start": {
-        "line": 125,
+        "line": 136,
         "column": 30
       },
       "end": {
-        "line": 128,
+        "line": 139,
         "column": 3
       }
     },
@@ -3106,22 +3106,6 @@
   {
     "token": "ouiSelectableTemplateSitewide.loadingResults",
     "defString": "Loading results",
-    "highlighting": "string",
-    "loc": {
-      "start": {
-        "line": 199,
-        "column": 8
-      },
-      "end": {
-        "line": 202,
-        "column": 10
-      }
-    },
-    "filepath": "src/components/selectable/selectable_templates/selectable_template_sitewide.tsx"
-  },
-  {
-    "token": "ouiSelectableTemplateSitewide.noResults",
-    "defString": "No results available",
     "highlighting": "string",
     "loc": {
       "start": {
@@ -3136,16 +3120,32 @@
     "filepath": "src/components/selectable/selectable_templates/selectable_template_sitewide.tsx"
   },
   {
+    "token": "ouiSelectableTemplateSitewide.noResults",
+    "defString": "No results available",
+    "highlighting": "string",
+    "loc": {
+      "start": {
+        "line": 221,
+        "column": 8
+      },
+      "end": {
+        "line": 224,
+        "column": 10
+      }
+    },
+    "filepath": "src/components/selectable/selectable_templates/selectable_template_sitewide.tsx"
+  },
+  {
     "token": "ouiSelectableTemplateSitewide.onFocusBadgeGoTo",
     "defString": "Go to",
     "highlighting": "string",
     "loc": {
       "start": {
-        "line": 256,
+        "line": 267,
         "column": 12
       },
       "end": {
-        "line": 259,
+        "line": 270,
         "column": 14
       }
     },
@@ -3157,11 +3157,11 @@
     "highlighting": "string",
     "loc": {
       "start": {
-        "line": 452,
+        "line": 463,
         "column": 16
       },
       "end": {
-        "line": 455,
+        "line": 466,
         "column": 18
       }
     },
@@ -3173,11 +3173,11 @@
     "highlighting": "string",
     "loc": {
       "start": {
-        "line": 474,
+        "line": 485,
         "column": 14
       },
       "end": {
-        "line": 478,
+        "line": 489,
         "column": 16
       }
     },
@@ -3189,11 +3189,11 @@
     "highlighting": "string",
     "loc": {
       "start": {
-        "line": 493,
+        "line": 504,
         "column": 14
       },
       "end": {
-        "line": 496,
+        "line": 507,
         "column": 16
       }
     },
@@ -3205,11 +3205,11 @@
     "highlighting": "string",
     "loc": {
       "start": {
-        "line": 560,
+        "line": 571,
         "column": 6
       },
       "end": {
-        "line": 560,
+        "line": 571,
         "column": 78
       }
     },
@@ -3221,11 +3221,11 @@
     "highlighting": "string",
     "loc": {
       "start": {
-        "line": 590,
+        "line": 601,
         "column": 6
       },
       "end": {
-        "line": 590,
+        "line": 601,
         "column": 78
       }
     },
@@ -3237,11 +3237,11 @@
     "highlighting": "string",
     "loc": {
       "start": {
-        "line": 161,
+        "line": 172,
         "column": 10
       },
       "end": {
-        "line": 161,
+        "line": 172,
         "column": 80
       }
     },
@@ -3253,11 +3253,11 @@
     "highlighting": "string",
     "loc": {
       "start": {
-        "line": 25,
+        "line": 36,
         "column": 17
       },
       "end": {
-        "line": 28,
+        "line": 39,
         "column": 4
       }
     },
@@ -3269,11 +3269,11 @@
     "highlighting": "string",
     "loc": {
       "start": {
-        "line": 30,
+        "line": 41,
         "column": 23
       },
       "end": {
-        "line": 34,
+        "line": 45,
         "column": 3
       }
     },
@@ -3285,11 +3285,11 @@
     "highlighting": "string",
     "loc": {
       "start": {
-        "line": 40,
+        "line": 51,
         "column": 17
       },
       "end": {
-        "line": 47,
+        "line": 58,
         "column": 3
       }
     },
@@ -3301,11 +3301,11 @@
     "highlighting": "string",
     "loc": {
       "start": {
-        "line": 49,
+        "line": 60,
         "column": 23
       },
       "end": {
-        "line": 53,
+        "line": 64,
         "column": 3
       }
     },
@@ -3317,11 +3317,11 @@
     "highlighting": "string",
     "loc": {
       "start": {
-        "line": 59,
+        "line": 70,
         "column": 17
       },
       "end": {
-        "line": 66,
+        "line": 77,
         "column": 3
       }
     },
@@ -3333,11 +3333,11 @@
     "highlighting": "string",
     "loc": {
       "start": {
-        "line": 68,
+        "line": 79,
         "column": 23
       },
       "end": {
-        "line": 72,
+        "line": 83,
         "column": 3
       }
     },
@@ -3349,11 +3349,11 @@
     "highlighting": "string",
     "loc": {
       "start": {
-        "line": 78,
+        "line": 89,
         "column": 17
       },
       "end": {
-        "line": 85,
+        "line": 96,
         "column": 3
       }
     },
@@ -3365,11 +3365,11 @@
     "highlighting": "string",
     "loc": {
       "start": {
-        "line": 87,
+        "line": 98,
         "column": 23
       },
       "end": {
-        "line": 91,
+        "line": 102,
         "column": 3
       }
     },
@@ -3381,11 +3381,11 @@
     "highlighting": "string",
     "loc": {
       "start": {
-        "line": 97,
+        "line": 108,
         "column": 17
       },
       "end": {
-        "line": 104,
+        "line": 115,
         "column": 3
       }
     },
@@ -3397,11 +3397,11 @@
     "highlighting": "string",
     "loc": {
       "start": {
-        "line": 106,
+        "line": 117,
         "column": 23
       },
       "end": {
-        "line": 110,
+        "line": 121,
         "column": 3
       }
     },
@@ -3413,11 +3413,11 @@
     "highlighting": "string",
     "loc": {
       "start": {
-        "line": 116,
+        "line": 127,
         "column": 17
       },
       "end": {
-        "line": 123,
+        "line": 134,
         "column": 3
       }
     },
@@ -3429,11 +3429,11 @@
     "highlighting": "string",
     "loc": {
       "start": {
-        "line": 125,
+        "line": 136,
         "column": 23
       },
       "end": {
-        "line": 129,
+        "line": 140,
         "column": 3
       }
     },
@@ -3445,11 +3445,11 @@
     "highlighting": "string",
     "loc": {
       "start": {
-        "line": 135,
+        "line": 146,
         "column": 17
       },
       "end": {
-        "line": 142,
+        "line": 153,
         "column": 3
       }
     },
@@ -3461,11 +3461,11 @@
     "highlighting": "string",
     "loc": {
       "start": {
-        "line": 144,
+        "line": 155,
         "column": 23
       },
       "end": {
-        "line": 148,
+        "line": 159,
         "column": 3
       }
     },
@@ -3477,11 +3477,11 @@
     "highlighting": "string",
     "loc": {
       "start": {
-        "line": 79,
+        "line": 90,
         "column": 8
       },
       "end": {
-        "line": 79,
+        "line": 90,
         "column": 72
       }
     },
@@ -3493,11 +3493,11 @@
     "highlighting": "string",
     "loc": {
       "start": {
-        "line": 103,
+        "line": 114,
         "column": 10
       },
       "end": {
-        "line": 106,
+        "line": 117,
         "column": 48
       }
     },
@@ -3509,11 +3509,11 @@
     "highlighting": "string",
     "loc": {
       "start": {
-        "line": 90,
+        "line": 101,
         "column": 8
       },
       "end": {
-        "line": 93,
+        "line": 104,
         "column": 10
       }
     },
@@ -3525,11 +3525,11 @@
     "highlighting": "string",
     "loc": {
       "start": {
-        "line": 107,
+        "line": 118,
         "column": 8
       },
       "end": {
-        "line": 111,
+        "line": 122,
         "column": 10
       }
     },
@@ -3541,11 +3541,11 @@
     "highlighting": "string",
     "loc": {
       "start": {
-        "line": 91,
+        "line": 102,
         "column": 6
       },
       "end": {
-        "line": 91,
+        "line": 102,
         "column": 69
       }
     },
@@ -3557,11 +3557,11 @@
     "highlighting": "string",
     "loc": {
       "start": {
-        "line": 120,
+        "line": 131,
         "column": 10
       },
       "end": {
-        "line": 123,
+        "line": 134,
         "column": 12
       }
     },
@@ -3573,11 +3573,11 @@
     "highlighting": "string",
     "loc": {
       "start": {
-        "line": 127,
+        "line": 138,
         "column": 6
       },
       "end": {
-        "line": 127,
+        "line": 138,
         "column": 68
       }
     },
@@ -3589,11 +3589,11 @@
     "highlighting": "string",
     "loc": {
       "start": {
-        "line": 60,
+        "line": 71,
         "column": 6
       },
       "end": {
-        "line": 60,
+        "line": 71,
         "column": 70
       }
     },
@@ -3605,11 +3605,11 @@
     "highlighting": "string",
     "loc": {
       "start": {
-        "line": 74,
+        "line": 85,
         "column": 6
       },
       "end": {
-        "line": 74,
+        "line": 85,
         "column": 74
       }
     },
@@ -3621,11 +3621,11 @@
     "highlighting": "string",
     "loc": {
       "start": {
-        "line": 87,
+        "line": 98,
         "column": 6
       },
       "end": {
-        "line": 87,
+        "line": 98,
         "column": 78
       }
     },
@@ -3637,11 +3637,11 @@
     "highlighting": "string",
     "loc": {
       "start": {
-        "line": 101,
+        "line": 112,
         "column": 4
       },
       "end": {
-        "line": 104,
+        "line": 115,
         "column": 34
       }
     },
@@ -3653,11 +3653,11 @@
     "highlighting": "string",
     "loc": {
       "start": {
-        "line": 187,
+        "line": 198,
         "column": 10
       },
       "end": {
-        "line": 193,
+        "line": 204,
         "column": 63
       }
     },
@@ -3669,11 +3669,11 @@
     "highlighting": "string",
     "loc": {
       "start": {
-        "line": 187,
+        "line": 198,
         "column": 10
       },
       "end": {
-        "line": 193,
+        "line": 204,
         "column": 63
       }
     },
@@ -3685,11 +3685,11 @@
     "highlighting": "string",
     "loc": {
       "start": {
-        "line": 187,
+        "line": 198,
         "column": 10
       },
       "end": {
-        "line": 193,
+        "line": 204,
         "column": 63
       }
     },
@@ -3701,11 +3701,11 @@
     "highlighting": "string",
     "loc": {
       "start": {
-        "line": 281,
+        "line": 292,
         "column": 12
       },
       "end": {
-        "line": 283,
+        "line": 294,
         "column": 77
       }
     },
@@ -3717,11 +3717,11 @@
     "highlighting": "string",
     "loc": {
       "start": {
-        "line": 305,
+        "line": 316,
         "column": 20
       },
       "end": {
-        "line": 312,
+        "line": 323,
         "column": 25
       }
     },

--- a/scripts/dtsgenerator.js
+++ b/scripts/dtsgenerator.js
@@ -183,3 +183,26 @@ declare module '@opensearch-project/oui' {
 }
   `;
 }
+
+/* OUI -> EUI Aliases */
+function buildEuiTokensObject() {
+  const { i18ndefs } = require('../i18ntokens.json').reduce(
+    ({ i18ndefs, tokens }, def) => {
+      if (!tokens.has(def.token)) {
+        tokens.add(def.token);
+        i18ndefs.push(def);
+      }
+      return { i18ndefs, tokens };
+    },
+    { i18ndefs: [], tokens: new Set() }
+  );
+  const caseSensitiveMapToE = {o: 'o', O: 'E'};
+  return `
+declare module '@opensearch-project/oui' {
+  export type EuiTokensObject = {
+    ${i18ndefs.map(({ token }) => `"${token.replace(/(o)(ui)/ig, (m, m1, m2) => caseSensitiveMapToE[m1] + m2)}": any;`).join('\n')}
+  }
+}
+  `;
+}
+/* End of Aliases */

--- a/scripts/eslint-plugin/require_license_header.js
+++ b/scripts/eslint-plugin/require_license_header.js
@@ -30,8 +30,6 @@
 
 const babelEslint = require('babel-eslint');
 
-// const { assert, normalizeWhitespace, init } = require('../lib');
-
 function assert(truth, message) {
   if (truth) {
     return;
@@ -72,8 +70,11 @@ module.exports = {
       {
         type: 'object',
         properties: {
-          license: {
-            type: 'string',
+          licenses: {
+            type: 'array',
+            items: {
+              type: 'string',
+            },
           },
         },
         additionalProperties: false,
@@ -83,33 +84,38 @@ module.exports = {
   create: context => {
     return {
       Program(program) {
-        const license = init(context, program, function() {
+        const licenses = init(context, program, function () {
           const options = context.options[0] || {};
-          const license = options.license;
+          const licenses = options.licenses;
 
-          assert(!!license, '"license" option is required');
+          assert(!!licenses, '"licenses" option is required');
 
-          const parsed = babelEslint.parse(license);
-          assert(!parsed.body.length, '"license" option must only include a single comment');
-          assert(
-            parsed.comments.length === 1,
-            '"license" option must only include a single comment'
-          );
+          return licenses.map((license, i) => {
+            const parsed = babelEslint.parse(license);
+            assert(
+              !parsed.body.length,
+              `"licenses[${i}]" option must only include a single comment`
+            );
+            assert(
+              parsed.comments.length === 1,
+              `"licenses[${i}]" option must only include a single comment`
+            );
 
-          return {
-            source: license,
-            nodeValue: normalizeWhitespace(parsed.comments[0].value),
-          };
+            return {
+              source: license,
+              nodeValue: normalizeWhitespace(parsed.comments[0].value),
+            };
+          });
         });
 
-        if (!license) {
-          return;
-        }
+        if (!licenses || !licenses.length) return;
 
         const sourceCode = context.getSourceCode();
         const comment = sourceCode
           .getAllComments()
-          .find(node => normalizeWhitespace(node.value) === license.nodeValue);
+          .find((node) =>
+            licenses.map((license) => license.nodeValue).includes(normalizeWhitespace(node.value))
+          );
 
         // no licence comment
         if (!comment) {
@@ -124,13 +130,16 @@ module.exports = {
                 return undefined;
               }
 
-              return fixer.replaceTextRange([0, 0], license.source + '\n\n');
+              return fixer.replaceTextRange([0, 0], licenses[0].source + '\n\n');
             },
           });
           return;
         }
 
         // ensure there is nothing before the comment
+        const currentLicense = licenses.find(
+          (license) => normalizeWhitespace(comment.value) === license.nodeValue
+        );
         const sourceBeforeNode = sourceCode
           .getText()
           .slice(0, sourceCode.getIndexFromLoc(comment.loc.start));
@@ -148,7 +157,7 @@ module.exports = {
               // if removing whitespace is not possible
               return [
                 fixer.remove(comment),
-                fixer.replaceTextRange([0, 0], license.source + '\n\n'),
+                fixer.replaceTextRange([0, 0], currentLicense.source + '\n\n'),
               ];
             },
           });

--- a/src-docs/src/views/panel/panel_example.js
+++ b/src-docs/src/views/panel/panel_example.js
@@ -168,8 +168,8 @@ export const PanelExample = {
             title="Certain allowed combinations of shadow, border, and color depend on the current theme.">
             <p>
               For instance, only plain or transparent panels can have a border
-              and/or shadow. The Cascadia theme doesn&apos;t allow combining
-              the <OuiCode>hasBorder</OuiCode> option with{' '}
+              and/or shadow. The Cascadia theme doesn&apos;t allow combining the{' '}
+              <OuiCode>hasBorder</OuiCode> option with{' '}
               <OuiCode>hasShadow</OuiCode>. The default theme only allows
               removing the border if both <OuiCode>hasShadow</OuiCode> and{' '}
               <OuiCode>hasBorder</OuiCode> are set to <OuiCode>false</OuiCode>.

--- a/src/components/selectable/selectable_templates/selectable_template_sitewide_option.tsx
+++ b/src/components/selectable/selectable_templates/selectable_template_sitewide_option.tsx
@@ -31,10 +31,10 @@
 import React, { ReactNode } from 'react';
 import classNames from 'classnames';
 import { CommonProps } from '../../common';
-import { OuiIconProps, OuiIcon } from '../../../components/icon';
-import { OuiAvatarProps, OuiAvatar } from '../../../components/avatar/avatar';
+import { OuiIconProps, OuiIcon } from '../../icon';
+import { OuiAvatarProps, OuiAvatar } from '../../avatar';
 import { OuiSelectableOption } from '../selectable_option';
-import { OuiHighlight } from '../../../components/highlight';
+import { OuiHighlight } from '../../highlight';
 
 export interface OuiSelectableTemplateSitewideMetaData extends CommonProps {
   /**

--- a/src/services/breakpoint.ts
+++ b/src/services/breakpoint.ts
@@ -134,3 +134,8 @@ export function isWithinBreakpoints(
   const currentBreakpoint = getBreakpoint(width, breakpoints);
   return currentBreakpoint ? sizes.includes(currentBreakpoint) : false;
 }
+
+/* OUI -> EUI Aliases */
+export type EuiBreakpointSize = OuiBreakpointSize;
+export type EuiBreakpoints = OuiBreakpoints;
+/* End of Aliases */

--- a/src/services/color/index.ts
+++ b/src/services/color/index.ts
@@ -61,3 +61,20 @@ export {
 } from './oui_palettes';
 export { rgbDef, HSV, RGB } from './color_types';
 export { getSteppedGradient } from './stepped_gradient';
+
+/* OUI -> EUI Aliases */
+export {
+  ouiPaletteForLightBackground as euiPaletteForLightBackground,
+  ouiPaletteForDarkBackground as euiPaletteForDarkBackground,
+  ouiPaletteColorBlind as euiPaletteColorBlind,
+  ouiPaletteColorBlindBehindText as euiPaletteColorBlindBehindText,
+  ouiPaletteForStatus as euiPaletteForStatus,
+  ouiPaletteForTemperature as euiPaletteForTemperature,
+  ouiPaletteComplimentary as euiPaletteComplimentary,
+  ouiPaletteNegative as euiPaletteNegative,
+  ouiPalettePositive as euiPalettePositive,
+  ouiPaletteCool as euiPaletteCool,
+  ouiPaletteWarm as euiPaletteWarm,
+  ouiPaletteGray as euiPaletteGray,
+} from './oui_palettes';
+/* End of Aliases */

--- a/src/services/color/oui_palettes.ts
+++ b/src/services/color/oui_palettes.ts
@@ -261,3 +261,20 @@ export const ouiPaletteGray = function (steps: number): OuiPalette {
     false
   );
 };
+
+/* OUI -> EUI Aliases */
+export type EuiPalette = OuiPalette;
+export interface EuiPaletteColorBlindProps extends OuiPaletteColorBlindProps {}
+export const euiPaletteColorBlind = ouiPaletteColorBlind;
+export const euiPaletteColorBlindBehindText = ouiPaletteColorBlindBehindText;
+export const euiPaletteForLightBackground = ouiPaletteForLightBackground;
+export const euiPaletteForDarkBackground = ouiPaletteForDarkBackground;
+export const euiPaletteForStatus = ouiPaletteForStatus;
+export const euiPaletteForTemperature = ouiPaletteForTemperature;
+export const euiPaletteComplimentary = ouiPaletteComplimentary;
+export const euiPaletteNegative = ouiPaletteNegative;
+export const euiPalettePositive = ouiPalettePositive;
+export const euiPaletteCool = ouiPaletteCool;
+export const euiPaletteWarm = ouiPaletteWarm;
+export const euiPaletteGray = ouiPaletteGray;
+/* End of Aliases */

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -139,3 +139,22 @@ export {
 } from './hooks';
 
 export { throttle } from './throttle';
+
+/* OUI -> EUI Aliases */
+export type { OuiBreakpointSize as EuiBreakpointSize } from './breakpoint';
+export {
+  ouiPaletteForLightBackground as euiPaletteForLightBackground,
+  ouiPaletteForDarkBackground as euiPaletteForDarkBackground,
+  ouiPaletteColorBlind as euiPaletteColorBlind,
+  ouiPaletteColorBlindBehindText as euiPaletteColorBlindBehindText,
+  ouiPaletteForStatus as euiPaletteForStatus,
+  ouiPaletteForTemperature as euiPaletteForTemperature,
+  ouiPaletteComplimentary as euiPaletteComplimentary,
+  ouiPaletteNegative as euiPaletteNegative,
+  ouiPalettePositive as euiPalettePositive,
+  ouiPaletteCool as euiPaletteCool,
+  ouiPaletteWarm as euiPaletteWarm,
+  ouiPaletteGray as euiPaletteGray,
+} from './color';
+export { OuiWindowEvent as EuiWindowEvent } from './window_event';
+/* End of Aliases */

--- a/src/services/popover/index.ts
+++ b/src/services/popover/index.ts
@@ -31,3 +31,7 @@
 export { calculatePopoverPosition } from './calculate_popover_position';
 export { findPopoverPosition, getElementZIndex } from './popover_positioning';
 export { OuiPopoverPosition } from './types';
+
+/* OUI -> EUI Aliases */
+export type { OuiPopoverPosition as EuiPopoverPosition } from './types';
+/* End of Aliases */

--- a/src/services/popover/popover_positioning.ts
+++ b/src/services/popover/popover_positioning.ts
@@ -824,3 +824,7 @@ export function getElementZIndex(
 
   return 0;
 }
+
+/* OUI -> EUI Aliases */
+export interface EuiClientRect extends OuiClientRect {}
+/* End of Aliases */

--- a/src/services/popover/types.ts
+++ b/src/services/popover/types.ts
@@ -29,3 +29,7 @@
  */
 
 export type OuiPopoverPosition = 'top' | 'right' | 'bottom' | 'left';
+
+/* OUI -> EUI Aliases */
+export type EuiPopoverPosition = OuiPopoverPosition;
+/* End of Aliases */

--- a/src/services/window_event/index.ts
+++ b/src/services/window_event/index.ts
@@ -29,3 +29,7 @@
  */
 
 export { OuiWindowEvent } from './window_event';
+
+/* OUI -> EUI Aliases */
+export { OuiWindowEvent as EuiWindowEvent } from './window_event';
+/* End of Aliases */

--- a/src/services/window_event/window_event.ts
+++ b/src/services/window_event/window_event.ts
@@ -68,3 +68,7 @@ export class OuiWindowEvent<E extends EventNames> extends Component<Props<E>> {
     return null;
   }
 }
+
+/* OUI -> EUI Aliases */
+export class EuiWindowEvent<E extends EventNames> extends OuiWindowEvent<E> {}
+/* End of Aliases */

--- a/src/themes/charts/themes.ts
+++ b/src/themes/charts/themes.ts
@@ -220,3 +220,10 @@ export const OUI_SPARKLINE_THEME_PARTIAL: PartialTheme = {
     },
   },
 };
+
+/* OUI -> EUI Aliases */
+export interface EuiChartThemeType extends OuiChartThemeType {}
+export const EUI_CHARTS_THEME_LIGHT = OUI_CHARTS_THEME_LIGHT;
+export const EUI_CHARTS_THEME_DARK = OUI_CHARTS_THEME_DARK;
+export const EUI_SPARKLINE_THEME_PARTIAL = OUI_SPARKLINE_THEME_PARTIAL;
+/* End of Aliases */

--- a/src/themes/index.ts
+++ b/src/themes/index.ts
@@ -29,3 +29,8 @@
  */
 
 export { OUI_THEMES, OUI_THEME } from './themes';
+
+/* OUI -> EUI Aliases */
+export { OUI_THEMES as EUI_THEMES } from './themes';
+export type { OUI_THEME as EUI_THEME } from './themes';
+/* End of Aliases */

--- a/src/themes/themes.ts
+++ b/src/themes/themes.ts
@@ -51,3 +51,8 @@ export const OUI_THEMES: OUI_THEME[] = [
     value: 'cascadia-dark',
   },
 ];
+
+/* OUI -> EUI Aliases */
+export interface EUI_THEME extends OUI_THEME {}
+export const EUI_THEMES = OUI_THEMES;
+/* End of Aliases */

--- a/src/utils/prop_types/index.ts
+++ b/src/utils/prop_types/index.ts
@@ -35,3 +35,7 @@ export const OuiPropTypes = {
   is,
   withRequiredProp,
 };
+
+/* OUI -> EUI Aliases */
+export const EuiPropTypes = OuiPropTypes;
+/* End of Aliases */


### PR DESCRIPTION
To allow consumers to continue to use `eui*`
* Duplicate components at build
* Duplicate `TokensObject` in the exported typedef
* Add aliases to `services`, `themes`, and `utils`
* Fix unnecessarily long relative paths in `src/components/selectable/selectable_templates/selectable_template_sitewide_option.tsx`
* Update `i18ntokens.json` due to the addition of headers
* Update `scripts/eslint-plugin/require_license_header.js` to match OSD's and allow multiple header options
* Minor lint fix in `src-docs/src/views/panel/panel_example.js`

Signed-off-by: Miki <miki@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
