### PR TITLE
Revises eui* aliases for seamless adoption

### DIFF
--- a/scripts/compile-clean.js
+++ b/scripts/compile-clean.js
@@ -15,3 +15,4 @@ rimraf.sync('dist');
 rimraf.sync('lib');
 rimraf.sync('es');
 rimraf.sync('test-env');
+rimraf.sync('types');

--- a/scripts/compile-scss.js
+++ b/scripts/compile-scss.js
@@ -130,11 +130,31 @@ async function compileScssFile(
     }
   );
 
-  const extractedVarTypes = await deriveSassVariableTypes(
+  /* OUI -> EUI Aliases: Modified */
+  // const extractedVarTypes = await deriveSassVariableTypes(
+  const extractedVarTypes_ = await deriveSassVariableTypes(
+  /* End of Aliases */
     extractedVars,
     `${packageName}/${outputVarsFilename}`,
     outputVarTypesFilename
   );
+
+  /* OUI -> EUI Aliases */
+  const declarationMatcher = /^declare\s+module\s+(['"]@opensearch-project\/oui.*?['"])\s*\{/msg;
+  let match;
+  const declarations = [];
+
+  while ((match = declarationMatcher.exec(extractedVarTypes_)) !== null) {
+      declarations.push(
+        "declare module " +
+        match[1].replace('@opensearch-project/oui', '@elastic/eui') + " {\n" +
+        "  import _ from " + match[1] + ";\n" +
+        "  export default _;\n" +
+        "}"
+      );
+  }
+  const extractedVarTypes = extractedVarTypes_ + '\n' + declarations.join('\n');
+  /* End of Aliases */
 
   const { css: postprocessedCss } = await postcss(postcssConfiguration).process(
     /* OUI -> EUI Aliases: Modified */

--- a/scripts/dtsgenerator.js
+++ b/scripts/dtsgenerator.js
@@ -53,6 +53,9 @@ const generator = dtsGenerator({
   resolveModuleId(params) {
     if (
       path.basename(params.currentModuleId) === 'index' &&
+      /* OUI -> EUI Aliases */
+      !params.currentModuleId.includes('eui_components') &&
+      /* End of Aliases */
       !hasParentIndex(path.resolve(baseDir, params.currentModuleId))
     ) {
       // this module is exporting from an `index(.d)?.ts` file, declare its exports straight to @opensearch-project/oui module
@@ -158,6 +161,9 @@ generator.then(() => {
       ) // end 3.
       .replace(/$/, `\n\n${buildOuiTokensObject()}`) // 4.
   );
+  /* OUI -> EUI Aliases */
+  fs.writeFileSync(defsFilePath, `\n\n${buildEuiTokensObject()}`, {flag: 'a', encoding: 'utf8'});
+  /* End of Aliases */
 });
 
 /** For step 4 **/
@@ -178,7 +184,7 @@ function buildOuiTokensObject() {
   return `
 declare module '@opensearch-project/oui' {
   export type OuiTokensObject = {
-    ${i18ndefs.map(({ token }) => `"${token}": any;`).join('\n')}
+    ${i18ndefs.map(({ token }) => `"${token}": any;`).join('\n  ')}
   }
 }
   `;
@@ -196,11 +202,11 @@ function buildEuiTokensObject() {
     },
     { i18ndefs: [], tokens: new Set() }
   );
-  const caseSensitiveMapToE = {o: 'o', O: 'E'};
+  const o2eMapper = {o: 'e', O: 'E'};
   return `
 declare module '@opensearch-project/oui' {
   export type EuiTokensObject = {
-    ${i18ndefs.map(({ token }) => `"${token.replace(/(o)(ui)/ig, (m, m1, m2) => caseSensitiveMapToE[m1] + m2)}": any;`).join('\n')}
+    ${i18ndefs.map(({ token }) => `"${token.replace(/(o)(?=ui)/ig, (m, m1) => o2eMapper[m1])}": any;`).join('\n  ')}
   }
 }
   `;

--- a/scripts/postinstall.js
+++ b/scripts/postinstall.js
@@ -18,3 +18,22 @@ if (fs.existsSync(targetFilePath)) {
   console.log(`removing ${targetFilePath}`);
   fs.unlinkSync(targetFilePath);
 }
+
+/* OUI -> EUI Aliases */
+const shell = require('shelljs');
+// Clean up and recreate the folders
+shell.rm('-rf', 'src/themes/eui');
+shell.rm('-rf', 'src/themes/eui-amsterdam');
+shell.mkdir('-p', 'src/themes/eui');
+shell.mkdir('-p', 'src/themes/eui-amsterdam');
+
+shell.cp('-fR', 'src/themes/oui/oui_colors_dark.scss', 'src/themes/eui/eui_colors_dark.scss');
+shell.cp('-fR', 'src/themes/oui/oui_colors_light.scss', 'src/themes/eui/eui_colors_light.scss');
+shell.cp('-fR', 'src/themes/oui/oui_globals.scss', 'src/themes/eui/eui_globals.scss');
+
+shell.cp('-fR', 'src/themes/oui-cascadia/global_styling', 'src/themes/eui-amsterdam/global_styling');
+shell.cp('-fR', 'src/themes/oui-cascadia/overrides', 'src/themes/eui-amsterdam/overrides');
+shell.cp('-fR', 'src/themes/oui-cascadia/oui_cascadia_colors_dark.scss', 'src/themes/eui-amsterdam/eui_amsterdam_colors_dark.scss');
+shell.cp('-fR', 'src/themes/oui-cascadia/oui_cascadia_colors_light.scss', 'src/themes/eui-amsterdam/eui_amsterdam_colors_light.scss');
+shell.cp('-fR', 'src/themes/oui-cascadia/oui_cascadia_globals.scss', 'src/themes/eui-amsterdam/eui_amsterdam_globals.scss');
+/* End of Aliases */

--- a/src/components/datagrid/_mixins.scss
+++ b/src/components/datagrid/_mixins.scss
@@ -86,9 +86,25 @@ $ouiDataGridStyles: (
 $euiDataGridPrefix: $ouiDataGridPrefix;
 $euiDataGridStyles: $ouiDataGridStyles;
 @function euiDataGridSelector($selectorKeys...) { @return ouiDataGridSelector($selectorKeys...); }
-@mixin euiDataGridStyles($selectorKeys...) { @include ouiDataGridStyles($selectorKeys...); }
-@mixin euiDataGridHeaderCell { @include ouiDataGridHeaderCell; }
+@mixin euiDataGridStyles($selectorKeys...) {
+  @include ouiDataGridStyles($selectorKeys...) {
+    @content;
+  }
+}
+@mixin euiDataGridHeaderCell {
+  .euiDataGridHeaderCell {
+    @content;
+  }
+}
 @mixin euiDataGridCellFocus { @include ouiDataGridCellFocus; }
-@mixin euiDataGridRowCell { @include ouiDataGridRowCell; }
-@mixin euiDataGridFooterCell { @include ouiDataGridFooterCell; }
+@mixin euiDataGridRowCell {
+  .euiDataGridRowCell {
+    @content;
+  }
+}
+@mixin euiDataGridFooterCell {
+  .euiDataGridRowCell.euiDataGridFooterCell {
+    @content;
+  }
+}
 /* End of Aliases */

--- a/src/components/header/_mixins.scss
+++ b/src/components/header/_mixins.scss
@@ -48,5 +48,40 @@
 
 
 /* OUI -> EUI Aliases */
-@mixin euiHeaderDarkTheme($backgroundColor) { @include ouiHeaderDarkTheme($backgroundColor); }
+@mixin euiHeaderDarkTheme($backgroundColor) {
+  background-color: $backgroundColor;
+  border-bottom-color: lightOrDarkTheme($backgroundColor, $ouiHeaderBorderColor);
+
+  .euiHeaderLogo__text,
+  .euiHeaderLink,
+  .euiHeaderSectionItemButton {
+    color: $ouiColorGhost;
+  }
+
+  .euiHeaderLink-isActive {
+    color: makeHighContrastColor($ouiColorPrimary, $backgroundColor);
+  }
+
+  .euiHeaderSectionItem {
+    &:after {
+      background: lightOrDarkTheme($ouiColorDarkShade, $ouiColorLightestShade);
+    }
+  }
+
+  .euiHeaderLogo,
+  .euiHeaderLink,
+  .euiHeaderSectionItemButton {
+    &:focus {
+      background: shade($ouiColorPrimary, 50%);
+    }
+  }
+
+  .euiHeaderSectionItemButton__notification--badge {
+    box-shadow: 0 0 0 1px $backgroundColor;
+  }
+
+  .euiHeaderSectionItemButton__notification--dot {
+    stroke: $backgroundColor;
+  }
+}
 /* End of Aliases */

--- a/src/global_styling/mixins/_beta_badge.scss
+++ b/src/global_styling/mixins/_beta_badge.scss
@@ -42,5 +42,30 @@
 
 
 /* OUI -> EUI Aliases */
-@mixin euiHasBetaBadge($selector, $spacing: $ouiSize) { @include ouiHasBetaBadge($selector, $spacing); }
+@mixin euiHasBetaBadge($selector, $spacing: $ouiSize) {
+  #{$selector}--hasBetaBadge {
+    position: relative;
+    overflow: visible; // 2
+
+    #{$selector}__betaBadgeWrapper {
+      position: absolute;
+      top: ($ouiSizeL / -2);
+      left: 50%;
+      transform: translateX(-50%);
+      z-index: 3; // get above abs positioned image
+      min-width: 30%; // 1
+      max-width: calc(100% - #{($spacing * 2)});
+
+      .euiToolTipAnchor,
+      #{$selector}__betaBadge {
+        width: 100%; // 1
+      }
+
+      #{$selector}__betaBadge {
+        overflow: hidden;
+        text-overflow: ellipsis;
+      }
+    }
+  }
+}
 /* End of Aliases */

--- a/src/global_styling/mixins/_button.scss
+++ b/src/global_styling/mixins/_button.scss
@@ -120,6 +120,23 @@
 @mixin euiButtonBase { @include ouiButtonBase; }
 @mixin euiButtonFocus { @include ouiButtonFocus; }
 @mixin euiButton { @include ouiButton; }
-@mixin euiButtonContent($isReverse: false) { @include ouiButtonContent($isReverse); }
-@mixin euiButtonContentDisabled { @include ouiButtonContentDisabled; }
+@mixin euiButtonContent($isReverse: false) {
+  @include ouiButtonContent($isReverse);
+
+  .euiButtonContent__icon,
+  .euiButtonContent__spinner {
+    flex-shrink: 0; // Ensures the icons/spinner don't scale down below their intended size
+  }
+}
+@mixin euiButtonContentDisabled {
+  @include ouiButtonContentDisabled;
+
+  .euiButtonContent__icon {
+    fill: currentColor;
+  }
+
+  .euiButtonContent__spinner {
+    border-color: ouiLoadingSpinnerBorderColors(currentColor);
+  }
+}
 /* End of Aliases */

--- a/src/global_styling/mixins/_form.scss
+++ b/src/global_styling/mixins/_form.scss
@@ -268,6 +268,12 @@
       ~ .ouiFormControlLayoutIcons {
         color: lightOrDarkTheme($ouiColorDarkestShade, $ouiColorLightShade);
       }
+
+      /* OUI -> EUI Aliases */
+      ~ .euiFormControlLayoutIcons {
+        color: lightOrDarkTheme($ouiColorDarkestShade, $ouiColorLightShade);
+      }
+      /* End of Aliases */
     }
 
   }
@@ -388,7 +394,11 @@
 @mixin euiFormLabel { @include ouiFormLabel; }
 @mixin euiFormControlLayoutPadding($numOfIcons, $side: 'right', $compressed: false) { @include ouiFormControlLayoutPadding($numOfIcons, $side, $compressed); }
 @mixin euiFormControlLayoutClearIcon($iconClass, $size: 'm') { @include ouiFormControlLayoutClearIcon($iconClass, $size); }
-@mixin euiPlaceholderPerBrowser { @include ouiPlaceholderPerBrowser; }
+@mixin euiPlaceholderPerBrowser {
+  @include ouiPlaceholderPerBrowser {
+    @content;
+  }
+}
 @function euiFormControlGradient($color: $ouiColorPrimary) { @return ouiFormControlGradient($color); }
 @mixin euiFormControlText { @include ouiFormControlText; }
 @mixin euiFormControlSize(

--- a/src/global_styling/mixins/_header.scss
+++ b/src/global_styling/mixins/_header.scss
@@ -39,5 +39,26 @@
 
 
 /* OUI -> EUI Aliases */
-@mixin euiHeaderAffordForFixed($headerHeight: $ouiHeaderHeightCompensation) { @include ouiHeaderAffordForFixed($headerHeight); }
+@mixin euiHeaderAffordForFixed($headerHeight: $ouiHeaderHeightCompensation) {
+  &.euiBody--headerIsFixed {
+    padding-top: $headerHeight;
+
+    .euiFlyout,
+    .euiCollapsibleNav {
+      top: $headerHeight;
+      height: calc(100% - #{$headerHeight});
+    }
+
+    @include euiBreakpoint('m', 'l', 'xl') {
+      .euiPageSideBar--sticky {
+        max-height: calc(100vh - #{$headerHeight});
+        top: #{$headerHeight};
+      }
+    }
+
+    .euiOverlayMask--belowHeader {
+      top: #{$headerHeight};
+    }
+  }
+}
 /* End of Aliases */

--- a/src/global_styling/mixins/_helpers.scss
+++ b/src/global_styling/mixins/_helpers.scss
@@ -146,6 +146,14 @@
 @mixin euiYScrollWithShadows { @include ouiYScrollWithShadows; }
 @mixin euiXScrollWithShadows { @include ouiXScrollWithShadows; }
 @mixin euiScreenReaderOnly { @include ouiScreenReaderOnly; }
-@mixin euiCanAnimate { @include ouiCanAnimate; }
-@mixin euiCantAnimate { @include ouiCantAnimate; }
+@mixin euiCanAnimate {
+  @include ouiCanAnimate {
+    @content;
+  }
+}
+@mixin euiCantAnimate {
+  @include ouiCantAnimate {
+    @content;
+  }
+}
 /* End of Aliases */

--- a/src/global_styling/mixins/_range.scss
+++ b/src/global_styling/mixins/_range.scss
@@ -42,7 +42,15 @@
 
 /* OUI -> EUI Aliases */
 @mixin euiRangeTrackSize { @include ouiRangeTrackSize; }
-@mixin euiRangeTrackPerBrowser { @include ouiRangeTrackPerBrowser; }
+@mixin euiRangeTrackPerBrowser {
+  @include ouiRangeTrackPerBrowser {
+    @content;
+  }
+}
 @mixin euiRangeThumbStyle { @include ouiRangeThumbStyle; }
-@mixin euiRangeThumbPerBrowser { @include ouiRangeThumbPerBrowser; }
+@mixin euiRangeThumbPerBrowser {
+  @include ouiRangeThumbPerBrowser {
+    @content;
+  }
+}
 /* End of Aliases */

--- a/src/global_styling/mixins/_responsive.scss
+++ b/src/global_styling/mixins/_responsive.scss
@@ -61,5 +61,9 @@
 
 
 /* OUI -> EUI Aliases */
-@mixin euiBreakpoint($sizes...) { @include ouiBreakpoint($sizes...); }
+@mixin euiBreakpoint($sizes...) {
+  @include ouiBreakpoint($sizes...) {
+    @content;
+  }
+}
 /* End of Aliases */

--- a/src/themes/oui-cascadia/global_styling/mixins/_range.scss
+++ b/src/themes/oui-cascadia/global_styling/mixins/_range.scss
@@ -70,11 +70,19 @@
 
 /* OUI -> EUI Aliases */
 @mixin euiRangeTrackSize($compressed: false) { @include ouiRangeTrackSize($compressed); }
-@mixin euiRangeTrackPerBrowser { @include ouiRangeTrackPerBrowser; }
+@mixin euiRangeTrackPerBrowser {
+  @include ouiRangeTrackPerBrowser {
+    @content;
+  }
+}
 @mixin euiRangeThumbBorder { @include ouiRangeThumbBorder; }
 @mixin euiRangeThumbBoxShadow { @include ouiRangeThumbBoxShadow; }
 @mixin euiRangeThumbFocusBoxShadow { @include ouiRangeThumbFocusBoxShadow; }
 @mixin euiRangeThumbStyle { @include ouiRangeThumbStyle; }
-@mixin euiRangeThumbPerBrowser { @include ouiRangeThumbPerBrowser; }
+@mixin euiRangeThumbPerBrowser {
+  @include ouiRangeThumbPerBrowser {
+    @content;
+  }
+}
 @mixin euiRangeThumbFocus { @include ouiRangeThumbFocus; }
 /* End of Aliases */

--- a/src/themes/oui-cascadia/overrides/_avatar.scss
+++ b/src/themes/oui-cascadia/overrides/_avatar.scss
@@ -16,3 +16,13 @@
     display: none;
   }
 }
+
+/* OUI -> EUI Aliases */
+.euiAvatar--space,
+.euiAvatar--user {
+  // Remove faux outline
+  &:after {
+    display: none;
+  }
+}
+/* End of Aliases */

--- a/src/themes/oui-cascadia/overrides/_button.scss
+++ b/src/themes/oui-cascadia/overrides/_button.scss
@@ -122,3 +122,116 @@
     background-color: transparentize($ouiButtonColorGhostDisabled, .9);
   }
 }
+
+/* OUI -> EUI Aliases */
+.euiButton,
+.euiButtonIcon {
+  // sass-lint:disable no-important
+  // remove for all states
+  box-shadow: none !important;
+}
+
+.euiButton.euiButton-isDisabled:not(.euiButton--ghost),
+.euiButtonIcon.euiButtonIcon-isDisabled:not(.euiButtonIcon--ghost) {
+  &,
+  &:hover {
+    $backgroundColorSimulated: mix($euiPageBackgroundColor, $euiButtonColorDisabled, 90%);
+    background-color: transparentize($euiButtonColorDisabled, .9);
+    color: makeDisabledContrastColor($euiButtonColorDisabled, $backgroundColorSimulated);
+  }
+}
+
+.euiButtonIcon--empty.euiButtonIcon-isDisabled:not(.euiButtonIcon--ghost) {
+  &,
+  &:hover {
+    background-color: transparent;
+    color: makeDisabledContrastColor($euiButtonColorDisabled, $euiPageBackgroundColor);
+  }
+}
+
+.euiButton--small,
+.euiButtonIcon--small,
+.euiButtonIcon--xSmall {
+  // Use a moderately smaller radius on small buttons
+  // so that they don't appear completely rounded
+  border-radius: $euiBorderRadius * (2 / 3);
+}
+
+// Change the hollow (bordered) buttons to have a transparent background
+// and no border
+@each $name, $color in $euiButtonTypes {
+  .euiButton--#{$name} {
+    @include euiButtonDefaultStyle($color);
+
+    @if ($name == 'ghost') {
+      // Ghost is unique and ALWAYS sits against a dark background.
+      $backgroundColorSimulated: mix($euiColorInk, $color, 70%);
+      color: makeHighContrastColor($color, $backgroundColorSimulated);
+    } @else {
+      &.euiButton--fill:focus {
+        outline-color: lightOrDarkTheme($euiColorInk, $euiColorGhost);
+      }
+    }
+
+    &.euiButton--fill:not([class*='isDisabled']) {
+      color: chooseLightOrDarkText($color, $euiColorGhost, $euiColorInk);
+
+      &,
+      &:hover,
+      &:focus {
+        background-color: $color;
+      }
+    }
+  }
+}
+
+// Fix ghost/disabled look specifically
+.euiButton.euiButton-isDisabled.euiButton--ghost,
+  // adding fill type to override default theme
+.euiButton.euiButton-isDisabled.euiButton--ghost.euiButton--fill {
+  &,
+  &:focus {
+    color: $euiButtonColorGhostDisabled;
+    background-color: transparentize($euiButtonColorGhostDisabled, .9);
+  }
+}
+
+
+// Duplicating the above for EuiButtonIcon
+@each $name, $color in $euiButtonTypes {
+  .euiButtonIcon--#{$name}:not(.euiButtonIcon--empty) {
+    @include euiButtonDefaultStyle($color);
+
+    @if ($name == 'ghost') {
+      // Ghost is unique and ALWAYS sits against a dark background.
+      $backgroundColorSimulated: mix($euiColorInk, $color, 70%);
+      color: makeHighContrastColor($color, $backgroundColorSimulated);
+    } @else {
+      &.euiButtonIcon--fill:focus {
+        outline-color: lightOrDarkTheme($euiColorInk, $euiColorGhost);
+      }
+    }
+
+    &.euiButtonIcon--fill:not([class*='isDisabled']) {
+      color: chooseLightOrDarkText($color, $euiColorGhost, $euiColorInk);
+
+      &,
+      &:hover,
+      &:focus {
+        background-color: $color;
+      }
+    }
+  }
+}
+
+// Fix ghost/disabled look specifically
+.euiButtonIcon:not(.euiButtonIcon--empty).euiButtonIcon-isDisabled.euiButtonIcon--ghost,
+  // adding fill type to override default theme
+.euiButtonIcon.euiButtonIcon-isDisabled.euiButtonIcon--ghost.euiButtonIcon--fill {
+  &,
+  &:focus {
+    color: $euiButtonColorGhostDisabled;
+    background-color: transparentize($euiButtonColorGhostDisabled, .9);
+  }
+}
+/* End of Aliases */

--- a/src/themes/oui-cascadia/overrides/_button_empty.scss
+++ b/src/themes/oui-cascadia/overrides/_button_empty.scss
@@ -29,3 +29,26 @@
     @include ouiFocusBackground($color);
   }
 }
+
+/* OUI -> EUI Aliases */
+.euiButtonEmpty {
+  border-radius: $euiBorderRadius;
+
+  &.euiButtonEmpty--small,
+  &.euiButtonEmpty--xSmall {
+    // Use a moderately smaller radius on small buttons
+    // so that they don't appear completely rounded
+    border-radius: $euiBorderRadius * .667;
+  }
+
+  &.euiButtonEmpty--xSmall {
+    font-size: $euiFontSizeXS;
+  }
+}
+
+@each $name, $color in $euiButtonTypes {
+  .euiButtonEmpty--#{$name}:enabled:focus {
+    @include euiFocusBackground($color);
+  }
+}
+/* End of Aliases */

--- a/src/themes/oui-cascadia/overrides/_button_group.scss
+++ b/src/themes/oui-cascadia/overrides/_button_group.scss
@@ -98,3 +98,92 @@
     }
   }
 }
+
+/* OUI -> EUI Aliases */
+.euiButtonGroup__buttons {
+  box-shadow: none !important; // sass-lint:disable-line no-important
+}
+
+.euiButtonGroup--medium,
+.euiButtonGroup--small {
+  .euiButtonGroupButton {
+    border: none !important; // sass-lint:disable-line no-important
+
+    // Complicated set of focus states depending on whether it's a button and can receive :focus,
+    // or an input and uses focus-within, and browser support for :focus-visible
+    &:focus,
+    &:focus-within {
+      outline-style: solid;
+      outline-color: lightOrDarkTheme($euiColorInk, $euiColorGhost);
+      outline-offset: -2px;
+
+      &:focus-visible {
+        outline-style: auto; // For chrome only
+      }
+    }
+
+    &:focus:not(:focus-visible) {
+      outline: none;
+    }
+  }
+
+  .euiButtonGroupButton-isDisabled:not(.euiButtonGroupButton--ghost):not(.euiButtonGroupButton-isSelected) {
+    $backgroundColorSimulated: mix($euiPageBackgroundColor, $euiButtonColorDisabled, 70%);
+    background-color: transparentize($euiButtonColorDisabled, .7);
+    color: makeHighContrastColor($euiButtonColorDisabled, $backgroundColorSimulated, 2);
+  }
+
+  // Change the hollow (bordered) buttons to have a transparent background
+  // and no border
+  @each $name, $color in $euiButtonTypes {
+    .euiButtonGroupButton--#{$name} {
+      @include euiButtonDefaultStyle($color);
+
+      @if ($name == 'ghost') {
+        // Ghost is unique and ALWAYS sits against a dark background.
+        $backgroundColorSimulated: mix($euiColorInk, $color, 70%);
+        color: makeHighContrastColor($color, $backgroundColorSimulated);
+      }
+    }
+  }
+
+  .euiButtonGroupButton-isDisabled.euiButtonGroupButton--ghost:not(.euiButtonGroupButton-isSelected) {
+    &,
+    &:hover,
+    &:focus {
+      background-color: transparentize($euiButtonColorGhostDisabled, .7);
+    }
+  }
+}
+
+.euiButtonGroup--small .euiButtonGroup__buttons {
+  // Use a moderately smaller radius on small buttons
+  // so that they don't appear completely rounded
+  border-radius: $euiBorderRadius * (2 / 3);
+}
+
+.euiButtonGroup--compressed .euiButtonGroupButton {
+  // Add 1 to the border radius to account for the background-clip
+  border-radius: $euiFormControlCompressedBorderRadius + 1;
+
+  @each $name, $color in $euiButtonTypes {
+    &--#{$name} {
+      // Complicated set of focus states depending on whether it's a button and can receive :focus,
+      // or an input and uses focus-within, and browser support for :focus-visible,
+      // and override nature of default theme
+      &:not([class*='isDisabled']):focus,
+      &:not([class*='isDisabled']):focus-within {
+        outline-color: $color;
+
+        &:focus-visible {
+          outline-style: auto; // For chrome only
+        }
+      }
+
+      &:not([class*='isDisabled']):focus:not(:focus-visible) {
+        outline: none;
+      }
+    }
+  }
+}
+/* End of Aliases */

--- a/src/themes/oui-cascadia/overrides/_call_out.scss
+++ b/src/themes/oui-cascadia/overrides/_call_out.scss
@@ -16,3 +16,13 @@
     font-weight: $ouiFontWeightMedium;
   }
 }
+
+/* OUI -> EUI Aliases */
+.euiCallOut {
+  border-left: none;
+
+  .euiCallOutHeader__title {
+    font-weight: $euiFontWeightMedium;
+  }
+}
+/* End of Aliases */

--- a/src/themes/oui-cascadia/overrides/_code_block.scss
+++ b/src/themes/oui-cascadia/overrides/_code_block.scss
@@ -17,3 +17,14 @@
     font-weight: $ouiCodeFontWeightBold;
   }
 }
+
+/* OUI -> EUI Aliases */
+.euiCodeBlock.euiCodeBlock--inline {
+  border-radius: $euiBorderRadiusSmall;
+  color: makeHighContrastColor($euiColorVis3, $euiCodeBlockBackgroundColor);
+
+  .euiCodeBlock__code {
+    font-weight: $euiCodeFontWeightBold;
+  }
+}
+/* End of Aliases */

--- a/src/themes/oui-cascadia/overrides/_color_stops.scss
+++ b/src/themes/oui-cascadia/overrides/_color_stops.scss
@@ -68,3 +68,65 @@
     background-color: $ouiRangeTrackColor;
   }
 }
+
+/* OUI -> EUI Aliases */
+.euiColorStops__addTarget,
+.euiColorStops__addContainer {
+  z-index: 1;
+}
+
+.euiColorStops__addTarget {
+  border: 1px solid $euiColorDarkShade;
+  box-shadow: none;
+}
+
+.euiColorStopThumb.euiRangeThumb:not(:disabled) {
+  // sass-lint:disable-block no-important no-color-literals
+  @include euiRangeThumbBorder;
+  @include euiRangeThumbBoxShadow;;
+
+  &:focus {
+    @include euiRangeThumbFocusBoxShadow;
+    outline: none;
+  }
+
+  // in Chrome/FF/Edge we don't want to focus on click
+  &:focus:not(:focus-visible)  {
+    @include euiRangeThumbBoxShadow;
+    outline: none;
+  }
+}
+
+.euiColorStops:not(.euiColorStops-isDisabled) {
+  .euiRangeTrack::after {
+    transition-property: box-shadow;
+    // this `transition-delay` prevents Safari of adding the focus ring (box-shadow) every time we click the `EuiColorStops`
+    // the focus still appear when we drag a color stop in Safari
+    transition-delay: $euiAnimSpeedExtraFast;
+  }
+
+  &:focus {
+    outline: none;
+
+    .euiRangeTrack::after {
+      // sass-lint:disable-block no-color-literals
+      box-shadow: 0 0 0 1px rgba($euiColorEmptyShade, .8),
+      0 0 0 3px $euiFocusRingColor;
+    }
+  }
+
+  &:focus:not(:focus-visible) {
+    .euiRangeTrack::after {
+      box-shadow: none;
+    }
+  }
+}
+
+.euiColorStops__highlight {
+  color: $euiRangeTrackColor;
+
+  .euiRangeHighlight__progress {
+    background-color: $euiRangeTrackColor;
+  }
+}
+/* End of Aliases */

--- a/src/themes/oui-cascadia/overrides/_comment.scss
+++ b/src/themes/oui-cascadia/overrides/_comment.scss
@@ -12,3 +12,9 @@
 .ouiCommentEvent--regular {
   box-shadow: none;
 }
+
+/* OUI -> EUI Aliases */
+.euiCommentEvent--regular {
+  box-shadow: none;
+}
+/* End of Aliases */

--- a/src/themes/oui-cascadia/overrides/_date_picker.scss
+++ b/src/themes/oui-cascadia/overrides/_date_picker.scss
@@ -27,3 +27,23 @@
 .ouiDatePicker.ouiDatePicker--shadow.ouiDatePicker--inline .react-datepicker {
   border: none;
 }
+
+/* OUI -> EUI Aliases */
+.euiDatePicker {
+  &.euiDatePicker--shadow {
+    .react-datepicker-popper,
+    .react-datepicker-popper[data-placement^='top'] {
+      border: none;
+      border-radius: $euiBorderRadius;
+    }
+  }
+}
+
+.euiDatePickerRange {
+  border-radius: $euiFormControlBorderRadius;
+}
+
+.euiDatePicker.euiDatePicker--shadow.euiDatePicker--inline .react-datepicker {
+  border: none;
+}
+/* End of Aliases */

--- a/src/themes/oui-cascadia/overrides/_filter_group.scss
+++ b/src/themes/oui-cascadia/overrides/_filter_group.scss
@@ -28,3 +28,25 @@
     box-shadow: 0 1px 0 0 $ouiFormBorderColor;
   }
 }
+
+/* OUI -> EUI Aliases */
+.euiFilterGroup {
+  border: none;
+  border-radius: $euiFormControlBorderRadius;
+  background-color: $euiFormBackgroundColor;
+  box-shadow: inset 0 0 0 1px $euiFormBorderColor;
+}
+
+.euiFilterButton {
+  border-radius: 0;
+  border: none;
+  background-color: transparent;
+  // Box shadow simulates bottom and left borders
+  box-shadow: 0 1px 0 0 $euiFormBorderColor, -1px 0 0 0 $euiFormBorderColor;
+
+  .euiFilterButton--withNext + & {
+    // Remove just the left faux border
+    box-shadow: 0 1px 0 0 $euiFormBorderColor;
+  }
+}
+/* End of Aliases */

--- a/src/themes/oui-cascadia/overrides/_form_control_layout.scss
+++ b/src/themes/oui-cascadia/overrides/_form_control_layout.scss
@@ -112,3 +112,109 @@
     }
   }
 }
+
+/* OUI -> EUI Aliases */
+.euiFormControlLayout--group {
+  border-radius: $euiFormControlBorderRadius;
+  background-color: $euiFormInputGroupLabelBackground;
+
+  .euiFormControlLayout__prepend:first-child {
+    @include euiFormControlSideBorderRadius($euiFormControlBorderRadius, $side: 'left', $internal: true);
+
+    [class*='euiButton'] {
+      @include euiFormControlSideBorderRadius($euiFormControlBorderRadius, $side: 'left', $internal: true);
+    }
+  }
+
+  .euiFormControlLayout__append:last-child {
+    @include euiFormControlSideBorderRadius($euiFormControlBorderRadius, $side: 'right', $internal: true);
+
+    [class*='euiButton'] {
+      @include euiFormControlSideBorderRadius($euiFormControlBorderRadius, $side: 'right', $internal: true);
+    }
+  }
+
+  [class*='euiButton']:focus {
+    @include euiFocusRing(null, 'inner');
+  }
+
+  .euiToolTipAnchor > .euiIcon {
+    @include euiFormControlSideBorderRadius($euiFormControlBorderRadius, $side: 'right', $internal: true);
+  }
+
+  .euiToolTipAnchor:first-child [class*='euiButton'] {
+    @include euiFormControlSideBorderRadius($euiFormControlBorderRadius, $side: 'left', $internal: true);
+  }
+
+  .euiToolTipAnchor:last-child {
+    [class*='euiButton'],
+    .euiText {
+      @include euiFormControlSideBorderRadius($euiFormControlBorderRadius, $side: 'right', $internal: true);
+    }
+  }
+
+  .euiFormControlLayout__childrenWrapper:nth-child(2) [class*='euiField'],
+  .euiFormControlLayout__childrenWrapper:nth-child(3) [class*='euiField'] {
+    border-radius: 0;
+  }
+
+  .euiFormControlLayout__childrenWrapper:first-child .euiSelect,
+  .euiFormControlLayout__childrenWrapper:first-child [class*='euiField'] {
+    @include euiFormControlSideBorderRadius($euiFormControlBorderRadius, $side: 'left');
+  }
+
+  .euiFormControlLayout__childrenWrapper:last-child .euiSelect,
+  .euiFormControlLayout__childrenWrapper:last-child [class*='euiField'] {
+    @include euiFormControlSideBorderRadius($euiFormControlBorderRadius, $side: 'right');
+  }
+
+  &.euiFormControlLayout--compressed {
+    border-radius: $euiFormControlCompressedBorderRadius;
+    background-color: $euiFormInputGroupLabelBackground;
+
+    .euiFormControlLayout__prepend:first-child {
+      @include euiFormControlSideBorderRadius($euiFormControlCompressedBorderRadius, $side: 'left', $internal: true);
+
+      [class*='euiButton'] {
+        @include euiFormControlSideBorderRadius($euiFormControlCompressedBorderRadius, $side: 'left');
+      }
+    }
+
+    .euiFormControlLayout__append:last-child {
+      @include euiFormControlSideBorderRadius($euiFormControlCompressedBorderRadius, $side: 'right', $internal: true);
+
+      [class*='euiButton'] {
+        @include euiFormControlSideBorderRadius($euiFormControlCompressedBorderRadius, $side: 'right', $internal: true);
+      }
+    }
+
+    .euiToolTipAnchor > .euiIcon {
+      @include euiFormControlSideBorderRadius($euiFormControlCompressedBorderRadius, $side: 'right', $internal: true);
+    }
+
+    .euiToolTipAnchor:first-child [class*='euiButton'] {
+      @include euiFormControlSideBorderRadius($euiFormControlCompressedBorderRadius, $side: 'left', $internal: true);
+    }
+
+    .euiToolTipAnchor:last-child [class*='euiButton'],
+    .euiToolTipAnchor:last-child .euiText {
+      @include euiFormControlSideBorderRadius($euiFormControlCompressedBorderRadius, $side: 'right', $internal: true);
+    }
+
+    .euiFormControlLayout__childrenWrapper:nth-child(2) [class*='euiField'],
+    .euiFormControlLayout__childrenWrapper:nth-child(3) [class*='euiField'] {
+      border-radius: 0;
+    }
+
+    .euiFormControlLayout__childrenWrapper:first-child .euiSelect,
+    .euiFormControlLayout__childrenWrapper:first-child [class*='euiField'] {
+      @include euiFormControlSideBorderRadius($euiFormControlCompressedBorderRadius, $side: 'left', $internal: true);
+    }
+
+    .euiFormControlLayout__childrenWrapper:last-child .euiSelect,
+    .euiFormControlLayout__childrenWrapper:last-child [class*='euiField'] {
+      @include euiFormControlSideBorderRadius($euiFormControlCompressedBorderRadius, $side: 'right', $internal: true);
+    }
+  }
+}
+/* End of Aliases */

--- a/src/themes/oui-cascadia/overrides/_form_control_layout_delimited.scss
+++ b/src/themes/oui-cascadia/overrides/_form_control_layout_delimited.scss
@@ -50,3 +50,47 @@
     }
   }
 }
+
+/* OUI -> EUI Aliases */
+.euiFormControlLayoutDelimited {
+  border-radius: $euiFormControlBorderRadius;
+
+  &.euiFormControlLayout--group {
+    .euiFormControlLayout__childrenWrapper:first-child {
+      border-radius: $euiFormControlBorderRadius 0 0 $euiFormControlBorderRadius;
+    }
+  }
+
+  .euiFormControlLayout__childrenWrapper:only-child {
+    border-radius: $euiFormControlBorderRadius;
+    overflow: hidden;
+  }
+
+  .euiFormControlLayout__prepend +
+  .euiFormControlLayout__childrenWrapper {
+    &:last-child {
+      border-radius: 0 $euiFormControlBorderRadius $euiFormControlBorderRadius 0;
+    }
+  }
+
+  &.euiFormControlLayout--compressed {
+    &.euiFormControlLayout--group {
+      .euiFormControlLayout__childrenWrapper:first-child {
+        border-radius: $euiFormControlCompressedBorderRadius 0 0 $euiFormControlCompressedBorderRadius;
+      }
+    }
+
+    .euiFormControlLayout__childrenWrapper:only-child {
+      border-radius: $euiFormControlCompressedBorderRadius;
+      overflow: hidden;
+    }
+
+    .euiFormControlLayout__prepend +
+    .euiFormControlLayout__childrenWrapper {
+      &:last-child {
+        border-radius: 0 $euiFormControlCompressedBorderRadius $euiFormControlCompressedBorderRadius 0;
+      }
+    }
+  }
+}
+/* End of Aliases */

--- a/src/themes/oui-cascadia/overrides/_form_controls.scss
+++ b/src/themes/oui-cascadia/overrides/_form_controls.scss
@@ -28,3 +28,25 @@
     outline: none;
   }
 }
+
+/* OUI -> EUI Aliases */
+.euiRadio .euiRadio__input {
+  &:focus {
+    @include euiCustomControlFocused('.euiRadio__circle');
+  }
+}
+
+.euiCheckbox .euiCheckbox__input {
+  &:focus {
+    @include euiCustomControlFocused('.euiCheckbox__square');
+  }
+}
+
+.euiSwitch .euiSwitch__button:focus {
+  @include euiFocusRing(null, 'outer');
+
+  .euiSwitch__track {
+    outline: none;
+  }
+}
+/* End of Aliases */

--- a/src/themes/oui-cascadia/overrides/_header.scss
+++ b/src/themes/oui-cascadia/overrides/_header.scss
@@ -118,3 +118,111 @@
   }
 }
 
+/* OUI -> EUI Aliases */
+.euiHeader {
+  height: $euiHeaderHeight;
+  padding-left: $euiSizeS;
+  padding-right: $euiSizeS;
+}
+
+// Remove borders without deleting the prop just yet
+.euiHeaderSectionItem:after {
+  display: none !important; // sass-lint:disable-line no-important
+}
+
+.euiHeaderLogo {
+  @include euiBreakpoint('xs') {
+    padding-left: $euiSizeXS;
+  }
+
+  padding-left: $euiSizeS;
+  padding-right: $euiSizeS;
+  min-width: $euiHeaderChildSize;
+}
+
+.euiHeaderLogo__text {
+  @include euiTitle('xxs');
+}
+
+.euiHeader--default + .euiHeader--default {
+  border-top: $euiBorderThin;
+}
+
+// Breadcrumbs
+
+.euiHeaderBreadcrumbs {
+  font-size: $euiFontSizeXS;
+  line-height: $euiSize;
+  margin-left: $euiSizeS;
+  margin-right: $euiSizeS;
+
+  // No separators
+  .euiBreadcrumbSeparator {
+    display: none !important; // sass-lint:disable-line no-important
+  }
+
+  // Only the header breadcrumbs get the new Cascadia style so that there can
+  // still be default text only breadcrumbs for places like EuiControlBar
+  .euiBreadcrumb {
+    @include euiButtonDefaultStyle($euiTextColor);
+    line-height: $euiSize;
+    font-weight: $euiFontWeightMedium;
+    padding: $euiSizeXS $euiSize;
+    clip-path: polygon(0 0, calc(100% - #{$euiSizeS}) 0, 100% 50%, calc(100% - #{$euiSizeS}) 100%, 0 100%, $euiSizeS 50%);
+
+    &:focus {
+      @include euiFocusRing(null, 'inner');
+
+      &:focus-visible {
+        // Turn radius and clip path off when in focus so the focus ring looks correct
+        border-radius: 0;
+        clip-path: none;
+      }
+    }
+
+    // If it's a link the easiest way to detect is via our .euiLink class since it can accept either href or onClick
+    // Also helps to add specificity for overriding hover state
+    &.euiBreadcrumb--collapsed,
+    &.euiLink {
+      @include euiButtonDefaultStyle($euiColorPrimary);
+
+      &:hover,
+      &:focus {
+        color: $euiColorPrimary;
+      }
+    }
+
+    &.euiBreadcrumb--collapsed .euiLink {
+      &,
+      &:hover,
+      &:focus {
+        color: $euiColorPrimary;
+      }
+    }
+
+    &:not(.euiBreadcrumb--last) {
+      margin-right: -$euiSizeXS;
+    }
+
+    &:first-child {
+      padding-left: $euiSizeM;
+      border-radius: $euiBorderRadius 0 0 $euiBorderRadius;
+      clip-path: polygon(0 0, calc(100% - #{$euiSizeS}) 0, 100% 50%, calc(100% - #{$euiSizeS}) 100%, 0 100%);
+    }
+  }
+
+  .euiBreadcrumb--last {
+    border-radius: 0 $euiBorderRadius $euiBorderRadius 0;
+    padding-right: $euiSizeM;
+    clip-path: polygon(0 0, 100% 0, 100% 100%, 0 100%, #{$euiSizeS} 50%);
+  }
+
+  // In case the item is first AND last, aka only, just make it a fully rounded item
+  .euiBreadcrumb:only-child {
+    clip-path: none;
+    padding-left: $euiSizeM;
+    padding-right: $euiSizeM;
+    border-radius: $euiBorderRadius;
+  }
+}
+/* End of Aliases */

--- a/src/themes/oui-cascadia/overrides/_hue.scss
+++ b/src/themes/oui-cascadia/overrides/_hue.scss
@@ -53,3 +53,50 @@
     }
   }
 }
+
+/* OUI -> EUI Aliases */
+.euiHue {
+  position: relative;
+  height: $euiSizeM;
+  border-radius: $euiSizeM;
+  margin: $euiSizeS 0;
+
+  &::before,
+  &::after {
+    display: none;
+  }
+
+  &__range {
+    @include euiRangeThumbPerBrowser {
+      // sass-lint:disable-block no-color-literals
+      border: 3px solid $euiRangeThumbBorderColor;
+      box-shadow: 0 2px 2px -1px rgba($euiShadowColor, .2),
+      0 1px 5px -2px rgba($euiShadowColor, .2);
+      background-color: inherit;
+    }
+
+    top: - $euiSizeM / 2;
+
+    &:focus {
+      @include euiRangeThumbPerBrowser {
+        @include euiRangeThumbFocusBoxShadow;
+        border: 3px solid $euiRangeThumbBorderColor;
+      }
+
+      outline: none;
+    }
+
+    &:focus:not(:focus-visible) {
+      @include euiRangeThumbPerBrowser {
+        // sass-lint:disable-block no-color-literals
+        box-shadow: 0 2px 2px -1px rgba($euiShadowColor, .2),
+        0 1px 5px -2px rgba($euiShadowColor, .2);
+      }
+    }
+
+    &:focus:focus-visible {
+      outline: none;
+    }
+  }
+}
+/* End of Aliases */

--- a/src/themes/oui-cascadia/overrides/_image.scss
+++ b/src/themes/oui-cascadia/overrides/_image.scss
@@ -19,3 +19,16 @@
 .ouiImage-isFullScreenCloseIcon {
   fill: $ouiColorGhost;
 }
+
+/* OUI -> EUI Aliases */
+.euiImage-isFullScreen {
+  .euiImage__caption {
+    color: $euiColorGhost;
+    text-shadow: 0 1px 2px transparentize($euiColorInk, .6);
+  }
+}
+
+.euiImage-isFullScreenCloseIcon {
+  fill: $euiColorGhost;
+}
+/* End of Aliases */

--- a/src/themes/oui-cascadia/overrides/_list_group_item.scss
+++ b/src/themes/oui-cascadia/overrides/_list_group_item.scss
@@ -12,3 +12,9 @@
 .ouiListGroupItem--medium {
   font-size: $ouiFontSizeM;
 }
+
+/* OUI -> EUI Aliases */
+.euiListGroupItem--medium {
+  font-size: $euiFontSizeM;
+}
+/* End of Aliases */

--- a/src/themes/oui-cascadia/overrides/_mark.scss
+++ b/src/themes/oui-cascadia/overrides/_mark.scss
@@ -12,3 +12,9 @@
 .ouiMark {
   background: $ouiFocusBackgroundColor;
 }
+
+/* OUI -> EUI Aliases */
+.ouiMark {
+  background: $euiFocusBackgroundColor;
+}
+/* End of Aliases */

--- a/src/themes/oui-cascadia/overrides/_markdown_editor.scss
+++ b/src/themes/oui-cascadia/overrides/_markdown_editor.scss
@@ -27,3 +27,24 @@
 .ouiMarkdownEditorFooter {
   border-radius: 0 0 $ouiFormControlBorderRadius $ouiFormControlBorderRadius;
 }
+
+/* OUI -> EUI Aliases */
+.euiMarkdownEditorToolbar {
+  border-radius: $euiFormControlBorderRadius $euiFormControlBorderRadius 0 0;
+}
+
+.euiMarkdownEditorTextArea {
+  &:focus {
+    outline: none;
+  }
+
+  &:focus:focus-visible {
+    outline-style: none;
+  }
+}
+
+.euiMarkdownEditorPreview,
+.euiMarkdownEditorFooter {
+  border-radius: 0 0 $euiFormControlBorderRadius $euiFormControlBorderRadius;
+}
+/* End of Aliases */

--- a/src/themes/oui-cascadia/overrides/_modal.scss
+++ b/src/themes/oui-cascadia/overrides/_modal.scss
@@ -12,3 +12,9 @@
 .ouiModal {
   border: none;
 }
+
+/* OUI -> EUI Aliases */
+.euiModal {
+  border: none;
+}
+/* End of Aliases */

--- a/src/themes/oui-cascadia/overrides/_overlay_mask.scss
+++ b/src/themes/oui-cascadia/overrides/_overlay_mask.scss
@@ -12,3 +12,9 @@
 .ouiOverlayMask {
   background: transparentize($ouiColorInk, .5);
 }
+
+/* OUI -> EUI Aliases */
+.euiOverlayMask {
+  background: transparentize($ouiColorInk, .5);
+}
+/* End of Aliases */

--- a/src/themes/oui-cascadia/overrides/_popover.scss
+++ b/src/themes/oui-cascadia/overrides/_popover.scss
@@ -113,3 +113,108 @@
   }
 }
 
+/* OUI -> EUI Aliases */
+.euiPopover__panel {
+  &:focus {
+    outline-offset: 0;
+  }
+
+  &.euiPopover__panel-isAttached {
+    @include euiBottomShadowMedium;
+
+    // Reset border radius to panel's
+    // Specificity also helps override default theme
+    @each $modifier, $amount in $euiPanelBorderRadiusModifiers {
+      &.euiPanel--#{$modifier} {
+        border-radius: $amount;
+      }
+    }
+  }
+
+  .euiPopover__panelArrow {
+    &:before {
+      filter: blur($euiSizeXS - 1px);
+      opacity: .2;
+    }
+
+    $arrowShadowCompensation: $euiSizeXS;
+
+    &.euiPopover__panelArrow--top {
+      &:before {
+        bottom: -$euiPopoverArrowSize;
+        border-top-color: $euiShadowColor;
+        clip-path: polygon(#{-$arrowShadowCompensation} 0, #{$euiPopoverArrowSize * 2 + $arrowShadowCompensation} 0, #{$euiPopoverArrowSize * 2 + $arrowShadowCompensation} #{$euiPopoverArrowSize + $arrowShadowCompensation}, #{-$arrowShadowCompensation} #{$euiPopoverArrowSize + $arrowShadowCompensation});
+      }
+
+      &:after {
+        bottom: -$euiPopoverArrowSize + 1;
+      }
+    }
+
+    &.euiPopover__panelArrow--right {
+      &:before {
+        border-right-color: $euiShadowColor;
+        clip-path: polygon(#{-$arrowShadowCompensation} #{-$arrowShadowCompensation}, $euiPopoverArrowSize #{-$arrowShadowCompensation}, $euiPopoverArrowSize #{$euiPopoverArrowSize * 2 + $arrowShadowCompensation}, #{-$arrowShadowCompensation} #{$euiPopoverArrowSize * 2 + $arrowShadowCompensation});
+      }
+
+      &:after {
+        left: -$euiPopoverArrowSize + 1;
+      }
+    }
+
+    &.euiPopover__panelArrow--bottom {
+      &:before {
+        border-bottom-color: $euiShadowColor;
+        clip-path: polygon(#{-$arrowShadowCompensation} #{-$arrowShadowCompensation}, #{$euiPopoverArrowSize * 2 + $arrowShadowCompensation} #{-$arrowShadowCompensation}, #{$euiPopoverArrowSize * 2 + $arrowShadowCompensation} $euiPopoverArrowSize, #{-$arrowShadowCompensation} $euiPopoverArrowSize);
+      }
+
+      &:after {
+        top: -$euiPopoverArrowSize + 1;
+      }
+    }
+
+    &.euiPopover__panelArrow--left {
+      &:before {
+        right: -$euiPopoverArrowSize;
+        border-left-color: $euiShadowColor;
+        clip-path: polygon(0 #{-$arrowShadowCompensation}, #{$euiPopoverArrowSize + $arrowShadowCompensation} #{-$arrowShadowCompensation}, #{$euiPopoverArrowSize + $arrowShadowCompensation} #{$euiPopoverArrowSize * 2 + $arrowShadowCompensation}, 0 #{$euiPopoverArrowSize * 2 + $arrowShadowCompensation});
+      }
+
+      &:after {
+        right: -$euiPopoverArrowSize + 1;
+      }
+    }
+  }
+}
+
+
+// Mainly for specificity, but don't add padding to the title if
+// neither the the panel nor the title has a padding modifier (aka NONE)
+.euiPopover__panel:not([class*='euiPanel--padding']) .euiPopoverTitle:not([class*='euiPopoverTitle--padding']) {
+  padding: 0;
+}
+
+// Allow the panel padding to actually modify the all side of the title
+@each $modifier, $amount in $euiPanelPaddingModifiers {
+  .euiPopover__panel.euiPanel--#{$modifier} .euiPopoverTitle:not([class*='euiPopoverTitle--padding']) {
+    padding: $amount;
+  }
+}
+
+/**
+ * Footer specific overrides
+ */
+
+// Mainly for specificity, but don't add padding to the footer if
+// neither the the panel nor the footer has a padding modifier (aka NONE)
+.euiPopover__panel:not([class*='euiPanel--padding']) .euiPopoverFooter:not([class*='euiPopoverFooter--padding']) {
+  padding: 0;
+}
+
+// Allow the panel padding to actually modify the all side of the footer
+@each $modifier, $amount in $euiPanelPaddingModifiers {
+  .euiPopover__panel.euiPanel--#{$modifier} .euiPopoverFooter:not([class*='euiPopoverFooter--padding']) {
+    padding: $amount;
+  }
+}
+/* End of Aliases */

--- a/src/themes/oui-cascadia/overrides/_progress.scss
+++ b/src/themes/oui-cascadia/overrides/_progress.scss
@@ -12,3 +12,9 @@
 .ouiProgress--native {
   border-radius: $ouiSizeS;
 }
+
+/* OUI -> EUI Aliases */
+.euiProgress--native {
+  border-radius: $ouiSizeS;
+}
+/* End of Aliases */

--- a/src/themes/oui-cascadia/overrides/_range.scss
+++ b/src/themes/oui-cascadia/overrides/_range.scss
@@ -12,3 +12,9 @@
 .ouiRangeTooltip__value {
   border-radius: $ouiBorderRadiusSmall;
 }
+
+/* OUI -> EUI Aliases */
+.euiRangeTooltip__value {
+  border-radius: $ouiBorderRadiusSmall;
+}
+/* End of Aliases */

--- a/src/themes/oui-cascadia/overrides/_range_draggable.scss
+++ b/src/themes/oui-cascadia/overrides/_range_draggable.scss
@@ -34,3 +34,31 @@
     }
   }
 }
+
+/* OUI -> EUI Aliases */
+.euiRangeDraggable {
+  &:focus {
+    outline: none;
+
+    ~ .euiRangeThumb {
+      @include euiRangeThumbFocus;
+    }
+  }
+
+  // in Chrome/FF/Edge we don't want to focus on click
+  &:focus:not(:focus-visible)  {
+    ~ .euiRangeThumb {
+      @include euiRangeThumbBoxShadow;
+      outline: none;
+    }
+  }
+
+  &:focus-visible {
+    outline: none;
+
+    ~ .euiRangeThumb {
+      @include euiRangeThumbFocus;
+    }
+  }
+}
+/* End of Aliases */

--- a/src/themes/oui-cascadia/overrides/_range_highlight.scss
+++ b/src/themes/oui-cascadia/overrides/_range_highlight.scss
@@ -40,3 +40,37 @@
     }
   }
 }
+
+/* OUI -> EUI Aliases */
+.euiRangeHighlight {
+  z-index: 1;
+  pointer-events: none;
+
+  &__progress {
+    background-color: $euiRangeHighlightColor;
+    border-color: $euiRangeHighlightColor;
+
+    &--hasFocus {
+      background-color: $euiColorPrimary;
+    }
+  }
+
+  &--compressed {
+    top: calc(50% - #{($euiRangeTrackCompressedHeight/2)});
+
+    .euiRangeHighlight__progress {
+      height: $euiRangeHighlightCompressedHeight;
+    }
+
+    &.euiRangeHighlight--hasTicks {
+      top: ($euiRangeThumbHeight - $euiRangeTrackCompressedHeight) / 2;
+    }
+  }
+
+  &:not(.euiRangeHighlight--compressed) {
+    &.euiRangeHighlight--hasTicks {
+      top: ($euiRangeThumbHeight - $euiRangeTrackHeight) / 2;
+    }
+  }
+}
+/* End of Aliases */

--- a/src/themes/oui-cascadia/overrides/_range_levels.scss
+++ b/src/themes/oui-cascadia/overrides/_range_levels.scss
@@ -41,3 +41,38 @@
     }
   }
 }
+
+/* OUI -> EUI Aliases */
+.euiRangeLevels {
+  .euiRangeLevel {
+    margin-top: 0;
+    margin-bottom: 0;
+
+    &:first-child {
+      margin-left: 0;
+    }
+
+    &:last-child {
+      margin-right: 0;
+    }
+  }
+
+  &--compressed {
+    .euiRangeLevel {
+      height: $euiRangeTrackCompressedHeight;
+
+      &:first-child {
+        margin-left: 0;
+      }
+
+      &:last-child {
+        margin-right: 0;
+      }
+    }
+
+    .euiRangeThumb--hasTicks {
+      top: 0;
+    }
+  }
+}
+/* End of Aliases */

--- a/src/themes/oui-cascadia/overrides/_range_slider.scss
+++ b/src/themes/oui-cascadia/overrides/_range_slider.scss
@@ -63,3 +63,60 @@
     }
   }
 }
+
+/* OUI -> EUI Aliases */
+.euiRangeSlider {
+  // in firefox just setting the z-index to the thumb doesn't work
+  // so we need to set the z-index to all the range slider and make the track transparent
+  @include euiRangeTrackPerBrowser {
+    background-color: transparent;
+  }
+
+  // z-index higher than .euiRangeHighlight that is 1
+  // the track is transparent we just want the thumb to be on top of the .euiRangeHighlight
+  z-index: 2;
+
+  &--hasTicks {
+    height: $euiRangeThumbHeight;
+  }
+
+  &:focus {
+    @include euiRangeThumbPerBrowser {
+      @include euiRangeThumbFocus;
+    }
+
+    @include euiRangeTrackPerBrowser {
+      background-color: transparent;
+    }
+
+    outline: none;
+
+    ~ .euiRangeHighlight .euiRangeHighlight__progress {
+      background-color: $euiColorPrimary;
+    }
+  }
+
+  // in Chrome/FF/Edge we don't want to focus on click
+  &:focus:not(:focus-visible) {
+    @include euiRangeThumbPerBrowser {
+      @include euiRangeThumbBoxShadow;
+      background-color: $euiRangeThumbBackgroundColor;
+    }
+
+    ~ .euiRangeHighlight .euiRangeHighlight__progress {
+      background-color: $euiRangeHighlightColor;
+    }
+  }
+
+  &:disabled {
+    // sass-lint:disable-block mixins-before-declarations
+    @include euiRangeThumbPerBrowser {
+      background-color: $euiRangeThumbBackgroundColor;
+    }
+
+    ~ .euiRangeThumb {
+      background-color: $euiRangeThumbBackgroundColor;
+    }
+  }
+}
+/* End of Aliases */

--- a/src/themes/oui-cascadia/overrides/_range_thumb.scss
+++ b/src/themes/oui-cascadia/overrides/_range_thumb.scss
@@ -31,3 +31,26 @@
   }
 }
 
+/* OUI -> EUI Aliases */
+.euiRangeThumb {
+  @include euiRangeThumbBoxShadow;
+  @include euiRangeThumbBorder;
+  background-color: $euiRangeThumbBackgroundColor;
+  z-index: 2; // higher than .euiRangeHighlight that is 1
+  pointer-events: none;
+
+  &--hasTicks {
+    top: 0;
+    margin-top: 0;
+  }
+
+  &:focus {
+    @include euiRangeThumbFocus;
+    outline: none;
+  }
+
+  &:focus:focus-visible {
+    outline: none;
+  }
+}
+/* End of Aliases */

--- a/src/themes/oui-cascadia/overrides/_range_ticks.scss
+++ b/src/themes/oui-cascadia/overrides/_range_ticks.scss
@@ -51,3 +51,48 @@
     font-weight: $ouiFontWeightMedium;
   }
 }
+
+/* OUI -> EUI Aliases */
+.euiRangeTicks:not(.euiRangeTicks--compressed) {
+  .euiRangeTick {
+    padding-top: 0;
+  }
+
+  .euiRangeTick:not(.euiRangeTick--hasTickMark)::before,
+  .euiRangeTick__pseudo {
+    width: $euiSizeXS;
+    height: $euiSizeM / 2;
+    background-color: $euiColorLightShade;
+    border-radius: $euiBorderRadiusSmall;
+  }
+}
+
+.euiRangeTicks--compressed {
+  .euiRangeTick {
+    padding-top: $euiSize - 2px;
+
+    &::before,
+    .euiRangeTick__pseudo {
+      background-color: $euiColorLightShade;
+      border-radius: $euiBorderRadiusSmall;
+    }
+  }
+}
+
+.euiRangeTick {
+  &::before {
+    background-color: $euiColorLightShade;
+    border-radius: $euiBorderRadiusSmall;
+  }
+
+  &:enabled:hover,
+  &:focus,
+  &--selected {
+    color: $euiColorPrimary;
+  }
+
+  &--selected {
+    font-weight: $euiFontWeightMedium;
+  }
+}
+/* End of Aliases */

--- a/src/themes/oui-cascadia/overrides/_range_tooltip.scss
+++ b/src/themes/oui-cascadia/overrides/_range_tooltip.scss
@@ -12,3 +12,9 @@
 .ouiRangeTooltip {
   z-index: 3; // higher than thumbs that are 2
 }
+
+/* OUI -> EUI Aliases */
+.euiRangeTooltip {
+  z-index: 3; // higher than thumbs that are 2
+}
+/* End of Aliases */

--- a/src/themes/oui-cascadia/overrides/_range_track.scss
+++ b/src/themes/oui-cascadia/overrides/_range_track.scss
@@ -119,3 +119,116 @@
     }
   }
 }
+
+/* OUI -> EUI Aliases */
+.euiRangeTrack {
+  &::after {
+    content: '';
+    display: block;
+    background: $euiRangeTrackColor;
+    border: $euiRangeTrackBorderWidth solid $euiRangeTrackBorderColor;
+    border-radius: $euiRangeTrackRadius;
+    position: absolute;
+    left: 0;
+  }
+
+  &:not(.euiRangeTrack--compressed)::after {
+    @include euiRangeTrackSize;
+  }
+
+  &--compressed::after {
+    @include euiRangeTrackSize($compressed: true);
+  }
+
+  &--compressed {
+    &.euiRangeTrack--hasLevels {
+      .euiRangeTicks {
+        height: $euiRangeThumbHeight + ($euiRangeTrackCompressedHeight / 2);
+        top: $euiRangeThumbHeight;
+      }
+
+      .euiRangeTick {
+        padding-top: $euiRangeTrackCompressedHeight;
+      }
+    }
+
+    &:not(.euiRangeTrack--hasLevels) {
+      .euiRangeTicks {
+        height: $euiRangeTrackCompressedHeight + $euiRangeThumbHeight;
+        top: $euiRangeTrackHeight * 2;
+      }
+
+      .euiRangeTick {
+        padding-top: $euiSizeM / 2;
+      }
+    }
+
+    &.euiRangeTrack--hasTicks::after {
+      top: ($euiRangeThumbHeight - $euiRangeTrackCompressedHeight) / 2;
+    }
+
+    &:not(.euiRangeTrack--hasTicks)::after {
+      top: calc(50% - #{($euiRangeTrackCompressedHeight/2)});
+    }
+
+    .euiRangeThumb--hasTicks {
+      top: 0;
+    }
+
+    .euiRangeLevels:not(.euiRangeLevels--hasTicks) {
+      top: $euiRangeThumbHeight + $euiRangeTrackCompressedHeight - 1;
+    }
+
+    .euiRangeLevels--hasTicks {
+      top: $euiRangeThumbHeight - $euiRangeTrackCompressedHeight - 1;
+    }
+  }
+
+  &:not(.euiRangeTrack--compressed) {
+    &.euiRangeTrack--hasLevels {
+      .euiRangeTicks {
+        height: $euiRangeThumbHeight + ($euiRangeThumbHeight / 4);
+        top: $euiRangeThumbHeight + ($euiRangeThumbHeight / 4);
+      }
+
+      .euiRangeTick {
+        padding-top: $euiRangeTrackHeight;
+      }
+    }
+
+    &:not(.euiRangeTrack--hasLevels) {
+      .euiRangeTicks {
+        height: $euiRangeHeight - $euiRangeThumbHeight;
+        top: $euiRangeThumbHeight;
+      }
+
+      .euiRangeTick {
+        // removing 1px to prevent label getting cut in Safari
+        padding-top: ($euiRangeTrackHeight * 2) - 1;
+      }
+    }
+
+    &.euiRangeTrack--hasTicks {
+      .euiRangeTooltip {
+        top: -($euiSizeXS / 2);
+      }
+
+      &::after {
+        top: ($euiRangeThumbHeight - $euiRangeTrackHeight) / 2;
+      }
+    }
+
+    &:not(.euiRangeTrack--hasTicks)::after {
+      top: calc(50% - #{($euiRangeTrackHeight/2)});
+    }
+
+    .euiRangeLevels:not(.euiRangeLevels--hasTicks) {
+      top: $euiRangeThumbHeight + $euiRangeTrackHeight + ($euiSizeXS / 2);
+    }
+
+    .euiRangeLevels--hasTicks {
+      top: $euiRangeTrackHeight * 2;
+    }
+  }
+}
+/* End of Aliases */

--- a/src/themes/oui-cascadia/overrides/_side_nav.scss
+++ b/src/themes/oui-cascadia/overrides/_side_nav.scss
@@ -26,3 +26,23 @@
     }
   }
 }
+
+/* OUI -> EUI Aliases */
+.euiSideNavItem--root {
+  padding-bottom: $euiSizeS;
+
+  & + & {
+    padding-top: $euiSizeS;
+    margin-top: $euiSizeS;
+  }
+
+  & > .euiSideNavItemButton {
+    margin-bottom: $euiSizeXS;
+
+    .euiSideNavItemButton__label {
+      @include euiTitle('xxs');
+      color: inherit;
+    }
+  }
+}
+/* End of Aliases */

--- a/src/themes/oui-cascadia/overrides/_steps.scss
+++ b/src/themes/oui-cascadia/overrides/_steps.scss
@@ -111,3 +111,106 @@
   outline: $ouiFocusRingSize solid $ouiColorPrimary;
 }
 
+/* OUI -> EUI Aliases */
+// Make the disabled step title the same disabled text color
+.euiStepHorizontal-isDisabled .euiStepHorizontal__title,
+.euiStep-isDisabled .euiStep__title {
+  color: $euiColorDisabledText;
+}
+
+// STEP NUMBER CHANGES
+
+.euiStepNumber {
+  outline-color: $euiColorPrimary;
+
+  .euiStepNumber__icon {
+    position: relative;
+    top: -1px;
+  }
+
+  &--small {
+    .euiStepNumber__icon {
+      top: -1px;
+    }
+  }
+
+  &--complete,
+  &--danger {
+    // Thicken the checkmark by adding a slight stroke.
+    .euiStepNumber__icon {
+      stroke: currentColor;
+      stroke-width: .5px;
+    }
+  }
+
+  // Create modifiers based upon the map
+  @each $name, $color in $euiStepStatusColors {
+    &--#{$name} {
+      background-color: $color;
+      color: chooseLightOrDarkText($color, $euiColorGhost, $euiColorInk);
+      outline-color: chooseLightOrDarkText($color, $color, $euiColorInk) !important; // sass-lint:disable-line no-important
+    }
+  }
+
+  &.euiStepNumber--incomplete {
+    background-color: transparent;
+    color: $euiTextColor;
+    border: $euiBorderThick;
+
+    // Don't hide the step number when "hollow"
+    .euiStepNumber__number {
+      display: unset;
+      position: relative;
+      top: -2px;
+    }
+  }
+}
+
+.euiStepNumber--disabled {
+  $backgroundColorSimulated: mix($euiPageBackgroundColor, $euiButtonColorDisabled, 90%);
+  background-color: transparentize($euiButtonColorDisabled, .9);
+  color: makeDisabledContrastColor($euiButtonColorDisabled, $backgroundColorSimulated);
+}
+
+.euiStepHorizontal__title {
+  font-weight: $euiFontWeightBold;
+}
+
+.euiStepHorizontal {
+  // create the connecting lines
+  &::before,
+  &::after {
+    @include makeLineProgress;
+    background-color: $euiBorderColor;
+  }
+}
+
+// Make the line connect to the numbers
+
+.euiStep {
+  &:not(:last-of-type) {
+    background-position: left $euiSizeXL;
+  }
+
+  &--small {
+    &:not(:last-of-type) {
+      background-position: -#{$euiSizeXS} $euiSizeL;
+    }
+  }
+}
+
+.euiStep__content {
+  padding-bottom: ($euiSizeXL + $euiSizeS);
+  margin-bottom: 0;
+}
+
+// Remove forced background from horizontal steps
+.euiStepsHorizontal {
+  background: none;
+}
+
+// Fix outline in Chrome for horizontal steps
+.euiStepHorizontal:focus:not(.euiStepHorizontal-isDisabled) .euiStepHorizontal__number:not(:focus-visible) {
+  outline: $euiFocusRingSize solid $euiColorPrimary;
+}
+/* End of Aliases */

--- a/src/themes/oui-cascadia/overrides/_tabs.scss
+++ b/src/themes/oui-cascadia/overrides/_tabs.scss
@@ -24,3 +24,19 @@
   @include fontSize($ouiTabFontSizeL);
   height: $ouiSizeXXL + $ouiSizeS;
 }
+
+/* OUI -> EUI Aliases */
+.euiTab {
+  font-weight: $euiFontWeightMedium;
+  height: $euiSizeXXL + $euiSizeS;
+}
+
+.euiTabs--small .euiTab {
+  height: $euiSizeXXL;
+}
+
+.euiTabs--large .euiTab {
+  @include fontSize($euiTabFontSizeL);
+  height: $euiSizeXXL + $euiSizeS;
+}
+/* End of Aliases */

--- a/src/themes/oui-cascadia/overrides/_text.scss
+++ b/src/themes/oui-cascadia/overrides/_text.scss
@@ -14,3 +14,10 @@
   @include fontSize($ouiFontSizeM);
   @include ouiScaleText($ouiFontSizeM);
 }
+
+/* OUI -> EUI Aliases */
+.euiText--medium {
+  @include fontSize($euiFontSizeM);
+  @include euiScaleText($euiFontSizeM);
+}
+/* End of Aliases */

--- a/src/themes/oui-cascadia/overrides/_toast.scss
+++ b/src/themes/oui-cascadia/overrides/_toast.scss
@@ -33,5 +33,25 @@ $ouiToastTypes: (
 
 
 /* OUI -> EUI Aliases */
-$euiToastTypes: $ouiToastTypes;
+.euiToast {
+  border: none;
+  border-radius: $euiBorderRadius;
+}
+
+$euiToastTypes: (
+  primary: $euiColorPrimary,
+  success: $euiColorSuccess,
+  warning: $euiColorWarning,
+  danger: $euiColorDanger
+);
+
+@each $name, $color in $euiToastTypes {
+  .euiToast--#{$name} {
+    border-top: 2px solid $color;
+  }
+}
+
+.euiToastHeader__title {
+  font-weight: $euiFontWeightBold;
+}
 /* End of Aliases */

--- a/src/themes/oui-cascadia/overrides/_tooltip.scss
+++ b/src/themes/oui-cascadia/overrides/_tooltip.scss
@@ -12,3 +12,9 @@
 .ouiToolTip {
   padding: $ouiSizeS;
 }
+
+/* OUI -> EUI Aliases */
+.euiToolTip {
+  padding: $euiSizeS;
+}
+/* End of Aliases */


### PR DESCRIPTION
To allow consumers to continue to use `eui*` with minimal changes
* Extended aliasing eui* within original paths
* Fix `TokensObject` duplication
* Re-export typedefs as `@elastic/eui`
* Duplicate named theme source files
* Fix mixin aliases with contents

Signed-off-by: Miki <miki@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
