### PR TITLE
Fix compile icon script to include license header

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -52,6 +52,7 @@ const OSD_HEADER = `
  * Modifications Copyright OpenSearch Contributors. See
  * GitHub history for details.
  */
+
 `;
 
 const APACHE_2_0_LICENSE_HEADER = `

--- a/scripts/compile-icons.js
+++ b/scripts/compile-icons.js
@@ -13,6 +13,9 @@ const glob = require('glob');
 const svgr = require('@svgr/core').default;
 const path = require('path');
 const fs = require('fs');
+const license = require('../.eslintrc.js').rules[
+  'local/require-license-header'
+][1].licenses[1];
 
 const rootDir = path.resolve(__dirname, '..');
 const srcDir = path.resolve(rootDir, 'src');
@@ -66,7 +69,7 @@ export const icon = ${componentName};
     );
 
     const outputFilePath = filePath.replace(/\.svg$/, '.js');
-    fs.writeFileSync(outputFilePath, jsxSource);
+    fs.writeFileSync(outputFilePath, license + jsxSource);
   } catch (e) {
     console.error(`Error processing ${filePath}`);
     console.error(e);


### PR DESCRIPTION
Signed-off-by: Bandini Bhopi <bandinib@amazon.com>

### Description
This PR updates the ```scripts/compile-icons``` script to include license header in the auto-generated compiled icon file. Scope of this fix is only limited to compiling existing icons. 


 
### Issues Resolved
#37  

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] All tests pass
  - [ ] `yarn lint`
  - [ ] `yarn test-unit`
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/oui/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
