### PR TITLE
Bump React 16.12.0 to 16.14.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -211,7 +211,7 @@
     "prop-types": "^15.6.0",
     "puppeteer": "^5.5.0",
     "raw-loader": "^4.0.1",
-    "react": "^16.12.0",
+    "react": "^16.14.0",
     "react-docgen-typescript": "^1.20.5",
     "react-dom": "^16.12.0",
     "react-helmet": "^6.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -13506,10 +13506,10 @@ react-window@^1.8.5:
     "@babel/runtime" "^7.0.0"
     memoize-one ">=3.1.1 <6"
 
-react@^16.12.0:
-  version "16.12.0"
-  resolved "https://registry.yarnpkg.com/react/-/react-16.12.0.tgz#0c0a9c6a142429e3614834d5a778e18aa78a0b83"
-  integrity sha512-fglqy3k5E+81pA8s+7K0/T3DBCF0ZDOher1elBFzF7O6arXJgzyu/FW+COxFvAWXJoJN9KIZbT2LXlukwphYTA==
+react@^16.14.0:
+  version "16.14.0"
+  resolved "https://registry.yarnpkg.com/react/-/react-16.14.0.tgz#94d776ddd0aaa37da3eda8fc5b6b18a4c9a3114d"
+  integrity sha512-0X2CImDkJGApiAlcf0ODKIneSwBPhqJawOa5wCtKbu7ZECrmS26NvtSILynQ66cgkT/RJ4LidJOc3bUESwmU8g==
   dependencies:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"


### PR DESCRIPTION
Signed-off-by: kaddy645 <xdeskart@amazon.com>

### Description
As a part of package Update issue, update React to match with OSD version
 
### Issues Resolved
[Issue](https://github.com/opensearch-project/oui/issues/56)
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [X] All tests pass
  - [X] `yarn lint`
  - [X] `yarn test-unit`
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/oui/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
