### PR TITLE
Remove beta badge accent color

### DIFF
--- a/src-docs/src/views/badge/beta_badge.js
+++ b/src-docs/src/views/badge/beta_badge.js
@@ -13,7 +13,7 @@ import React from 'react';
 
 import { OuiBetaBadge, OuiSpacer, OuiTitle } from '../../../../src/components';
 
-const colors = ['hollow', 'accent', 'subdued'];
+const colors = ['hollow', 'subdued'];
 
 export default () => (
   <div>

--- a/src/components/badge/beta_badge/__snapshots__/beta_badge.test.tsx.snap
+++ b/src/components/badge/beta_badge/__snapshots__/beta_badge.test.tsx.snap
@@ -11,15 +11,6 @@ exports[`OuiBetaBadge is rendered 1`] = `
 </span>
 `;
 
-exports[`OuiBetaBadge props color accent is rendered 1`] = `
-<span
-  class="ouiBetaBadge ouiBetaBadge--accent"
-  title="Beta"
->
-  Beta
-</span>
-`;
-
 exports[`OuiBetaBadge props color hollow is rendered 1`] = `
 <span
   class="ouiBetaBadge ouiBetaBadge--hollow"

--- a/src/components/badge/beta_badge/_beta_badge.scss
+++ b/src/components/badge/beta_badge/_beta_badge.scss
@@ -86,13 +86,3 @@
     color: chooseLightOrDarkText($backgroundColor, $ouiColorGhost, $ouiColorInk);
   }
 }
-
-.ouiBetaBadge--accent {
-  $backgroundColor: $ouiColorAccentText;
-  background: $backgroundColor;
-  color: chooseLightOrDarkText($backgroundColor, $ouiColorGhost, $ouiColorInk);
-
-  &.ouiBetaBadge-isClickable {
-    color: chooseLightOrDarkText($backgroundColor, $ouiColorGhost, $ouiColorInk);
-  }
-}

--- a/src/components/badge/beta_badge/beta_badge.tsx
+++ b/src/components/badge/beta_badge/beta_badge.tsx
@@ -46,7 +46,6 @@ import { OuiToolTip, ToolTipPositions } from '../../tool_tip';
 import { OuiIcon, IconType } from '../../icon';
 
 const colorToClassMap = {
-  accent: 'ouiBetaBadge--accent',
   subdued: 'ouiBetaBadge--subdued',
   hollow: 'ouiBetaBadge--hollow',
 };
@@ -134,7 +133,7 @@ type BadgeProps = {
    */
   title?: string;
   /**
-   * Accepts accent, subdued and hollow.
+   * Accepts subdued and hollow.
    */
   color?: BetaBadgeColor;
   size?: BetaBadgeSize;


### PR DESCRIPTION
### Description
Removes the `accent` color option for the beta badge, as per #93 
 
![2022-10-28 12_36_23-Badge - OpenSearch UI Framework](https://user-images.githubusercontent.com/6763209/198718366-896bdd16-e8db-45c9-ae97-12a104c06846.png)

### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [x] All tests pass
  - [x] `yarn lint`
  - [x] `yarn test-unit`
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/oui/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
