### PR TITLE
Fix carat height

### DIFF
--- a/src-docs/src/assets/version-selector.js
+++ b/src-docs/src/assets/version-selector.js
@@ -63,7 +63,7 @@ const tpl = `
     #root > svg {
         position: absolute;
         right: .5em;
-        top: .6em;
+        top: .3em;
     }
     
     #dropdown {


### PR DESCRIPTION
### Description
Fix the height of the carat for the version selector

![2022-11-03 13_45_36-Card - OpenSearch UI Framework](https://user-images.githubusercontent.com/6763209/199830548-878e98aa-dbd6-4ff7-ac8a-c8e72bd1e7a7.png)

### Issues Resolved
#105 
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] All tests pass
  - [ ] `yarn lint`
  - [ ] `yarn test-unit`
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/oui/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
