### PR TITLE
[OUI Docs] Doc site header clean up

### DIFF
--- a/src-docs/src/components/guide_page/guide_page_header.tsx
+++ b/src-docs/src/components/guide_page/guide_page_header.tsx
@@ -24,8 +24,6 @@ import { OuiPopover } from '../../../../src/components/popover';
 import { useIsWithinBreakpoints } from '../../../../src/services/hooks';
 import { OuiButtonEmpty } from '../../../../src/components/button';
 
-// @ts-ignore Not TS
-import { CodeSandboxLink } from '../../components/codesandbox/link';
 import logoOUI from '../../images/logo-oui.svg';
 import { GuideThemeSelector, GuideSketchLink } from '../guide_theme_selector';
 
@@ -88,25 +86,6 @@ export const GuidePageHeader: React.FunctionComponent<GuidePageHeaderProps> = ({
     );
   }
 
-  function renderCodeSandbox() {
-    const label = 'Codesandbox';
-    return isMobileSize ? (
-      <CodeSandboxLink key="codesandbox">
-        <OuiButtonEmpty size="s" flush="both" iconType="logoCodesandbox">
-          {label}
-        </OuiButtonEmpty>
-      </CodeSandboxLink>
-    ) : (
-      <OuiToolTip content="Codesandbox" key="codesandbox">
-        <CodeSandboxLink>
-          <OuiHeaderSectionItemButton aria-label="Codesandbox">
-            <OuiIcon type="logoCodesandbox" aria-hidden="true" />
-          </OuiHeaderSectionItemButton>
-        </CodeSandboxLink>
-      </OuiToolTip>
-    );
-  }
-
   const [mobilePopoverIsOpen, setMobilePopoverIsOpen] = useState(false);
 
   function renderMobileMenu() {
@@ -127,7 +106,6 @@ export const GuidePageHeader: React.FunctionComponent<GuidePageHeaderProps> = ({
         <div className="guideOptionsPopover">
           {renderGithub()}
           <GuideSketchLink />
-          {renderCodeSandbox()}
         </div>
       </OuiPopover>
     );
@@ -148,7 +126,6 @@ export const GuidePageHeader: React.FunctionComponent<GuidePageHeaderProps> = ({
         />,
         renderGithub(),
         <GuideSketchLink key="sketch" />,
-        renderCodeSandbox(),
       ];
 
   return (

--- a/src-docs/src/components/guide_page/guide_page_header.tsx
+++ b/src-docs/src/components/guide_page/guide_page_header.tsx
@@ -25,7 +25,7 @@ import { useIsWithinBreakpoints } from '../../../../src/services/hooks';
 import { OuiButtonEmpty } from '../../../../src/components/button';
 
 import logoOUI from '../../images/logo-oui.svg';
-import { GuideThemeSelector, GuideSketchLink } from '../guide_theme_selector';
+import { GuideThemeSelector } from '../guide_theme_selector';
 
 const pkg = require('../../../../package.json');
 
@@ -103,10 +103,7 @@ export const GuidePageHeader: React.FunctionComponent<GuidePageHeaderProps> = ({
         button={button}
         isOpen={mobilePopoverIsOpen}
         closePopover={() => setMobilePopoverIsOpen(false)}>
-        <div className="guideOptionsPopover">
-          {renderGithub()}
-          <GuideSketchLink />
-        </div>
+        <div className="guideOptionsPopover">{renderGithub()}</div>
       </OuiPopover>
     );
   }
@@ -125,7 +122,6 @@ export const GuidePageHeader: React.FunctionComponent<GuidePageHeaderProps> = ({
           selectedLocale={selectedLocale}
         />,
         renderGithub(),
-        <GuideSketchLink key="sketch" />,
       ];
 
   return (

--- a/src-docs/src/components/guide_page/guide_page_header.tsx
+++ b/src-docs/src/components/guide_page/guide_page_header.tsx
@@ -27,11 +27,7 @@ import { OuiButtonEmpty } from '../../../../src/components/button';
 // @ts-ignore Not TS
 import { CodeSandboxLink } from '../../components/codesandbox/link';
 import logoOUI from '../../images/logo-oui.svg';
-import {
-  GuideThemeSelector,
-  GuideSketchLink,
-  GuideFigmaLink,
-} from '../guide_theme_selector';
+import { GuideThemeSelector, GuideSketchLink } from '../guide_theme_selector';
 
 const pkg = require('../../../../package.json');
 
@@ -131,7 +127,6 @@ export const GuidePageHeader: React.FunctionComponent<GuidePageHeaderProps> = ({
         <div className="guideOptionsPopover">
           {renderGithub()}
           <GuideSketchLink />
-          <GuideFigmaLink />
           {renderCodeSandbox()}
         </div>
       </OuiPopover>
@@ -153,7 +148,6 @@ export const GuidePageHeader: React.FunctionComponent<GuidePageHeaderProps> = ({
         />,
         renderGithub(),
         <GuideSketchLink key="sketch" />,
-        <GuideFigmaLink key="figma" />,
         renderCodeSandbox(),
       ];
 

--- a/src-docs/src/components/guide_theme_selector/guide_theme_selector.tsx
+++ b/src-docs/src/components/guide_theme_selector/guide_theme_selector.tsx
@@ -18,13 +18,10 @@ import {
   OuiContextMenuItem,
 } from '../../../../src/components/context_menu';
 import { OuiPopover } from '../../../../src/components/popover';
-import { OuiHorizontalRule } from '../../../../src/components/horizontal_rule';
 import { useIsWithinBreakpoints } from '../../../../src/services/hooks/useIsWithinBreakpoints';
 import { OUI_THEME, OUI_THEMES } from '../../../../src/themes';
 
 import { ThemeContext } from '../with_theme';
-// @ts-ignore Not TS
-import { GuideLocaleSelector } from '../guide_locale_selector';
 
 type GuideThemeSelectorProps = {
   onToggleLocale: () => {};
@@ -45,8 +42,6 @@ export const GuideThemeSelector: React.FunctionComponent<GuideThemeSelectorProps
 // @ts-ignore Context has no type
 const GuideThemeSelectorComponent: React.FunctionComponent<GuideThemeSelectorProps> = ({
   context,
-  onToggleLocale,
-  selectedLocale,
 }) => {
   const isMobileSize = useIsWithinBreakpoints(['xs', 's']);
   const [isPopoverOpen, setPopover] = useState(false);
@@ -102,17 +97,6 @@ const GuideThemeSelectorComponent: React.FunctionComponent<GuideThemeSelectorPro
       panelPaddingSize="none"
       anchorPosition="downRight">
       <OuiContextMenuPanel size="s" items={items} />
-      {location.host.includes('803') && (
-        <>
-          <OuiHorizontalRule margin="none" />
-          <div style={{ padding: 8 }}>
-            <GuideLocaleSelector
-              onToggleLocale={onToggleLocale}
-              selectedLocale={selectedLocale}
-            />
-          </div>
-        </>
-      )}
     </OuiPopover>
   );
 };

--- a/src-docs/src/views/card/playground.js
+++ b/src-docs/src/views/card/playground.js
@@ -49,7 +49,7 @@ export const cardConfig = () => {
   propsToUse.icon = {
     ...propsToUse.icon,
     type: PropTypes.ReactNode,
-    value: '<OuiIcon type="logoElastic" size="xl" />',
+    value: '<OuiIcon type="logoOUI" size="xl" />',
   };
 
   propsToUse.children = {

--- a/src-docs/src/views/collapsible_nav/collapsible_nav_all.tsx
+++ b/src-docs/src/views/collapsible_nav/collapsible_nav_all.tsx
@@ -260,7 +260,7 @@ const CollapsibleNavAll = () => {
 
   const leftSectionItems = [
     collapsibleNav,
-    <OuiHeaderLogo href={exitPath} iconType="logoElastic">
+    <OuiHeaderLogo href={exitPath} iconType="logoOUI">
       Elastic
     </OuiHeaderLogo>,
   ];

--- a/src-docs/src/views/collapsible_nav/collapsible_nav_group.tsx
+++ b/src-docs/src/views/collapsible_nav/collapsible_nav_group.tsx
@@ -25,7 +25,7 @@ export default () => (
     <OuiCollapsibleNavGroup
       data-test-subj="TEST"
       title="Nav group"
-      iconType="logoElastic">
+      iconType="logoOUI">
       <OuiText size="s" color="subdued">
         <p>
           This is a nice group with a heading supplied via{' '}
@@ -38,7 +38,7 @@ export default () => (
       background="light"
       title="Nav group"
       isCollapsible={true}
-      iconType="logoElastic"
+      iconType="logoOUI"
       initialIsOpen={true}>
       <OuiText size="s" color="subdued">
         <p>

--- a/src-docs/src/views/header/header.js
+++ b/src-docs/src/views/header/header.js
@@ -41,7 +41,7 @@ import { htmlIdGenerator } from '../../../../src/services';
 export default () => {
   const renderLogo = () => (
     <OuiHeaderLogo
-      iconType="logoElastic"
+      iconType="logoOUI"
       href="#"
       onClick={(e) => e.preventDefault()}
       aria-label="Go to home page"

--- a/src-docs/src/views/header/header_elastic_pattern.js
+++ b/src-docs/src/views/header/header_elastic_pattern.js
@@ -283,7 +283,7 @@ export default ({ theme }) => {
         sections={[
           {
             items: [
-              <OuiHeaderLogo iconType="logoElastic" href="">
+              <OuiHeaderLogo iconType="logoOUI" href="">
                 Elastic
               </OuiHeaderLogo>,
               deploymentMenu,

--- a/src-docs/src/views/header/header_sections.js
+++ b/src-docs/src/views/header/header_sections.js
@@ -27,7 +27,7 @@ import {
 export default () => {
   const renderLogo = (
     <OuiHeaderLogo
-      iconType="logoElastic"
+      iconType="logoOUI"
       href="#"
       onClick={(e) => e.preventDefault()}
       aria-label="Go to home page"

--- a/src-docs/src/views/header/header_stacked.js
+++ b/src-docs/src/views/header/header_stacked.js
@@ -52,9 +52,7 @@ export default () => {
         position={isFixed ? 'fixed' : 'static'}
         sections={[
           {
-            items: [
-              <OuiHeaderLogo iconType="logoElastic">Elastic</OuiHeaderLogo>,
-            ],
+            items: [<OuiHeaderLogo iconType="logoOUI">Elastic</OuiHeaderLogo>],
             borders: 'none',
           },
           {

--- a/src-docs/src/views/icon/logos.js
+++ b/src-docs/src/views/icon/logos.js
@@ -28,7 +28,7 @@ export const iconTypes = [
   'logoCode',
   'logoCloud',
   'logoCloudEnterprise',
-  'logoElastic',
+  'logoOUI',
   'logoElasticStack',
   'logoElasticsearch',
   'logoEnterpriseSearch',

--- a/src-docs/src/views/notification_event/notification_event_flexible.js
+++ b/src-docs/src/views/notification_event/notification_event_flexible.js
@@ -51,7 +51,7 @@ const notificationEventsData = [
   {
     id: 'news',
     type: 'News',
-    iconType: 'logoElastic',
+    iconType: 'logoOUI',
     iconAriaLabel: 'Elastic',
     time: '3 min ago',
     badgeColor: 'accent',

--- a/src-docs/src/views/notification_event/notification_event_props_methods.js
+++ b/src-docs/src/views/notification_event/notification_event_props_methods.js
@@ -39,7 +39,7 @@ export default () => {
           <div className="guideDemo__notificationEventHighlight">
             <CircleIndicator name="B" />
             <OuiIcon
-              type="logoElastic"
+              type="logoOUI"
               className="guideDemo__notificationEventIcon"
             />
           </div>

--- a/src-docs/src/views/notification_event/notifications_feed.js
+++ b/src-docs/src/views/notification_event/notifications_feed.js
@@ -52,7 +52,7 @@ const notificationEventsData = [
   {
     id: 'news-01',
     type: 'News',
-    iconType: 'logoElastic',
+    iconType: 'logoOUI',
     iconAriaLabel: 'Elastic',
     time: '6 min ago',
     badgeColor: 'accent',

--- a/src-docs/src/views/page/page.js
+++ b/src-docs/src/views/page/page.js
@@ -28,7 +28,7 @@ export default () => (
     <OuiPageSideBar>SideBar nav</OuiPageSideBar>
     <OuiPageBody>
       <OuiPageHeader
-        iconType="logoElastic"
+        iconType="logoOUI"
         pageTitle="Page title"
         rightSideItems={[
           <OuiButton fill>Add something</OuiButton>,

--- a/src-docs/src/views/page/page_bottom_bar.js
+++ b/src-docs/src/views/page/page_bottom_bar.js
@@ -34,7 +34,7 @@ export default ({ button = <></>, content, sideNav, bottomBar }) => {
           <OuiPageHeader
             bottomBorder
             restrictWidth
-            iconType="logoElastic"
+            iconType="logoOUI"
             pageTitle="Page title"
             rightSideItems={[button]}
           />

--- a/src-docs/src/views/page/page_bottom_bar_template.js
+++ b/src-docs/src/views/page/page_bottom_bar_template.js
@@ -18,7 +18,7 @@ export default ({ button = <></>, content, sideNav, bottomBar }) => {
     <OuiPageTemplate
       pageSideBar={sideNav}
       pageHeader={{
-        iconType: 'logoElastic',
+        iconType: 'logoOUI',
         pageTitle: 'Page title',
         rightSideItems: [button],
       }}

--- a/src-docs/src/views/page/page_centered_content.js
+++ b/src-docs/src/views/page/page_centered_content.js
@@ -29,7 +29,7 @@ export default ({ button = <></>, content, sideNav }) => (
     <OuiPageBody panelled>
       <OuiPageHeader
         restrictWidth
-        iconType="logoElastic"
+        iconType="logoOUI"
         pageTitle="Page title"
         rightSideItems={[button]}
       />

--- a/src-docs/src/views/page/page_centered_content_template.js
+++ b/src-docs/src/views/page/page_centered_content_template.js
@@ -19,7 +19,7 @@ export default ({ button = <></>, content, sideNav }) => (
     pageContentProps={{ paddingSize: 'none' }}
     pageSideBar={sideNav}
     pageHeader={{
-      iconType: 'logoElastic',
+      iconType: 'logoOUI',
       pageTitle: 'Page title',
       rightSideItems: [button],
     }}>

--- a/src-docs/src/views/page/page_custom_content.js
+++ b/src-docs/src/views/page/page_custom_content.js
@@ -26,7 +26,7 @@ export default ({ button = <></> }) => (
   <OuiPage paddingSize="l">
     <OuiPageBody>
       <OuiPageHeader
-        iconType="logoElastic"
+        iconType="logoOUI"
         pageTitle="Page title"
         rightSideItems={[button, <OuiButton>Do something</OuiButton>]}
         bottomBorder

--- a/src-docs/src/views/page/page_custom_content_template.js
+++ b/src-docs/src/views/page/page_custom_content_template.js
@@ -24,7 +24,7 @@ export default ({ button = <></> }) => (
     restrictWidth={false}
     template="empty"
     pageHeader={{
-      iconType: 'logoElastic',
+      iconType: 'logoOUI',
       pageTitle: 'Page title',
       rightSideItems: [button, <OuiButton>Do something</OuiButton>],
     }}>

--- a/src-docs/src/views/page/page_new.js
+++ b/src-docs/src/views/page/page_new.js
@@ -29,7 +29,7 @@ export default ({ button = <></>, content, sideNav }) => (
     <OuiPageBody panelled>
       <OuiPageHeader
         restrictWidth
-        iconType="logoElastic"
+        iconType="logoOUI"
         pageTitle="Page title"
         rightSideItems={[button]}
         tabs={[{ label: 'Tab 1', isSelected: true }, { label: 'Tab 2' }]}

--- a/src-docs/src/views/page/page_restricting_width.js
+++ b/src-docs/src/views/page/page_restricting_width.js
@@ -30,7 +30,7 @@ export default ({ button = <></>, content, sideNav }) => {
       <OuiPageBody panelled>
         <OuiPageHeader
           restrictWidth={'75%'}
-          iconType="logoElastic"
+          iconType="logoOUI"
           pageTitle="Page title"
           rightSideItems={[button]}
           description="Restricting the width to 75%."

--- a/src-docs/src/views/page/page_restricting_width_template.js
+++ b/src-docs/src/views/page/page_restricting_width_template.js
@@ -19,7 +19,7 @@ export default ({ button = <></>, content, sideNav }) => {
       pageSideBar={sideNav}
       restrictWidth="75%"
       pageHeader={{
-        iconType: 'logoElastic',
+        iconType: 'logoOUI',
         pageTitle: 'Page title',
         rightSideItems: [button],
         description: 'Restricting the width to 75%.',

--- a/src-docs/src/views/page/page_simple_empty_content.js
+++ b/src-docs/src/views/page/page_simple_empty_content.js
@@ -24,7 +24,7 @@ export default ({ button = <></>, content }) => (
     <OuiPageBody>
       <OuiPageHeader
         restrictWidth
-        iconType="logoElastic"
+        iconType="logoOUI"
         pageTitle="Page title"
         rightSideItems={[button]}
         paddingSize="l"

--- a/src-docs/src/views/page/page_simple_empty_content_template.js
+++ b/src-docs/src/views/page/page_simple_empty_content_template.js
@@ -18,7 +18,7 @@ export default ({ button = <></>, content }) => (
     template="centeredContent"
     pageContentProps={{ paddingSize: 'none' }}
     pageHeader={{
-      iconType: 'logoElastic',
+      iconType: 'logoOUI',
       pageTitle: 'Page title',
       rightSideItems: [button],
     }}>

--- a/src-docs/src/views/page/page_template.js
+++ b/src-docs/src/views/page/page_template.js
@@ -21,7 +21,7 @@ export default ({ button = <></>, content, sideNav }) => {
       pageSideBar={sideNav}
       bottomBar={showBottomBar ? 'Bottom bar' : undefined}
       pageHeader={{
-        iconType: 'logoElastic',
+        iconType: 'logoOUI',
         pageTitle: 'Page title',
         rightSideItems: [button],
         tabs: [

--- a/src-docs/src/views/tables/actions/actions.js
+++ b/src-docs/src/views/tables/actions/actions.js
@@ -183,7 +183,7 @@ export const Table = () => {
           {
             name: 'Elastic.co',
             description: 'Go to elastic.co',
-            icon: 'logoElastic',
+            icon: 'logoOUI',
             type: 'icon',
             href: 'https://elastic.co',
             target: '_blank',

--- a/src/components/header/__snapshots__/header_logo.test.tsx.snap
+++ b/src/components/header/__snapshots__/header_logo.test.tsx.snap
@@ -10,7 +10,7 @@ exports[`OuiHeaderLogo is rendered 1`] = `
   <span
     aria-label="Elastic"
     class="ouiHeaderLogo__icon"
-    data-ouiicon-type="logoElastic"
+    data-ouiicon-type="logoOUI"
   />
 </a>
 `;
@@ -24,7 +24,7 @@ exports[`OuiHeaderLogo renders href 1`] = `
   <span
     aria-label="Elastic"
     class="ouiHeaderLogo__icon"
-    data-ouiicon-type="logoElastic"
+    data-ouiicon-type="logoOUI"
   />
 </a>
 `;
@@ -38,7 +38,7 @@ exports[`OuiHeaderLogo renders href with rel 1`] = `
   <span
     aria-label="Elastic"
     class="ouiHeaderLogo__icon"
-    data-ouiicon-type="logoElastic"
+    data-ouiicon-type="logoOUI"
   />
 </a>
 `;

--- a/src/components/header/header_logo.tsx
+++ b/src/components/header/header_logo.tsx
@@ -54,7 +54,7 @@ export type OuiHeaderLogoProps = CommonProps &
   };
 
 export const OuiHeaderLogo: FunctionComponent<OuiHeaderLogoProps> = ({
-  iconType = 'logoElastic',
+  iconType = 'logoOUI',
   iconTitle = 'Elastic',
   href,
   rel,

--- a/src/components/icon/__snapshots__/icon.test.tsx.snap
+++ b/src/components/icon/__snapshots__/icon.test.tsx.snap
@@ -4274,7 +4274,7 @@ exports[`OuiIcon props type logoDropwizard is rendered 1`] = `
 </svg>
 `;
 
-exports[`OuiIcon props type logoElastic is rendered 1`] = `
+exports[`OuiIcon props type logoOUI is rendered 1`] = `
 <svg
   aria-hidden="true"
   class="ouiIcon ouiIcon--medium ouiIcon-isLoaded"

--- a/src/components/icon/icon.tsx
+++ b/src/components/icon/icon.tsx
@@ -237,7 +237,7 @@ const typeToPathMap = {
   logoCouchbase: 'logo_couchbase',
   logoDocker: 'logo_docker',
   logoDropwizard: 'logo_dropwizard',
-  logoElastic: 'logo_elastic',
+  logoOUI: 'logo_oui',
   logoElasticsearch: 'logo_elasticsearch',
   logoElasticStack: 'logo_elastic_stack',
   logoEnterpriseSearch: 'logo_enterprise_search',

--- a/src/components/loading/__snapshots__/loading_logo.test.tsx.snap
+++ b/src/components/loading/__snapshots__/loading_logo.test.tsx.snap
@@ -26,7 +26,7 @@ exports[`OuiLoadingLogo logo is rendered 1`] = `
     class="ouiLoadingLogo__icon"
   >
     <span
-      data-ouiicon-type="logoElastic"
+      data-ouiicon-type="logoOUI"
     />
   </span>
 </span>

--- a/src/components/loading/loading_elastic.tsx
+++ b/src/components/loading/loading_elastic.tsx
@@ -57,7 +57,7 @@ export const OuiLoadingElastic: FunctionComponent<
 
   return (
     <span className={classes} {...rest}>
-      <OuiIcon type="logoElastic" size={size} />
+      <OuiIcon type="logoOUI" size={size} />
     </span>
   );
 };

--- a/src/components/loading/loading_logo.test.tsx
+++ b/src/components/loading/loading_logo.test.tsx
@@ -43,7 +43,7 @@ describe('OuiLoadingLogo', () => {
 
   test('logo is rendered', () => {
     const component = render(
-      <OuiLoadingLogo logo="logoElastic" {...requiredProps} />
+      <OuiLoadingLogo logo="logoOUI" {...requiredProps} />
     );
 
     expect(component).toMatchSnapshot();

--- a/src/themes/themes.ts
+++ b/src/themes/themes.ts
@@ -42,14 +42,6 @@ export const OUI_THEMES: OUI_THEME[] = [
     text: 'Dark',
     value: 'dark',
   },
-  {
-    text: 'Cascadia: Light',
-    value: 'cascadia-light',
-  },
-  {
-    text: 'Cascadia: Dark',
-    value: 'cascadia-dark',
-  },
 ];
 
 /* OUI -> EUI Aliases */


### PR DESCRIPTION
### Description
1. Removed Figma, Codesandbox, Sketch link and icon. 
2. Removed Cascadia options and Babelfish from theme dropdown.
3.  Changed logoElastic to logoOUI.
 
### Issues Resolved
https://github.com/opensearch-project/oui/issues/111

### Screenshots

**Header Changes**

*Before:*

<img width="1536" alt="Screen Shot 2022-11-11 at 5 14 41 PM" src="https://user-images.githubusercontent.com/63824432/201449579-a7ce660a-04da-4f2a-82aa-5b78f88e122f.png">

*After:*
<img width="1534" alt="Screen Shot 2022-11-11 at 5 14 59 PM" src="https://user-images.githubusercontent.com/63824432/201449592-1ff2cb62-d7bd-4be2-af9f-4ff5e8699526.png">

**Changed logoElastic to logoOUI**

*Before:*

<img width="1298" alt="Screen Shot 2022-11-11 at 5 18 45 PM" src="https://user-images.githubusercontent.com/63824432/201449736-bb646340-0806-47db-9445-f685681615be.png">

*After:*

<img width="1294" alt="Screen Shot 2022-11-11 at 5 18 58 PM" src="https://user-images.githubusercontent.com/63824432/201449749-93442aa6-4d7c-4ded-b922-ec06485e1657.png">

The blank image is because of a reference to a broken image. @KrooshalUX will commit logo change which will resolve this. Also one UT is failing because of this reference to a broken image. This should also resolve.

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] All tests pass
  - [X] `yarn lint`
  - [ ] `yarn test-unit`
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/oui/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
