### PR TITLE
Update breadcrumbs to new styling

### DIFF
--- a/src/components/breadcrumbs/__snapshots__/breadcrumbs.test.tsx.snap
+++ b/src/components/breadcrumbs/__snapshots__/breadcrumbs.test.tsx.snap
@@ -29,7 +29,7 @@ exports[`OuiBreadcrumbs is rendered 1`] = `
     </span>
   </span>
   <div
-    class="ouiBreadcrumbWrapper"
+    class="ouiBreadcrumbWrapper ouiBreadcrumbWrapper--collapsed"
   >
     <div
       class="ouiPopover ouiPopover--anchorDownCenter ouiBreadcrumb ouiBreadcrumb--collapsed"
@@ -62,7 +62,7 @@ exports[`OuiBreadcrumbs is rendered 1`] = `
     </button>
   </span>
   <span
-    class="ouiBreadcrumbWrapper"
+    class="ouiBreadcrumbWrapper ouiBreadcrumbWrapper--truncate"
   >
     <a
       class="ouiLink ouiLink--subdued ouiBreadcrumb ouiBreadcrumb--truncate"
@@ -123,7 +123,7 @@ exports[`OuiBreadcrumbs props max doesn't break when max exceeds the number of b
     </span>
   </span>
   <span
-    class="ouiBreadcrumbWrapper"
+    class="ouiBreadcrumbWrapper ouiBreadcrumbWrapper--truncate"
   >
     <span
       aria-current="false"
@@ -153,7 +153,7 @@ exports[`OuiBreadcrumbs props max doesn't break when max exceeds the number of b
     </button>
   </span>
   <span
-    class="ouiBreadcrumbWrapper"
+    class="ouiBreadcrumbWrapper ouiBreadcrumbWrapper--truncate"
   >
     <a
       class="ouiLink ouiLink--subdued ouiBreadcrumb ouiBreadcrumb--truncate"
@@ -182,7 +182,7 @@ exports[`OuiBreadcrumbs props max renders 1 item 1`] = `
   class="ouiBreadcrumbs ouiBreadcrumbs--truncate"
 >
   <div
-    class="ouiBreadcrumbWrapper"
+    class="ouiBreadcrumbWrapper ouiBreadcrumbWrapper--collapsed"
   >
     <div
       class="ouiPopover ouiPopover--anchorDownCenter ouiBreadcrumb ouiBreadcrumb--collapsed"
@@ -255,7 +255,7 @@ exports[`OuiBreadcrumbs props max renders all items with null 1`] = `
     </span>
   </span>
   <span
-    class="ouiBreadcrumbWrapper"
+    class="ouiBreadcrumbWrapper ouiBreadcrumbWrapper--truncate"
   >
     <span
       aria-current="false"
@@ -285,7 +285,7 @@ exports[`OuiBreadcrumbs props max renders all items with null 1`] = `
     </button>
   </span>
   <span
-    class="ouiBreadcrumbWrapper"
+    class="ouiBreadcrumbWrapper ouiBreadcrumbWrapper--truncate"
   >
     <a
       class="ouiLink ouiLink--subdued ouiBreadcrumb ouiBreadcrumb--truncate"
@@ -336,7 +336,7 @@ exports[`OuiBreadcrumbs props responsive is rendered 1`] = `
     </span>
   </span>
   <div
-    class="ouiBreadcrumbWrapper"
+    class="ouiBreadcrumbWrapper ouiBreadcrumbWrapper--collapsed"
   >
     <div
       class="ouiPopover ouiPopover--anchorDownCenter ouiBreadcrumb ouiBreadcrumb--collapsed"
@@ -369,7 +369,7 @@ exports[`OuiBreadcrumbs props responsive is rendered 1`] = `
     </button>
   </span>
   <span
-    class="ouiBreadcrumbWrapper"
+    class="ouiBreadcrumbWrapper ouiBreadcrumbWrapper--truncate"
   >
     <a
       class="ouiLink ouiLink--subdued ouiBreadcrumb ouiBreadcrumb--truncate"
@@ -420,7 +420,7 @@ exports[`OuiBreadcrumbs props responsive is rendered as false 1`] = `
     </span>
   </span>
   <div
-    class="ouiBreadcrumbWrapper"
+    class="ouiBreadcrumbWrapper ouiBreadcrumbWrapper--collapsed"
   >
     <div
       class="ouiPopover ouiPopover--anchorDownCenter ouiBreadcrumb ouiBreadcrumb--collapsed"
@@ -453,7 +453,7 @@ exports[`OuiBreadcrumbs props responsive is rendered as false 1`] = `
     </button>
   </span>
   <span
-    class="ouiBreadcrumbWrapper"
+    class="ouiBreadcrumbWrapper ouiBreadcrumbWrapper--truncate"
   >
     <a
       class="ouiLink ouiLink--subdued ouiBreadcrumb ouiBreadcrumb--truncate"
@@ -482,7 +482,7 @@ exports[`OuiBreadcrumbs props responsive is rendered with custom breakpoints 1`]
   class="ouiBreadcrumbs ouiBreadcrumbs--truncate"
 >
   <div
-    class="ouiBreadcrumbWrapper"
+    class="ouiBreadcrumbWrapper ouiBreadcrumbWrapper--collapsed"
   >
     <div
       class="ouiPopover ouiPopover--anchorDownCenter ouiBreadcrumb ouiBreadcrumb--collapsed"
@@ -545,7 +545,7 @@ exports[`OuiBreadcrumbs props truncate as false is rendered 1`] = `
     </span>
   </span>
   <div
-    class="ouiBreadcrumbWrapper"
+    class="ouiBreadcrumbWrapper ouiBreadcrumbWrapper--collapsed"
   >
     <div
       class="ouiPopover ouiPopover--anchorDownCenter ouiBreadcrumb ouiBreadcrumb--collapsed"
@@ -578,7 +578,7 @@ exports[`OuiBreadcrumbs props truncate as false is rendered 1`] = `
     </button>
   </span>
   <span
-    class="ouiBreadcrumbWrapper"
+    class="ouiBreadcrumbWrapper ouiBreadcrumbWrapper--truncate"
   >
     <a
       class="ouiLink ouiLink--subdued ouiBreadcrumb ouiBreadcrumb--truncate"

--- a/src/components/breadcrumbs/__snapshots__/breadcrumbs.test.tsx.snap
+++ b/src/components/breadcrumbs/__snapshots__/breadcrumbs.test.tsx.snap
@@ -14,18 +14,12 @@ exports[`OuiBreadcrumbs is rendered 1`] = `
   >
     Animals
   </a>
-  <div
-    class="ouiBreadcrumbSeparator"
-  />
   <span
     aria-current="false"
     class="ouiBreadcrumb"
   >
     Metazoans
   </span>
-  <div
-    class="ouiBreadcrumbSeparator"
-  />
   <div
     class="ouiPopover ouiPopover--anchorDownCenter ouiBreadcrumb ouiBreadcrumb--collapsed"
   >
@@ -45,18 +39,12 @@ exports[`OuiBreadcrumbs is rendered 1`] = `
       </button>
     </div>
   </div>
-  <div
-    class="ouiBreadcrumbSeparator"
-  />
   <button
     class="ouiLink ouiLink--subdued ouiBreadcrumb"
     type="button"
   >
     Reptiles
   </button>
-  <div
-    class="ouiBreadcrumbSeparator"
-  />
   <a
     class="ouiLink ouiLink--subdued ouiBreadcrumb ouiBreadcrumb--truncate"
     href="#"
@@ -64,9 +52,6 @@ exports[`OuiBreadcrumbs is rendered 1`] = `
   >
     Boa constrictor
   </a>
-  <div
-    class="ouiBreadcrumbSeparator"
-  />
   <span
     aria-current="page"
     class="ouiBreadcrumb ouiBreadcrumb--last"
@@ -89,54 +74,36 @@ exports[`OuiBreadcrumbs props max doesn't break when max exceeds the number of b
   >
     Animals
   </a>
-  <div
-    class="ouiBreadcrumbSeparator"
-  />
   <span
     aria-current="false"
     class="ouiBreadcrumb"
   >
     Metazoans
   </span>
-  <div
-    class="ouiBreadcrumbSeparator"
-  />
   <span
     aria-current="false"
     class="ouiBreadcrumb"
   >
     Chordates
   </span>
-  <div
-    class="ouiBreadcrumbSeparator"
-  />
   <span
     aria-current="false"
     class="ouiBreadcrumb ouiBreadcrumb--truncate"
   >
     Nebulosa subspecies is also a real mouthful, especially for creatures without mouths
   </span>
-  <div
-    class="ouiBreadcrumbSeparator"
-  />
   <span
     aria-current="false"
     class="ouiBreadcrumb"
   >
     Tetrapods
   </span>
-  <div
-    class="ouiBreadcrumbSeparator"
-  />
   <button
     class="ouiLink ouiLink--subdued ouiBreadcrumb"
     type="button"
   >
     Reptiles
   </button>
-  <div
-    class="ouiBreadcrumbSeparator"
-  />
   <a
     class="ouiLink ouiLink--subdued ouiBreadcrumb ouiBreadcrumb--truncate"
     href="#"
@@ -144,9 +111,6 @@ exports[`OuiBreadcrumbs props max doesn't break when max exceeds the number of b
   >
     Boa constrictor
   </a>
-  <div
-    class="ouiBreadcrumbSeparator"
-  />
   <span
     aria-current="page"
     class="ouiBreadcrumb ouiBreadcrumb--last"
@@ -180,9 +144,6 @@ exports[`OuiBreadcrumbs props max renders 1 item 1`] = `
       </button>
     </div>
   </div>
-  <div
-    class="ouiBreadcrumbSeparator"
-  />
   <span
     aria-current="page"
     class="ouiBreadcrumb ouiBreadcrumb--last"
@@ -205,54 +166,36 @@ exports[`OuiBreadcrumbs props max renders all items with null 1`] = `
   >
     Animals
   </a>
-  <div
-    class="ouiBreadcrumbSeparator"
-  />
   <span
     aria-current="false"
     class="ouiBreadcrumb"
   >
     Metazoans
   </span>
-  <div
-    class="ouiBreadcrumbSeparator"
-  />
   <span
     aria-current="false"
     class="ouiBreadcrumb"
   >
     Chordates
   </span>
-  <div
-    class="ouiBreadcrumbSeparator"
-  />
   <span
     aria-current="false"
     class="ouiBreadcrumb ouiBreadcrumb--truncate"
   >
     Nebulosa subspecies is also a real mouthful, especially for creatures without mouths
   </span>
-  <div
-    class="ouiBreadcrumbSeparator"
-  />
   <span
     aria-current="false"
     class="ouiBreadcrumb"
   >
     Tetrapods
   </span>
-  <div
-    class="ouiBreadcrumbSeparator"
-  />
   <button
     class="ouiLink ouiLink--subdued ouiBreadcrumb"
     type="button"
   >
     Reptiles
   </button>
-  <div
-    class="ouiBreadcrumbSeparator"
-  />
   <a
     class="ouiLink ouiLink--subdued ouiBreadcrumb ouiBreadcrumb--truncate"
     href="#"
@@ -260,9 +203,6 @@ exports[`OuiBreadcrumbs props max renders all items with null 1`] = `
   >
     Boa constrictor
   </a>
-  <div
-    class="ouiBreadcrumbSeparator"
-  />
   <span
     aria-current="page"
     class="ouiBreadcrumb ouiBreadcrumb--last"
@@ -285,18 +225,12 @@ exports[`OuiBreadcrumbs props responsive is rendered 1`] = `
   >
     Animals
   </a>
-  <div
-    class="ouiBreadcrumbSeparator"
-  />
   <span
     aria-current="false"
     class="ouiBreadcrumb"
   >
     Metazoans
   </span>
-  <div
-    class="ouiBreadcrumbSeparator"
-  />
   <div
     class="ouiPopover ouiPopover--anchorDownCenter ouiBreadcrumb ouiBreadcrumb--collapsed"
   >
@@ -316,18 +250,12 @@ exports[`OuiBreadcrumbs props responsive is rendered 1`] = `
       </button>
     </div>
   </div>
-  <div
-    class="ouiBreadcrumbSeparator"
-  />
   <button
     class="ouiLink ouiLink--subdued ouiBreadcrumb"
     type="button"
   >
     Reptiles
   </button>
-  <div
-    class="ouiBreadcrumbSeparator"
-  />
   <a
     class="ouiLink ouiLink--subdued ouiBreadcrumb ouiBreadcrumb--truncate"
     href="#"
@@ -335,9 +263,6 @@ exports[`OuiBreadcrumbs props responsive is rendered 1`] = `
   >
     Boa constrictor
   </a>
-  <div
-    class="ouiBreadcrumbSeparator"
-  />
   <span
     aria-current="page"
     class="ouiBreadcrumb ouiBreadcrumb--last"
@@ -360,18 +285,12 @@ exports[`OuiBreadcrumbs props responsive is rendered as false 1`] = `
   >
     Animals
   </a>
-  <div
-    class="ouiBreadcrumbSeparator"
-  />
   <span
     aria-current="false"
     class="ouiBreadcrumb"
   >
     Metazoans
   </span>
-  <div
-    class="ouiBreadcrumbSeparator"
-  />
   <div
     class="ouiPopover ouiPopover--anchorDownCenter ouiBreadcrumb ouiBreadcrumb--collapsed"
   >
@@ -391,18 +310,12 @@ exports[`OuiBreadcrumbs props responsive is rendered as false 1`] = `
       </button>
     </div>
   </div>
-  <div
-    class="ouiBreadcrumbSeparator"
-  />
   <button
     class="ouiLink ouiLink--subdued ouiBreadcrumb"
     type="button"
   >
     Reptiles
   </button>
-  <div
-    class="ouiBreadcrumbSeparator"
-  />
   <a
     class="ouiLink ouiLink--subdued ouiBreadcrumb ouiBreadcrumb--truncate"
     href="#"
@@ -410,9 +323,6 @@ exports[`OuiBreadcrumbs props responsive is rendered as false 1`] = `
   >
     Boa constrictor
   </a>
-  <div
-    class="ouiBreadcrumbSeparator"
-  />
   <span
     aria-current="page"
     class="ouiBreadcrumb ouiBreadcrumb--last"
@@ -446,9 +356,6 @@ exports[`OuiBreadcrumbs props responsive is rendered with custom breakpoints 1`]
       </button>
     </div>
   </div>
-  <div
-    class="ouiBreadcrumbSeparator"
-  />
   <span
     aria-current="page"
     class="ouiBreadcrumb ouiBreadcrumb--last"
@@ -471,18 +378,12 @@ exports[`OuiBreadcrumbs props truncate as false is rendered 1`] = `
   >
     Animals
   </a>
-  <div
-    class="ouiBreadcrumbSeparator"
-  />
   <span
     aria-current="false"
     class="ouiBreadcrumb"
   >
     Metazoans
   </span>
-  <div
-    class="ouiBreadcrumbSeparator"
-  />
   <div
     class="ouiPopover ouiPopover--anchorDownCenter ouiBreadcrumb ouiBreadcrumb--collapsed"
   >
@@ -502,18 +403,12 @@ exports[`OuiBreadcrumbs props truncate as false is rendered 1`] = `
       </button>
     </div>
   </div>
-  <div
-    class="ouiBreadcrumbSeparator"
-  />
   <button
     class="ouiLink ouiLink--subdued ouiBreadcrumb"
     type="button"
   >
     Reptiles
   </button>
-  <div
-    class="ouiBreadcrumbSeparator"
-  />
   <a
     class="ouiLink ouiLink--subdued ouiBreadcrumb ouiBreadcrumb--truncate"
     href="#"
@@ -521,9 +416,6 @@ exports[`OuiBreadcrumbs props truncate as false is rendered 1`] = `
   >
     Boa constrictor
   </a>
-  <div
-    class="ouiBreadcrumbSeparator"
-  />
   <span
     aria-current="page"
     class="ouiBreadcrumb ouiBreadcrumb--last"

--- a/src/components/breadcrumbs/__snapshots__/breadcrumbs.test.tsx.snap
+++ b/src/components/breadcrumbs/__snapshots__/breadcrumbs.test.tsx.snap
@@ -6,19 +6,23 @@ exports[`OuiBreadcrumbs is rendered 1`] = `
   class="ouiBreadcrumbs testClass1 testClass2 ouiBreadcrumbs--truncate"
   data-test-subj="test subject string"
 >
-  <span
-    class="ouiBreadcrumbWrapper"
+  <div
+    class="ouiBreadcrumbWall"
   >
-    <a
-      class="ouiLink ouiLink--subdued ouiBreadcrumb customClass"
-      data-test-subj="breadcrumbsAnimals"
-      href="#"
-      rel="noreferrer"
+    <div
+      class="ouiBreadcrumbWrapper ouiBreadcrumbWrapper--first"
     >
-      Animals
-    </a>
-  </span>
-  <span
+      <a
+        class="ouiLink ouiLink--subdued ouiBreadcrumb customClass"
+        data-test-subj="breadcrumbsAnimals"
+        href="#"
+        rel="noreferrer"
+      >
+        Animals
+      </a>
+    </div>
+  </div>
+  <div
     class="ouiBreadcrumbWrapper"
   >
     <span
@@ -27,7 +31,7 @@ exports[`OuiBreadcrumbs is rendered 1`] = `
     >
       Metazoans
     </span>
-  </span>
+  </div>
   <div
     class="ouiBreadcrumbWrapper ouiBreadcrumbWrapper--collapsed"
   >
@@ -51,7 +55,7 @@ exports[`OuiBreadcrumbs is rendered 1`] = `
       </div>
     </div>
   </div>
-  <span
+  <div
     class="ouiBreadcrumbWrapper"
   >
     <button
@@ -60,8 +64,8 @@ exports[`OuiBreadcrumbs is rendered 1`] = `
     >
       Reptiles
     </button>
-  </span>
-  <span
+  </div>
+  <div
     class="ouiBreadcrumbWrapper ouiBreadcrumbWrapper--truncate"
   >
     <a
@@ -71,8 +75,8 @@ exports[`OuiBreadcrumbs is rendered 1`] = `
     >
       Boa constrictor
     </a>
-  </span>
-  <span
+  </div>
+  <div
     class="ouiBreadcrumbWrapper ouiBreadcrumbWrapper--last"
   >
     <span
@@ -81,7 +85,7 @@ exports[`OuiBreadcrumbs is rendered 1`] = `
     >
       Edit
     </span>
-  </span>
+  </div>
 </nav>
 `;
 
@@ -90,19 +94,23 @@ exports[`OuiBreadcrumbs props max doesn't break when max exceeds the number of b
   aria-label="breadcrumb"
   class="ouiBreadcrumbs ouiBreadcrumbs--truncate"
 >
-  <span
-    class="ouiBreadcrumbWrapper"
+  <div
+    class="ouiBreadcrumbWall"
   >
-    <a
-      class="ouiLink ouiLink--subdued ouiBreadcrumb customClass"
-      data-test-subj="breadcrumbsAnimals"
-      href="#"
-      rel="noreferrer"
+    <div
+      class="ouiBreadcrumbWrapper ouiBreadcrumbWrapper--first"
     >
-      Animals
-    </a>
-  </span>
-  <span
+      <a
+        class="ouiLink ouiLink--subdued ouiBreadcrumb customClass"
+        data-test-subj="breadcrumbsAnimals"
+        href="#"
+        rel="noreferrer"
+      >
+        Animals
+      </a>
+    </div>
+  </div>
+  <div
     class="ouiBreadcrumbWrapper"
   >
     <span
@@ -111,8 +119,8 @@ exports[`OuiBreadcrumbs props max doesn't break when max exceeds the number of b
     >
       Metazoans
     </span>
-  </span>
-  <span
+  </div>
+  <div
     class="ouiBreadcrumbWrapper"
   >
     <span
@@ -121,8 +129,8 @@ exports[`OuiBreadcrumbs props max doesn't break when max exceeds the number of b
     >
       Chordates
     </span>
-  </span>
-  <span
+  </div>
+  <div
     class="ouiBreadcrumbWrapper ouiBreadcrumbWrapper--truncate"
   >
     <span
@@ -131,8 +139,8 @@ exports[`OuiBreadcrumbs props max doesn't break when max exceeds the number of b
     >
       Nebulosa subspecies is also a real mouthful, especially for creatures without mouths
     </span>
-  </span>
-  <span
+  </div>
+  <div
     class="ouiBreadcrumbWrapper"
   >
     <span
@@ -141,8 +149,8 @@ exports[`OuiBreadcrumbs props max doesn't break when max exceeds the number of b
     >
       Tetrapods
     </span>
-  </span>
-  <span
+  </div>
+  <div
     class="ouiBreadcrumbWrapper"
   >
     <button
@@ -151,8 +159,8 @@ exports[`OuiBreadcrumbs props max doesn't break when max exceeds the number of b
     >
       Reptiles
     </button>
-  </span>
-  <span
+  </div>
+  <div
     class="ouiBreadcrumbWrapper ouiBreadcrumbWrapper--truncate"
   >
     <a
@@ -162,8 +170,8 @@ exports[`OuiBreadcrumbs props max doesn't break when max exceeds the number of b
     >
       Boa constrictor
     </a>
-  </span>
-  <span
+  </div>
+  <div
     class="ouiBreadcrumbWrapper ouiBreadcrumbWrapper--last"
   >
     <span
@@ -172,7 +180,7 @@ exports[`OuiBreadcrumbs props max doesn't break when max exceeds the number of b
     >
       Edit
     </span>
-  </span>
+  </div>
 </nav>
 `;
 
@@ -204,7 +212,7 @@ exports[`OuiBreadcrumbs props max renders 1 item 1`] = `
       </div>
     </div>
   </div>
-  <span
+  <div
     class="ouiBreadcrumbWrapper ouiBreadcrumbWrapper--last"
   >
     <span
@@ -213,7 +221,7 @@ exports[`OuiBreadcrumbs props max renders 1 item 1`] = `
     >
       Edit
     </span>
-  </span>
+  </div>
 </nav>
 `;
 
@@ -222,19 +230,23 @@ exports[`OuiBreadcrumbs props max renders all items with null 1`] = `
   aria-label="breadcrumb"
   class="ouiBreadcrumbs ouiBreadcrumbs--truncate"
 >
-  <span
-    class="ouiBreadcrumbWrapper"
+  <div
+    class="ouiBreadcrumbWall"
   >
-    <a
-      class="ouiLink ouiLink--subdued ouiBreadcrumb customClass"
-      data-test-subj="breadcrumbsAnimals"
-      href="#"
-      rel="noreferrer"
+    <div
+      class="ouiBreadcrumbWrapper ouiBreadcrumbWrapper--first"
     >
-      Animals
-    </a>
-  </span>
-  <span
+      <a
+        class="ouiLink ouiLink--subdued ouiBreadcrumb customClass"
+        data-test-subj="breadcrumbsAnimals"
+        href="#"
+        rel="noreferrer"
+      >
+        Animals
+      </a>
+    </div>
+  </div>
+  <div
     class="ouiBreadcrumbWrapper"
   >
     <span
@@ -243,8 +255,8 @@ exports[`OuiBreadcrumbs props max renders all items with null 1`] = `
     >
       Metazoans
     </span>
-  </span>
-  <span
+  </div>
+  <div
     class="ouiBreadcrumbWrapper"
   >
     <span
@@ -253,8 +265,8 @@ exports[`OuiBreadcrumbs props max renders all items with null 1`] = `
     >
       Chordates
     </span>
-  </span>
-  <span
+  </div>
+  <div
     class="ouiBreadcrumbWrapper ouiBreadcrumbWrapper--truncate"
   >
     <span
@@ -263,8 +275,8 @@ exports[`OuiBreadcrumbs props max renders all items with null 1`] = `
     >
       Nebulosa subspecies is also a real mouthful, especially for creatures without mouths
     </span>
-  </span>
-  <span
+  </div>
+  <div
     class="ouiBreadcrumbWrapper"
   >
     <span
@@ -273,8 +285,8 @@ exports[`OuiBreadcrumbs props max renders all items with null 1`] = `
     >
       Tetrapods
     </span>
-  </span>
-  <span
+  </div>
+  <div
     class="ouiBreadcrumbWrapper"
   >
     <button
@@ -283,8 +295,8 @@ exports[`OuiBreadcrumbs props max renders all items with null 1`] = `
     >
       Reptiles
     </button>
-  </span>
-  <span
+  </div>
+  <div
     class="ouiBreadcrumbWrapper ouiBreadcrumbWrapper--truncate"
   >
     <a
@@ -294,8 +306,8 @@ exports[`OuiBreadcrumbs props max renders all items with null 1`] = `
     >
       Boa constrictor
     </a>
-  </span>
-  <span
+  </div>
+  <div
     class="ouiBreadcrumbWrapper ouiBreadcrumbWrapper--last"
   >
     <span
@@ -304,7 +316,7 @@ exports[`OuiBreadcrumbs props max renders all items with null 1`] = `
     >
       Edit
     </span>
-  </span>
+  </div>
 </nav>
 `;
 
@@ -313,19 +325,23 @@ exports[`OuiBreadcrumbs props responsive is rendered 1`] = `
   aria-label="breadcrumb"
   class="ouiBreadcrumbs ouiBreadcrumbs--truncate"
 >
-  <span
-    class="ouiBreadcrumbWrapper"
+  <div
+    class="ouiBreadcrumbWall"
   >
-    <a
-      class="ouiLink ouiLink--subdued ouiBreadcrumb customClass"
-      data-test-subj="breadcrumbsAnimals"
-      href="#"
-      rel="noreferrer"
+    <div
+      class="ouiBreadcrumbWrapper ouiBreadcrumbWrapper--first"
     >
-      Animals
-    </a>
-  </span>
-  <span
+      <a
+        class="ouiLink ouiLink--subdued ouiBreadcrumb customClass"
+        data-test-subj="breadcrumbsAnimals"
+        href="#"
+        rel="noreferrer"
+      >
+        Animals
+      </a>
+    </div>
+  </div>
+  <div
     class="ouiBreadcrumbWrapper"
   >
     <span
@@ -334,7 +350,7 @@ exports[`OuiBreadcrumbs props responsive is rendered 1`] = `
     >
       Metazoans
     </span>
-  </span>
+  </div>
   <div
     class="ouiBreadcrumbWrapper ouiBreadcrumbWrapper--collapsed"
   >
@@ -358,7 +374,7 @@ exports[`OuiBreadcrumbs props responsive is rendered 1`] = `
       </div>
     </div>
   </div>
-  <span
+  <div
     class="ouiBreadcrumbWrapper"
   >
     <button
@@ -367,8 +383,8 @@ exports[`OuiBreadcrumbs props responsive is rendered 1`] = `
     >
       Reptiles
     </button>
-  </span>
-  <span
+  </div>
+  <div
     class="ouiBreadcrumbWrapper ouiBreadcrumbWrapper--truncate"
   >
     <a
@@ -378,8 +394,8 @@ exports[`OuiBreadcrumbs props responsive is rendered 1`] = `
     >
       Boa constrictor
     </a>
-  </span>
-  <span
+  </div>
+  <div
     class="ouiBreadcrumbWrapper ouiBreadcrumbWrapper--last"
   >
     <span
@@ -388,7 +404,7 @@ exports[`OuiBreadcrumbs props responsive is rendered 1`] = `
     >
       Edit
     </span>
-  </span>
+  </div>
 </nav>
 `;
 
@@ -397,19 +413,23 @@ exports[`OuiBreadcrumbs props responsive is rendered as false 1`] = `
   aria-label="breadcrumb"
   class="ouiBreadcrumbs ouiBreadcrumbs--truncate"
 >
-  <span
-    class="ouiBreadcrumbWrapper"
+  <div
+    class="ouiBreadcrumbWall"
   >
-    <a
-      class="ouiLink ouiLink--subdued ouiBreadcrumb customClass"
-      data-test-subj="breadcrumbsAnimals"
-      href="#"
-      rel="noreferrer"
+    <div
+      class="ouiBreadcrumbWrapper ouiBreadcrumbWrapper--first"
     >
-      Animals
-    </a>
-  </span>
-  <span
+      <a
+        class="ouiLink ouiLink--subdued ouiBreadcrumb customClass"
+        data-test-subj="breadcrumbsAnimals"
+        href="#"
+        rel="noreferrer"
+      >
+        Animals
+      </a>
+    </div>
+  </div>
+  <div
     class="ouiBreadcrumbWrapper"
   >
     <span
@@ -418,7 +438,7 @@ exports[`OuiBreadcrumbs props responsive is rendered as false 1`] = `
     >
       Metazoans
     </span>
-  </span>
+  </div>
   <div
     class="ouiBreadcrumbWrapper ouiBreadcrumbWrapper--collapsed"
   >
@@ -442,7 +462,7 @@ exports[`OuiBreadcrumbs props responsive is rendered as false 1`] = `
       </div>
     </div>
   </div>
-  <span
+  <div
     class="ouiBreadcrumbWrapper"
   >
     <button
@@ -451,8 +471,8 @@ exports[`OuiBreadcrumbs props responsive is rendered as false 1`] = `
     >
       Reptiles
     </button>
-  </span>
-  <span
+  </div>
+  <div
     class="ouiBreadcrumbWrapper ouiBreadcrumbWrapper--truncate"
   >
     <a
@@ -462,8 +482,8 @@ exports[`OuiBreadcrumbs props responsive is rendered as false 1`] = `
     >
       Boa constrictor
     </a>
-  </span>
-  <span
+  </div>
+  <div
     class="ouiBreadcrumbWrapper ouiBreadcrumbWrapper--last"
   >
     <span
@@ -472,7 +492,7 @@ exports[`OuiBreadcrumbs props responsive is rendered as false 1`] = `
     >
       Edit
     </span>
-  </span>
+  </div>
 </nav>
 `;
 
@@ -504,7 +524,7 @@ exports[`OuiBreadcrumbs props responsive is rendered with custom breakpoints 1`]
       </div>
     </div>
   </div>
-  <span
+  <div
     class="ouiBreadcrumbWrapper ouiBreadcrumbWrapper--last"
   >
     <span
@@ -513,7 +533,7 @@ exports[`OuiBreadcrumbs props responsive is rendered with custom breakpoints 1`]
     >
       Edit
     </span>
-  </span>
+  </div>
 </nav>
 `;
 
@@ -522,19 +542,23 @@ exports[`OuiBreadcrumbs props truncate as false is rendered 1`] = `
   aria-label="breadcrumb"
   class="ouiBreadcrumbs"
 >
-  <span
-    class="ouiBreadcrumbWrapper"
+  <div
+    class="ouiBreadcrumbWall"
   >
-    <a
-      class="ouiLink ouiLink--subdued ouiBreadcrumb customClass"
-      data-test-subj="breadcrumbsAnimals"
-      href="#"
-      rel="noreferrer"
+    <div
+      class="ouiBreadcrumbWrapper ouiBreadcrumbWrapper--first"
     >
-      Animals
-    </a>
-  </span>
-  <span
+      <a
+        class="ouiLink ouiLink--subdued ouiBreadcrumb customClass"
+        data-test-subj="breadcrumbsAnimals"
+        href="#"
+        rel="noreferrer"
+      >
+        Animals
+      </a>
+    </div>
+  </div>
+  <div
     class="ouiBreadcrumbWrapper"
   >
     <span
@@ -543,7 +567,7 @@ exports[`OuiBreadcrumbs props truncate as false is rendered 1`] = `
     >
       Metazoans
     </span>
-  </span>
+  </div>
   <div
     class="ouiBreadcrumbWrapper ouiBreadcrumbWrapper--collapsed"
   >
@@ -567,7 +591,7 @@ exports[`OuiBreadcrumbs props truncate as false is rendered 1`] = `
       </div>
     </div>
   </div>
-  <span
+  <div
     class="ouiBreadcrumbWrapper"
   >
     <button
@@ -576,8 +600,8 @@ exports[`OuiBreadcrumbs props truncate as false is rendered 1`] = `
     >
       Reptiles
     </button>
-  </span>
-  <span
+  </div>
+  <div
     class="ouiBreadcrumbWrapper ouiBreadcrumbWrapper--truncate"
   >
     <a
@@ -587,8 +611,8 @@ exports[`OuiBreadcrumbs props truncate as false is rendered 1`] = `
     >
       Boa constrictor
     </a>
-  </span>
-  <span
+  </div>
+  <div
     class="ouiBreadcrumbWrapper ouiBreadcrumbWrapper--last"
   >
     <span
@@ -597,6 +621,6 @@ exports[`OuiBreadcrumbs props truncate as false is rendered 1`] = `
     >
       Edit
     </span>
-  </span>
+  </div>
 </nav>
 `;

--- a/src/components/breadcrumbs/__snapshots__/breadcrumbs.test.tsx.snap
+++ b/src/components/breadcrumbs/__snapshots__/breadcrumbs.test.tsx.snap
@@ -6,57 +6,81 @@ exports[`OuiBreadcrumbs is rendered 1`] = `
   class="ouiBreadcrumbs testClass1 testClass2 ouiBreadcrumbs--truncate"
   data-test-subj="test subject string"
 >
-  <a
-    class="ouiLink ouiLink--subdued ouiBreadcrumb customClass"
-    data-test-subj="breadcrumbsAnimals"
-    href="#"
-    rel="noreferrer"
-  >
-    Animals
-  </a>
   <span
-    aria-current="false"
-    class="ouiBreadcrumb"
+    class="ouiBreadcrumbWrapper"
   >
-    Metazoans
+    <a
+      class="ouiLink ouiLink--subdued ouiBreadcrumb customClass"
+      data-test-subj="breadcrumbsAnimals"
+      href="#"
+      rel="noreferrer"
+    >
+      Animals
+    </a>
+  </span>
+  <span
+    class="ouiBreadcrumbWrapper"
+  >
+    <span
+      aria-current="false"
+      class="ouiBreadcrumb"
+    >
+      Metazoans
+    </span>
   </span>
   <div
-    class="ouiPopover ouiPopover--anchorDownCenter ouiBreadcrumb ouiBreadcrumb--collapsed"
+    class="ouiBreadcrumbWrapper"
   >
     <div
-      class="ouiPopover__anchor"
+      class="ouiPopover ouiPopover--anchorDownCenter ouiBreadcrumb ouiBreadcrumb--collapsed"
     >
-      <button
-        aria-label="Show collapsed breadcrumbs"
-        class="ouiLink ouiLink--subdued ouiBreadcrumb__collapsedLink"
-        title="Show collapsed breadcrumbs"
-        type="button"
+      <div
+        class="ouiPopover__anchor"
       >
-        … 
-        <span
-          data-ouiicon-type="arrowDown"
-        />
-      </button>
+        <button
+          aria-label="Show collapsed breadcrumbs"
+          class="ouiLink ouiLink--subdued ouiBreadcrumb__collapsedLink"
+          title="Show collapsed breadcrumbs"
+          type="button"
+        >
+          … 
+          <span
+            data-ouiicon-type="arrowDown"
+          />
+        </button>
+      </div>
     </div>
   </div>
-  <button
-    class="ouiLink ouiLink--subdued ouiBreadcrumb"
-    type="button"
-  >
-    Reptiles
-  </button>
-  <a
-    class="ouiLink ouiLink--subdued ouiBreadcrumb ouiBreadcrumb--truncate"
-    href="#"
-    rel="noreferrer"
-  >
-    Boa constrictor
-  </a>
   <span
-    aria-current="page"
-    class="ouiBreadcrumb ouiBreadcrumb--last"
+    class="ouiBreadcrumbWrapper"
   >
-    Edit
+    <button
+      class="ouiLink ouiLink--subdued ouiBreadcrumb"
+      type="button"
+    >
+      Reptiles
+    </button>
+  </span>
+  <span
+    class="ouiBreadcrumbWrapper"
+  >
+    <a
+      class="ouiLink ouiLink--subdued ouiBreadcrumb ouiBreadcrumb--truncate"
+      href="#"
+      rel="noreferrer"
+    >
+      Boa constrictor
+    </a>
+  </span>
+  <span
+    class="ouiBreadcrumbWrapper ouiBreadcrumbWrapper--last"
+  >
+    <span
+      aria-current="page"
+      class="ouiBreadcrumb ouiBreadcrumb--last"
+    >
+      Edit
+    </span>
   </span>
 </nav>
 `;
@@ -66,56 +90,88 @@ exports[`OuiBreadcrumbs props max doesn't break when max exceeds the number of b
   aria-label="breadcrumb"
   class="ouiBreadcrumbs ouiBreadcrumbs--truncate"
 >
-  <a
-    class="ouiLink ouiLink--subdued ouiBreadcrumb customClass"
-    data-test-subj="breadcrumbsAnimals"
-    href="#"
-    rel="noreferrer"
-  >
-    Animals
-  </a>
   <span
-    aria-current="false"
-    class="ouiBreadcrumb"
+    class="ouiBreadcrumbWrapper"
   >
-    Metazoans
+    <a
+      class="ouiLink ouiLink--subdued ouiBreadcrumb customClass"
+      data-test-subj="breadcrumbsAnimals"
+      href="#"
+      rel="noreferrer"
+    >
+      Animals
+    </a>
   </span>
   <span
-    aria-current="false"
-    class="ouiBreadcrumb"
+    class="ouiBreadcrumbWrapper"
   >
-    Chordates
+    <span
+      aria-current="false"
+      class="ouiBreadcrumb"
+    >
+      Metazoans
+    </span>
   </span>
   <span
-    aria-current="false"
-    class="ouiBreadcrumb ouiBreadcrumb--truncate"
+    class="ouiBreadcrumbWrapper"
   >
-    Nebulosa subspecies is also a real mouthful, especially for creatures without mouths
+    <span
+      aria-current="false"
+      class="ouiBreadcrumb"
+    >
+      Chordates
+    </span>
   </span>
   <span
-    aria-current="false"
-    class="ouiBreadcrumb"
+    class="ouiBreadcrumbWrapper"
   >
-    Tetrapods
+    <span
+      aria-current="false"
+      class="ouiBreadcrumb ouiBreadcrumb--truncate"
+    >
+      Nebulosa subspecies is also a real mouthful, especially for creatures without mouths
+    </span>
   </span>
-  <button
-    class="ouiLink ouiLink--subdued ouiBreadcrumb"
-    type="button"
-  >
-    Reptiles
-  </button>
-  <a
-    class="ouiLink ouiLink--subdued ouiBreadcrumb ouiBreadcrumb--truncate"
-    href="#"
-    rel="noreferrer"
-  >
-    Boa constrictor
-  </a>
   <span
-    aria-current="page"
-    class="ouiBreadcrumb ouiBreadcrumb--last"
+    class="ouiBreadcrumbWrapper"
   >
-    Edit
+    <span
+      aria-current="false"
+      class="ouiBreadcrumb"
+    >
+      Tetrapods
+    </span>
+  </span>
+  <span
+    class="ouiBreadcrumbWrapper"
+  >
+    <button
+      class="ouiLink ouiLink--subdued ouiBreadcrumb"
+      type="button"
+    >
+      Reptiles
+    </button>
+  </span>
+  <span
+    class="ouiBreadcrumbWrapper"
+  >
+    <a
+      class="ouiLink ouiLink--subdued ouiBreadcrumb ouiBreadcrumb--truncate"
+      href="#"
+      rel="noreferrer"
+    >
+      Boa constrictor
+    </a>
+  </span>
+  <span
+    class="ouiBreadcrumbWrapper ouiBreadcrumbWrapper--last"
+  >
+    <span
+      aria-current="page"
+      class="ouiBreadcrumb ouiBreadcrumb--last"
+    >
+      Edit
+    </span>
   </span>
 </nav>
 `;
@@ -126,29 +182,37 @@ exports[`OuiBreadcrumbs props max renders 1 item 1`] = `
   class="ouiBreadcrumbs ouiBreadcrumbs--truncate"
 >
   <div
-    class="ouiPopover ouiPopover--anchorDownCenter ouiBreadcrumb ouiBreadcrumb--collapsed"
+    class="ouiBreadcrumbWrapper"
   >
     <div
-      class="ouiPopover__anchor"
+      class="ouiPopover ouiPopover--anchorDownCenter ouiBreadcrumb ouiBreadcrumb--collapsed"
     >
-      <button
-        aria-label="Show collapsed breadcrumbs"
-        class="ouiLink ouiLink--subdued ouiBreadcrumb__collapsedLink"
-        title="Show collapsed breadcrumbs"
-        type="button"
+      <div
+        class="ouiPopover__anchor"
       >
-        … 
-        <span
-          data-ouiicon-type="arrowDown"
-        />
-      </button>
+        <button
+          aria-label="Show collapsed breadcrumbs"
+          class="ouiLink ouiLink--subdued ouiBreadcrumb__collapsedLink"
+          title="Show collapsed breadcrumbs"
+          type="button"
+        >
+          … 
+          <span
+            data-ouiicon-type="arrowDown"
+          />
+        </button>
+      </div>
     </div>
   </div>
   <span
-    aria-current="page"
-    class="ouiBreadcrumb ouiBreadcrumb--last"
+    class="ouiBreadcrumbWrapper ouiBreadcrumbWrapper--last"
   >
-    Edit
+    <span
+      aria-current="page"
+      class="ouiBreadcrumb ouiBreadcrumb--last"
+    >
+      Edit
+    </span>
   </span>
 </nav>
 `;
@@ -158,56 +222,88 @@ exports[`OuiBreadcrumbs props max renders all items with null 1`] = `
   aria-label="breadcrumb"
   class="ouiBreadcrumbs ouiBreadcrumbs--truncate"
 >
-  <a
-    class="ouiLink ouiLink--subdued ouiBreadcrumb customClass"
-    data-test-subj="breadcrumbsAnimals"
-    href="#"
-    rel="noreferrer"
-  >
-    Animals
-  </a>
   <span
-    aria-current="false"
-    class="ouiBreadcrumb"
+    class="ouiBreadcrumbWrapper"
   >
-    Metazoans
+    <a
+      class="ouiLink ouiLink--subdued ouiBreadcrumb customClass"
+      data-test-subj="breadcrumbsAnimals"
+      href="#"
+      rel="noreferrer"
+    >
+      Animals
+    </a>
   </span>
   <span
-    aria-current="false"
-    class="ouiBreadcrumb"
+    class="ouiBreadcrumbWrapper"
   >
-    Chordates
+    <span
+      aria-current="false"
+      class="ouiBreadcrumb"
+    >
+      Metazoans
+    </span>
   </span>
   <span
-    aria-current="false"
-    class="ouiBreadcrumb ouiBreadcrumb--truncate"
+    class="ouiBreadcrumbWrapper"
   >
-    Nebulosa subspecies is also a real mouthful, especially for creatures without mouths
+    <span
+      aria-current="false"
+      class="ouiBreadcrumb"
+    >
+      Chordates
+    </span>
   </span>
   <span
-    aria-current="false"
-    class="ouiBreadcrumb"
+    class="ouiBreadcrumbWrapper"
   >
-    Tetrapods
+    <span
+      aria-current="false"
+      class="ouiBreadcrumb ouiBreadcrumb--truncate"
+    >
+      Nebulosa subspecies is also a real mouthful, especially for creatures without mouths
+    </span>
   </span>
-  <button
-    class="ouiLink ouiLink--subdued ouiBreadcrumb"
-    type="button"
-  >
-    Reptiles
-  </button>
-  <a
-    class="ouiLink ouiLink--subdued ouiBreadcrumb ouiBreadcrumb--truncate"
-    href="#"
-    rel="noreferrer"
-  >
-    Boa constrictor
-  </a>
   <span
-    aria-current="page"
-    class="ouiBreadcrumb ouiBreadcrumb--last"
+    class="ouiBreadcrumbWrapper"
   >
-    Edit
+    <span
+      aria-current="false"
+      class="ouiBreadcrumb"
+    >
+      Tetrapods
+    </span>
+  </span>
+  <span
+    class="ouiBreadcrumbWrapper"
+  >
+    <button
+      class="ouiLink ouiLink--subdued ouiBreadcrumb"
+      type="button"
+    >
+      Reptiles
+    </button>
+  </span>
+  <span
+    class="ouiBreadcrumbWrapper"
+  >
+    <a
+      class="ouiLink ouiLink--subdued ouiBreadcrumb ouiBreadcrumb--truncate"
+      href="#"
+      rel="noreferrer"
+    >
+      Boa constrictor
+    </a>
+  </span>
+  <span
+    class="ouiBreadcrumbWrapper ouiBreadcrumbWrapper--last"
+  >
+    <span
+      aria-current="page"
+      class="ouiBreadcrumb ouiBreadcrumb--last"
+    >
+      Edit
+    </span>
   </span>
 </nav>
 `;
@@ -217,57 +313,81 @@ exports[`OuiBreadcrumbs props responsive is rendered 1`] = `
   aria-label="breadcrumb"
   class="ouiBreadcrumbs ouiBreadcrumbs--truncate"
 >
-  <a
-    class="ouiLink ouiLink--subdued ouiBreadcrumb customClass"
-    data-test-subj="breadcrumbsAnimals"
-    href="#"
-    rel="noreferrer"
-  >
-    Animals
-  </a>
   <span
-    aria-current="false"
-    class="ouiBreadcrumb"
+    class="ouiBreadcrumbWrapper"
   >
-    Metazoans
+    <a
+      class="ouiLink ouiLink--subdued ouiBreadcrumb customClass"
+      data-test-subj="breadcrumbsAnimals"
+      href="#"
+      rel="noreferrer"
+    >
+      Animals
+    </a>
+  </span>
+  <span
+    class="ouiBreadcrumbWrapper"
+  >
+    <span
+      aria-current="false"
+      class="ouiBreadcrumb"
+    >
+      Metazoans
+    </span>
   </span>
   <div
-    class="ouiPopover ouiPopover--anchorDownCenter ouiBreadcrumb ouiBreadcrumb--collapsed"
+    class="ouiBreadcrumbWrapper"
   >
     <div
-      class="ouiPopover__anchor"
+      class="ouiPopover ouiPopover--anchorDownCenter ouiBreadcrumb ouiBreadcrumb--collapsed"
     >
-      <button
-        aria-label="Show collapsed breadcrumbs"
-        class="ouiLink ouiLink--subdued ouiBreadcrumb__collapsedLink"
-        title="Show collapsed breadcrumbs"
-        type="button"
+      <div
+        class="ouiPopover__anchor"
       >
-        … 
-        <span
-          data-ouiicon-type="arrowDown"
-        />
-      </button>
+        <button
+          aria-label="Show collapsed breadcrumbs"
+          class="ouiLink ouiLink--subdued ouiBreadcrumb__collapsedLink"
+          title="Show collapsed breadcrumbs"
+          type="button"
+        >
+          … 
+          <span
+            data-ouiicon-type="arrowDown"
+          />
+        </button>
+      </div>
     </div>
   </div>
-  <button
-    class="ouiLink ouiLink--subdued ouiBreadcrumb"
-    type="button"
-  >
-    Reptiles
-  </button>
-  <a
-    class="ouiLink ouiLink--subdued ouiBreadcrumb ouiBreadcrumb--truncate"
-    href="#"
-    rel="noreferrer"
-  >
-    Boa constrictor
-  </a>
   <span
-    aria-current="page"
-    class="ouiBreadcrumb ouiBreadcrumb--last"
+    class="ouiBreadcrumbWrapper"
   >
-    Edit
+    <button
+      class="ouiLink ouiLink--subdued ouiBreadcrumb"
+      type="button"
+    >
+      Reptiles
+    </button>
+  </span>
+  <span
+    class="ouiBreadcrumbWrapper"
+  >
+    <a
+      class="ouiLink ouiLink--subdued ouiBreadcrumb ouiBreadcrumb--truncate"
+      href="#"
+      rel="noreferrer"
+    >
+      Boa constrictor
+    </a>
+  </span>
+  <span
+    class="ouiBreadcrumbWrapper ouiBreadcrumbWrapper--last"
+  >
+    <span
+      aria-current="page"
+      class="ouiBreadcrumb ouiBreadcrumb--last"
+    >
+      Edit
+    </span>
   </span>
 </nav>
 `;
@@ -277,57 +397,81 @@ exports[`OuiBreadcrumbs props responsive is rendered as false 1`] = `
   aria-label="breadcrumb"
   class="ouiBreadcrumbs ouiBreadcrumbs--truncate"
 >
-  <a
-    class="ouiLink ouiLink--subdued ouiBreadcrumb customClass"
-    data-test-subj="breadcrumbsAnimals"
-    href="#"
-    rel="noreferrer"
-  >
-    Animals
-  </a>
   <span
-    aria-current="false"
-    class="ouiBreadcrumb"
+    class="ouiBreadcrumbWrapper"
   >
-    Metazoans
+    <a
+      class="ouiLink ouiLink--subdued ouiBreadcrumb customClass"
+      data-test-subj="breadcrumbsAnimals"
+      href="#"
+      rel="noreferrer"
+    >
+      Animals
+    </a>
+  </span>
+  <span
+    class="ouiBreadcrumbWrapper"
+  >
+    <span
+      aria-current="false"
+      class="ouiBreadcrumb"
+    >
+      Metazoans
+    </span>
   </span>
   <div
-    class="ouiPopover ouiPopover--anchorDownCenter ouiBreadcrumb ouiBreadcrumb--collapsed"
+    class="ouiBreadcrumbWrapper"
   >
     <div
-      class="ouiPopover__anchor"
+      class="ouiPopover ouiPopover--anchorDownCenter ouiBreadcrumb ouiBreadcrumb--collapsed"
     >
-      <button
-        aria-label="Show collapsed breadcrumbs"
-        class="ouiLink ouiLink--subdued ouiBreadcrumb__collapsedLink"
-        title="Show collapsed breadcrumbs"
-        type="button"
+      <div
+        class="ouiPopover__anchor"
       >
-        … 
-        <span
-          data-ouiicon-type="arrowDown"
-        />
-      </button>
+        <button
+          aria-label="Show collapsed breadcrumbs"
+          class="ouiLink ouiLink--subdued ouiBreadcrumb__collapsedLink"
+          title="Show collapsed breadcrumbs"
+          type="button"
+        >
+          … 
+          <span
+            data-ouiicon-type="arrowDown"
+          />
+        </button>
+      </div>
     </div>
   </div>
-  <button
-    class="ouiLink ouiLink--subdued ouiBreadcrumb"
-    type="button"
-  >
-    Reptiles
-  </button>
-  <a
-    class="ouiLink ouiLink--subdued ouiBreadcrumb ouiBreadcrumb--truncate"
-    href="#"
-    rel="noreferrer"
-  >
-    Boa constrictor
-  </a>
   <span
-    aria-current="page"
-    class="ouiBreadcrumb ouiBreadcrumb--last"
+    class="ouiBreadcrumbWrapper"
   >
-    Edit
+    <button
+      class="ouiLink ouiLink--subdued ouiBreadcrumb"
+      type="button"
+    >
+      Reptiles
+    </button>
+  </span>
+  <span
+    class="ouiBreadcrumbWrapper"
+  >
+    <a
+      class="ouiLink ouiLink--subdued ouiBreadcrumb ouiBreadcrumb--truncate"
+      href="#"
+      rel="noreferrer"
+    >
+      Boa constrictor
+    </a>
+  </span>
+  <span
+    class="ouiBreadcrumbWrapper ouiBreadcrumbWrapper--last"
+  >
+    <span
+      aria-current="page"
+      class="ouiBreadcrumb ouiBreadcrumb--last"
+    >
+      Edit
+    </span>
   </span>
 </nav>
 `;
@@ -338,29 +482,37 @@ exports[`OuiBreadcrumbs props responsive is rendered with custom breakpoints 1`]
   class="ouiBreadcrumbs ouiBreadcrumbs--truncate"
 >
   <div
-    class="ouiPopover ouiPopover--anchorDownCenter ouiBreadcrumb ouiBreadcrumb--collapsed"
+    class="ouiBreadcrumbWrapper"
   >
     <div
-      class="ouiPopover__anchor"
+      class="ouiPopover ouiPopover--anchorDownCenter ouiBreadcrumb ouiBreadcrumb--collapsed"
     >
-      <button
-        aria-label="Show collapsed breadcrumbs"
-        class="ouiLink ouiLink--subdued ouiBreadcrumb__collapsedLink"
-        title="Show collapsed breadcrumbs"
-        type="button"
+      <div
+        class="ouiPopover__anchor"
       >
-        … 
-        <span
-          data-ouiicon-type="arrowDown"
-        />
-      </button>
+        <button
+          aria-label="Show collapsed breadcrumbs"
+          class="ouiLink ouiLink--subdued ouiBreadcrumb__collapsedLink"
+          title="Show collapsed breadcrumbs"
+          type="button"
+        >
+          … 
+          <span
+            data-ouiicon-type="arrowDown"
+          />
+        </button>
+      </div>
     </div>
   </div>
   <span
-    aria-current="page"
-    class="ouiBreadcrumb ouiBreadcrumb--last"
+    class="ouiBreadcrumbWrapper ouiBreadcrumbWrapper--last"
   >
-    Edit
+    <span
+      aria-current="page"
+      class="ouiBreadcrumb ouiBreadcrumb--last"
+    >
+      Edit
+    </span>
   </span>
 </nav>
 `;
@@ -370,57 +522,81 @@ exports[`OuiBreadcrumbs props truncate as false is rendered 1`] = `
   aria-label="breadcrumb"
   class="ouiBreadcrumbs"
 >
-  <a
-    class="ouiLink ouiLink--subdued ouiBreadcrumb customClass"
-    data-test-subj="breadcrumbsAnimals"
-    href="#"
-    rel="noreferrer"
-  >
-    Animals
-  </a>
   <span
-    aria-current="false"
-    class="ouiBreadcrumb"
+    class="ouiBreadcrumbWrapper"
   >
-    Metazoans
+    <a
+      class="ouiLink ouiLink--subdued ouiBreadcrumb customClass"
+      data-test-subj="breadcrumbsAnimals"
+      href="#"
+      rel="noreferrer"
+    >
+      Animals
+    </a>
+  </span>
+  <span
+    class="ouiBreadcrumbWrapper"
+  >
+    <span
+      aria-current="false"
+      class="ouiBreadcrumb"
+    >
+      Metazoans
+    </span>
   </span>
   <div
-    class="ouiPopover ouiPopover--anchorDownCenter ouiBreadcrumb ouiBreadcrumb--collapsed"
+    class="ouiBreadcrumbWrapper"
   >
     <div
-      class="ouiPopover__anchor"
+      class="ouiPopover ouiPopover--anchorDownCenter ouiBreadcrumb ouiBreadcrumb--collapsed"
     >
-      <button
-        aria-label="Show collapsed breadcrumbs"
-        class="ouiLink ouiLink--subdued ouiBreadcrumb__collapsedLink"
-        title="Show collapsed breadcrumbs"
-        type="button"
+      <div
+        class="ouiPopover__anchor"
       >
-        … 
-        <span
-          data-ouiicon-type="arrowDown"
-        />
-      </button>
+        <button
+          aria-label="Show collapsed breadcrumbs"
+          class="ouiLink ouiLink--subdued ouiBreadcrumb__collapsedLink"
+          title="Show collapsed breadcrumbs"
+          type="button"
+        >
+          … 
+          <span
+            data-ouiicon-type="arrowDown"
+          />
+        </button>
+      </div>
     </div>
   </div>
-  <button
-    class="ouiLink ouiLink--subdued ouiBreadcrumb"
-    type="button"
-  >
-    Reptiles
-  </button>
-  <a
-    class="ouiLink ouiLink--subdued ouiBreadcrumb ouiBreadcrumb--truncate"
-    href="#"
-    rel="noreferrer"
-  >
-    Boa constrictor
-  </a>
   <span
-    aria-current="page"
-    class="ouiBreadcrumb ouiBreadcrumb--last"
+    class="ouiBreadcrumbWrapper"
   >
-    Edit
+    <button
+      class="ouiLink ouiLink--subdued ouiBreadcrumb"
+      type="button"
+    >
+      Reptiles
+    </button>
+  </span>
+  <span
+    class="ouiBreadcrumbWrapper"
+  >
+    <a
+      class="ouiLink ouiLink--subdued ouiBreadcrumb ouiBreadcrumb--truncate"
+      href="#"
+      rel="noreferrer"
+    >
+      Boa constrictor
+    </a>
+  </span>
+  <span
+    class="ouiBreadcrumbWrapper ouiBreadcrumbWrapper--last"
+  >
+    <span
+      aria-current="page"
+      class="ouiBreadcrumb ouiBreadcrumb--last"
+    >
+      Edit
+    </span>
   </span>
 </nav>
 `;

--- a/src/components/breadcrumbs/_breadcrumbs.scss
+++ b/src/components/breadcrumbs/_breadcrumbs.scss
@@ -29,6 +29,10 @@
 
   &:not(.ouiBreadcrumb--last) {
     color: $ouiTextSubduedColor;
+
+    &:hover {
+      color: $ouiBreadCrumbHoverColor !important; // sass-lint:disable-line no-important
+    }
   }
 }
 
@@ -39,6 +43,10 @@
 .ouiBreadcrumb--collapsed {
   flex-shrink: 0;
   color: $ouiBreadcrumbCollapsedLink;
+}
+
+.ouiBreadcrumb__collapsedLink:hover {
+  color: $ouiBreadCrumbHoverColor !important; // sass-lint:disable-line no-important
 }
 
 .ouiBreadcrumbs__inPopover .ouiBreadcrumb--last {

--- a/src/components/breadcrumbs/_breadcrumbs.scss
+++ b/src/components/breadcrumbs/_breadcrumbs.scss
@@ -80,5 +80,5 @@
 }
 
 .ouiBreadcrumbWrapper--last {
-  background-color: $ouiBreadcrumbBlueBackground
+  background-color: $ouiBreadcrumbBlueBackground;
 }

--- a/src/components/breadcrumbs/_breadcrumbs.scss
+++ b/src/components/breadcrumbs/_breadcrumbs.scss
@@ -80,21 +80,25 @@
 }
 
 .ouiBreadcrumbWrapper {
-  margin-bottom: $ouiSizeXS; /* 1 */
   background-color: $ouiBreadcrumbGrayBackground;
   transform: skewX(-20deg);
   border-radius: $ouiSizeXS;
   padding: $ouiSizeXS - 2.5 $ouiSizeL - $ouiSizeXS;
+
+  &:not(.ouiBreadcrumbWrapper--first) {
+    margin-bottom: $ouiSizeXS; /* 1 */
+  }
 
   &:not(.ouiBreadcrumbWrapper--last) {
     margin-right: $ouiBreadcrumbSpacing;
   }
 }
 
-.ouiBreadcrumbWrapper--first {
-  background-image: linear-gradient(to right, $ouiBreadcrumbGrayBackground 0 30px, transparent 30px);
+.ouiBreadcrumbWall {
+  background-image: linear-gradient(to right, $ouiBreadcrumbGrayBackground 0 $ouiSizeM, transparent $ouiSizeM);
   border-radius: $ouiSizeXS;
   overflow: hidden;
+  margin-bottom: $ouiSizeXS; /* 1 */
 }
 
 .ouiBreadcrumbWrapper--last {

--- a/src/components/breadcrumbs/_breadcrumbs.scss
+++ b/src/components/breadcrumbs/_breadcrumbs.scss
@@ -68,15 +68,11 @@
   }
 }
 
-.ouiBreadcrumb--truncate,
-.ouiBreadcrumbWrapper--truncate {
+.ouiBreadcrumb--truncate {
   @include ouiTextTruncate;
+  max-width: 100%;
   text-align: center;
   vertical-align: top; // overflow hidden causes misalignment of links and slashes, this fixes that
-}
-
-.ouiBreadcrumb--truncate {
-  max-width: 100%;
 }
 
 .ouiBreadcrumbWrapper--truncate {

--- a/src/components/breadcrumbs/_breadcrumbs.scss
+++ b/src/components/breadcrumbs/_breadcrumbs.scss
@@ -43,6 +43,7 @@
 .ouiBreadcrumb--collapsed {
   flex-shrink: 0;
   color: $ouiBreadcrumbCollapsedLink;
+  vertical-align: top !important; // sass-lint:disable-line no-important
 }
 
 .ouiBreadcrumb__collapsedLink:hover {

--- a/src/components/breadcrumbs/_breadcrumbs.scss
+++ b/src/components/breadcrumbs/_breadcrumbs.scss
@@ -51,20 +51,36 @@
   flex-wrap: nowrap;
 
   .ouiBreadcrumb:not(.ouiBreadcrumb--collapsed) {
+    max-width: 100%;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    vertical-align: top; // overflow hidden causes misalignment of links and slashes, this fixes that
+  }
+
+  .ouiBreadcrumbWrapper:not(.ouiBreadcrumbWrapper--collapsed) {
     max-width: $ouiBreadcrumbTruncateWidth;
+    overflow: hidden;
     text-overflow: ellipsis;
 
-    &.ouiBreadcrumb--last {
+    &.ouiBreadcrumbWrapper--last {
       max-width: none;
     }
   }
 }
 
-.ouiBreadcrumb--truncate {
+.ouiBreadcrumb--truncate,
+.ouiBreadcrumbWrapper--truncate {
   @include ouiTextTruncate;
-  max-width: $ouiBreadcrumbTruncateWidth;
   text-align: center;
   vertical-align: top; // overflow hidden causes misalignment of links and slashes, this fixes that
+}
+
+.ouiBreadcrumb--truncate {
+  max-width: 100%;
+}
+
+.ouiBreadcrumbWrapper--truncate {
+  max-width: $ouiBreadcrumbTruncateWidth;
 }
 
 .ouiBreadcrumbWrapper {
@@ -77,6 +93,12 @@
   &:not(.ouiBreadcrumbWrapper--last) {
     margin-right: $ouiBreadcrumbSpacing;
   }
+}
+
+.ouiBreadcrumbWrapper--first {
+  background-image: linear-gradient(to right, $ouiBreadcrumbGrayBackground 0 30px, transparent 30px);
+  border-radius: $ouiSizeXS;
+  overflow: hidden;
 }
 
 .ouiBreadcrumbWrapper--last {

--- a/src/components/breadcrumbs/_breadcrumbs.scss
+++ b/src/components/breadcrumbs/_breadcrumbs.scss
@@ -25,10 +25,9 @@
 
 .ouiBreadcrumb {
   display: inline-block;
-  margin-bottom: $ouiSizeXS; /* 1 */
+  transform: skewX(20deg);
 
   &:not(.ouiBreadcrumb--last) {
-    margin-right: $ouiBreadcrumbSpacing;
     color: $ouiTextSubduedColor;
   }
 }
@@ -39,6 +38,7 @@
 
 .ouiBreadcrumb--collapsed {
   flex-shrink: 0;
+  color: $ouiBreadcrumbCollapsedLink;
 }
 
 .ouiBreadcrumbs__inPopover .ouiBreadcrumb--last {
@@ -52,7 +52,6 @@
 
   .ouiBreadcrumb:not(.ouiBreadcrumb--collapsed) {
     max-width: $ouiBreadcrumbTruncateWidth;
-    overflow: hidden;
     text-overflow: ellipsis;
 
     &.ouiBreadcrumb--last {
@@ -66,4 +65,20 @@
   max-width: $ouiBreadcrumbTruncateWidth;
   text-align: center;
   vertical-align: top; // overflow hidden causes misalignment of links and slashes, this fixes that
+}
+
+.ouiBreadcrumbWrapper {
+  margin-bottom: $ouiSizeXS; /* 1 */
+  background-color: $ouiBreadcrumbGrayBackground;
+  transform: skewX(-20deg);
+  border-radius: $ouiSizeXS;
+  padding: $ouiSizeXS - 2.5 $ouiSizeL - $ouiSizeXS;
+
+  &:not(.ouiBreadcrumbWrapper--last) {
+    margin-right: $ouiBreadcrumbSpacing;
+  }
+}
+
+.ouiBreadcrumbWrapper--last {
+  background-color: $ouiBreadcrumbBlueBackground
 }

--- a/src/components/breadcrumbs/_breadcrumbs.scss
+++ b/src/components/breadcrumbs/_breadcrumbs.scss
@@ -41,16 +41,6 @@
   flex-shrink: 0;
 }
 
-.ouiBreadcrumbSeparator {
-  flex-shrink: 0;
-  display: inline-block;
-  margin-right: $ouiBreadcrumbSpacing;
-  width: 1px;
-  height: $ouiSize;
-  transform: translateY(-1px) rotate(15deg);
-  background: $ouiColorLightShade;
-}
-
 .ouiBreadcrumbs__inPopover .ouiBreadcrumb--last {
   font-weight: $ouiFontWeightRegular;
   color: $ouiColorDarkShade !important; // sass-lint:disable-line no-important

--- a/src/components/breadcrumbs/_variables.scss
+++ b/src/components/breadcrumbs/_variables.scss
@@ -12,9 +12,9 @@
 $ouiBreadcrumbSpacing: $ouiSizeS !default;
 $ouiBreadcrumbTruncateWidth: $ouiSize * 10 !default;
 
-$ouiBreadcrumbBlueBackground: #b9d9eb;
-$ouiBreadcrumbGrayBackground: #d9e1e2;
-$ouiBreadcrumbCollapsedLink: #002a3a;
+$ouiBreadcrumbBlueBackground: #B9D9EB;
+$ouiBreadcrumbGrayBackground: #D9E1E2;
+$ouiBreadcrumbCollapsedLink: #002A3A;
 
 /* OUI -> EUI Aliases */
 $euiBreadcrumbSpacing: $ouiBreadcrumbSpacing;

--- a/src/components/breadcrumbs/_variables.scss
+++ b/src/components/breadcrumbs/_variables.scss
@@ -12,8 +12,15 @@
 $ouiBreadcrumbSpacing: $ouiSizeS !default;
 $ouiBreadcrumbTruncateWidth: $ouiSize * 10 !default;
 
+$ouiBreadcrumbBlueBackground: #b9d9eb;
+$ouiBreadcrumbGrayBackground: #d9e1e2;
+$ouiBreadcrumbCollapsedLink: #002a3a;
 
 /* OUI -> EUI Aliases */
 $euiBreadcrumbSpacing: $ouiBreadcrumbSpacing;
 $euiBreadcrumbTruncateWidth: $ouiBreadcrumbTruncateWidth;
+
+$euiBreadcrumbBlueBackground: $ouiBreadcrumbBlueBackground;
+$euiBreadcrumbGrayBackground: $ouiBreadcrumbGrayBackground;
+$euiBreadcrumbCollapsedLink: $ouiBreadcrumbCollapsedLink;
 /* End of Aliases */

--- a/src/components/breadcrumbs/_variables.scss
+++ b/src/components/breadcrumbs/_variables.scss
@@ -12,9 +12,10 @@
 $ouiBreadcrumbSpacing: $ouiSizeS !default;
 $ouiBreadcrumbTruncateWidth: $ouiSize * 10 !default;
 
-$ouiBreadcrumbBlueBackground: #B9D9EB;
-$ouiBreadcrumbGrayBackground: #D9E1E2;
-$ouiBreadcrumbCollapsedLink: #002A3A;
+$ouiBreadcrumbBlueBackground: #B9D9EB !default;
+$ouiBreadcrumbGrayBackground: #D9E1E2 !default;
+$ouiBreadcrumbCollapsedLink: #002A3A !default;
+$ouiBreadCrumbHoverColor: #535861 !default;
 
 /* OUI -> EUI Aliases */
 $euiBreadcrumbSpacing: $ouiBreadcrumbSpacing;
@@ -23,4 +24,5 @@ $euiBreadcrumbTruncateWidth: $ouiBreadcrumbTruncateWidth;
 $euiBreadcrumbBlueBackground: $ouiBreadcrumbBlueBackground;
 $euiBreadcrumbGrayBackground: $ouiBreadcrumbGrayBackground;
 $euiBreadcrumbCollapsedLink: $ouiBreadcrumbCollapsedLink;
+$euiBreadCrumbHoverColor: $ouiBreadCrumbHoverColor;
 /* End of Aliases */

--- a/src/components/breadcrumbs/breadcrumbs.tsx
+++ b/src/components/breadcrumbs/breadcrumbs.tsx
@@ -268,11 +268,7 @@ export const OuiBreadcrumbs: FunctionComponent<OuiBreadcrumbsProps> = ({
       );
     }
 
-    return (
-      <Fragment key={index}>
-        {link}
-      </Fragment>
-    );
+    return <Fragment key={index}>{link}</Fragment>;
   });
 
   // Use the default object if they simply passed `true` for responsive

--- a/src/components/breadcrumbs/breadcrumbs.tsx
+++ b/src/components/breadcrumbs/breadcrumbs.tsx
@@ -162,19 +162,21 @@ const limitBreadcrumbs = (
 
     return (
       <Fragment>
-        <OuiPopover
-          className="ouiBreadcrumb ouiBreadcrumb--collapsed"
-          button={ellipsisButton}
-          isOpen={isPopoverOpen}
-          closePopover={() => setIsPopoverOpen(false)}>
-          <OuiBreadcrumbs
-            className="ouiBreadcrumbs__inPopover"
-            breadcrumbs={overflowBreadcrumbs}
-            responsive={false}
-            truncate={false}
-            max={0}
-          />
-        </OuiPopover>
+        <div className="ouiBreadcrumbWrapper">
+          <OuiPopover
+            className="ouiBreadcrumb ouiBreadcrumb--collapsed"
+            button={ellipsisButton}
+            isOpen={isPopoverOpen}
+            closePopover={() => setIsPopoverOpen(false)}>
+            <OuiBreadcrumbs
+              className="ouiBreadcrumbs__inPopover"
+              breadcrumbs={overflowBreadcrumbs}
+              responsive={false}
+              truncate={false}
+              max={0}
+            />
+          </OuiPopover>
+        </div>
       </Fragment>
     );
   };

--- a/src/components/breadcrumbs/breadcrumbs.tsx
+++ b/src/components/breadcrumbs/breadcrumbs.tsx
@@ -227,6 +227,10 @@ export const OuiBreadcrumbs: FunctionComponent<OuiBreadcrumbsProps> = ({
 
     const isLastBreadcrumb = index === breadcrumbs.length - 1;
 
+    const breadcrumbWrapperClasses = classNames('ouiBreadcrumbWrapper', {
+      'ouiBreadcrumbWrapper--last': isLastBreadcrumb,
+    });
+
     const breadcrumbClasses = classNames('ouiBreadcrumb', breadcrumbClassName, {
       'ouiBreadcrumb--last': isLastBreadcrumb,
       'ouiBreadcrumb--truncate': truncate,
@@ -238,13 +242,14 @@ export const OuiBreadcrumbs: FunctionComponent<OuiBreadcrumbsProps> = ({
       link = (
         <OuiInnerText>
           {(ref, innerText) => (
-            <span
-              ref={ref}
-              className={breadcrumbClasses}
-              title={innerText}
-              aria-current={isLastBreadcrumb ? 'page' : 'false'}
-              {...breadcrumbRest}>
-              {text}
+            <span ref={ref} className={breadcrumbWrapperClasses}>
+              <span
+                className={breadcrumbClasses}
+                title={innerText}
+                aria-current={isLastBreadcrumb ? 'page' : 'false'}
+                {...breadcrumbRest}>
+                {text}
+              </span>
             </span>
           )}
         </OuiInnerText>
@@ -253,16 +258,17 @@ export const OuiBreadcrumbs: FunctionComponent<OuiBreadcrumbsProps> = ({
       link = (
         <OuiInnerText>
           {(ref, innerText) => (
-            <OuiLink
-              ref={ref}
-              color={isLastBreadcrumb ? 'text' : 'subdued'}
-              onClick={onClick}
-              href={href}
-              className={breadcrumbClasses}
-              title={innerText}
-              {...breadcrumbRest}>
-              {text}
-            </OuiLink>
+            <span ref={ref} className={breadcrumbWrapperClasses}>
+              <OuiLink
+                color={isLastBreadcrumb ? 'text' : 'subdued'}
+                onClick={onClick}
+                href={href}
+                className={breadcrumbClasses}
+                title={innerText}
+                {...breadcrumbRest}>
+                {text}
+              </OuiLink>
+            </span>
           )}
         </OuiInnerText>
       );

--- a/src/components/breadcrumbs/breadcrumbs.tsx
+++ b/src/components/breadcrumbs/breadcrumbs.tsx
@@ -227,9 +227,11 @@ export const OuiBreadcrumbs: FunctionComponent<OuiBreadcrumbsProps> = ({
       ...breadcrumbRest
     } = breadcrumb;
 
+    const isFirstBreadcrumb = index === 0;
     const isLastBreadcrumb = index === breadcrumbs.length - 1;
 
     const breadcrumbWrapperClasses = classNames('ouiBreadcrumbWrapper', {
+      'ouiBreadcrumbWrapper--first': isFirstBreadcrumb,
       'ouiBreadcrumbWrapper--last': isLastBreadcrumb,
       'ouiBreadcrumbWrapper--truncate': truncate,
     });
@@ -275,11 +277,15 @@ export const OuiBreadcrumbs: FunctionComponent<OuiBreadcrumbsProps> = ({
       );
     }
 
-    return (
-      <Fragment key={index}>
-        <span className={breadcrumbWrapperClasses}>{link}</span>
-      </Fragment>
-    );
+    let wrapper = <div className={breadcrumbWrapperClasses}>{link}</div>;
+
+    if (isFirstBreadcrumb) {
+      const breadcrumbWallClasses = classNames('ouiBreadcrumbWall');
+
+      wrapper = <div className={breadcrumbWallClasses}>{wrapper}</div>;
+    }
+
+    return <Fragment key={index}>{wrapper}</Fragment>;
   });
 
   // Use the default object if they simply passed `true` for responsive

--- a/src/components/breadcrumbs/breadcrumbs.tsx
+++ b/src/components/breadcrumbs/breadcrumbs.tsx
@@ -162,7 +162,7 @@ const limitBreadcrumbs = (
 
     return (
       <Fragment>
-        <div className="ouiBreadcrumbWrapper">
+        <div className="ouiBreadcrumbWrapper ouiBreadcrumbWrapper--collapsed">
           <OuiPopover
             className="ouiBreadcrumb ouiBreadcrumb--collapsed"
             button={ellipsisButton}
@@ -227,10 +227,12 @@ export const OuiBreadcrumbs: FunctionComponent<OuiBreadcrumbsProps> = ({
       ...breadcrumbRest
     } = breadcrumb;
 
+    // const isFirstBreadcrumb = index === 0;
     const isLastBreadcrumb = index === breadcrumbs.length - 1;
 
     const breadcrumbWrapperClasses = classNames('ouiBreadcrumbWrapper', {
       'ouiBreadcrumbWrapper--last': isLastBreadcrumb,
+      'ouiBreadcrumbWrapper--truncate': truncate,
     });
 
     const breadcrumbClasses = classNames('ouiBreadcrumb', breadcrumbClassName, {

--- a/src/components/breadcrumbs/breadcrumbs.tsx
+++ b/src/components/breadcrumbs/breadcrumbs.tsx
@@ -227,7 +227,6 @@ export const OuiBreadcrumbs: FunctionComponent<OuiBreadcrumbsProps> = ({
       ...breadcrumbRest
     } = breadcrumb;
 
-    // const isFirstBreadcrumb = index === 0;
     const isLastBreadcrumb = index === breadcrumbs.length - 1;
 
     const breadcrumbWrapperClasses = classNames('ouiBreadcrumbWrapper', {

--- a/src/components/breadcrumbs/breadcrumbs.tsx
+++ b/src/components/breadcrumbs/breadcrumbs.tsx
@@ -175,7 +175,6 @@ const limitBreadcrumbs = (
             max={0}
           />
         </OuiPopover>
-        <OuiBreadcrumbSeparator />
       </Fragment>
     );
   };
@@ -186,8 +185,6 @@ const limitBreadcrumbs = (
 
   return [...breadcrumbsAtStart, ...breadcrumbsAtEnd];
 };
-
-const OuiBreadcrumbSeparator = () => <div className="ouiBreadcrumbSeparator" />;
 
 export const OuiBreadcrumbs: FunctionComponent<OuiBreadcrumbsProps> = ({
   breadcrumbs,
@@ -271,16 +268,9 @@ export const OuiBreadcrumbs: FunctionComponent<OuiBreadcrumbsProps> = ({
       );
     }
 
-    let separator;
-
-    if (!isLastBreadcrumb) {
-      separator = <OuiBreadcrumbSeparator />;
-    }
-
     return (
       <Fragment key={index}>
         {link}
-        {separator}
       </Fragment>
     );
   });

--- a/src/components/breadcrumbs/breadcrumbs.tsx
+++ b/src/components/breadcrumbs/breadcrumbs.tsx
@@ -245,14 +245,13 @@ export const OuiBreadcrumbs: FunctionComponent<OuiBreadcrumbsProps> = ({
       link = (
         <OuiInnerText>
           {(ref, innerText) => (
-            <span ref={ref} className={breadcrumbWrapperClasses}>
-              <span
-                className={breadcrumbClasses}
-                title={innerText}
-                aria-current={isLastBreadcrumb ? 'page' : 'false'}
-                {...breadcrumbRest}>
-                {text}
-              </span>
+            <span
+              ref={ref}
+              className={breadcrumbClasses}
+              title={innerText}
+              aria-current={isLastBreadcrumb ? 'page' : 'false'}
+              {...breadcrumbRest}>
+              {text}
             </span>
           )}
         </OuiInnerText>
@@ -261,23 +260,26 @@ export const OuiBreadcrumbs: FunctionComponent<OuiBreadcrumbsProps> = ({
       link = (
         <OuiInnerText>
           {(ref, innerText) => (
-            <span ref={ref} className={breadcrumbWrapperClasses}>
-              <OuiLink
-                color={isLastBreadcrumb ? 'text' : 'subdued'}
-                onClick={onClick}
-                href={href}
-                className={breadcrumbClasses}
-                title={innerText}
-                {...breadcrumbRest}>
-                {text}
-              </OuiLink>
-            </span>
+            <OuiLink
+              ref={ref}
+              color={isLastBreadcrumb ? 'text' : 'subdued'}
+              onClick={onClick}
+              href={href}
+              className={breadcrumbClasses}
+              title={innerText}
+              {...breadcrumbRest}>
+              {text}
+            </OuiLink>
           )}
         </OuiInnerText>
       );
     }
 
-    return <Fragment key={index}>{link}</Fragment>;
+    return (
+      <Fragment key={index}>
+        <span className={breadcrumbWrapperClasses}>{link}</span>
+      </Fragment>
+    );
   });
 
   // Use the default object if they simply passed `true` for responsive

--- a/src/components/control_bar/__snapshots__/control_bar.test.tsx.snap
+++ b/src/components/control_bar/__snapshots__/control_bar.test.tsx.snap
@@ -19,18 +19,22 @@ exports[`OuiControlBar is rendered 1`] = `
       aria-label="breadcrumb"
       class="ouiBreadcrumbs ouiControlBar__breadcrumbs ouiBreadcrumbs--truncate"
     >
-      <span
-        class="ouiBreadcrumbWrapper"
+      <div
+        class="ouiBreadcrumbWall"
       >
-        <span
-          aria-current="false"
-          class="ouiBreadcrumb"
-          title="src"
+        <div
+          class="ouiBreadcrumbWrapper ouiBreadcrumbWrapper--first"
         >
-          src
-        </span>
-      </span>
-      <span
+          <span
+            aria-current="false"
+            class="ouiBreadcrumb"
+            title="src"
+          >
+            src
+          </span>
+        </div>
+      </div>
+      <div
         class="ouiBreadcrumbWrapper ouiBreadcrumbWrapper--last"
       >
         <span
@@ -40,7 +44,7 @@ exports[`OuiControlBar is rendered 1`] = `
         >
           components
         </span>
-      </span>
+      </div>
     </nav>
     <button
       class="ouiButton ouiButton--ghost ouiButton--small ouiControlBar__button"
@@ -161,18 +165,22 @@ exports[`OuiControlBar props leftOffset is rendered 1`] = `
                 aria-label="breadcrumb"
                 class="ouiBreadcrumbs ouiControlBar__breadcrumbs ouiBreadcrumbs--truncate"
               >
-                <span
-                  class="ouiBreadcrumbWrapper"
+                <div
+                  class="ouiBreadcrumbWall"
                 >
-                  <span
-                    aria-current="false"
-                    class="ouiBreadcrumb"
-                    title="src"
+                  <div
+                    class="ouiBreadcrumbWrapper ouiBreadcrumbWrapper--first"
                   >
-                    src
-                  </span>
-                </span>
-                <span
+                    <span
+                      aria-current="false"
+                      class="ouiBreadcrumb"
+                      title="src"
+                    >
+                      src
+                    </span>
+                  </div>
+                </div>
+                <div
                   class="ouiBreadcrumbWrapper ouiBreadcrumbWrapper--last"
                 >
                   <span
@@ -182,7 +190,7 @@ exports[`OuiControlBar props leftOffset is rendered 1`] = `
                   >
                     components
                   </span>
-                </span>
+                </div>
               </nav>
               <button
                 class="ouiButton ouiButton--ghost ouiButton--small ouiControlBar__button"
@@ -276,20 +284,24 @@ exports[`OuiControlBar props leftOffset is rendered 1`] = `
                 aria-label="breadcrumb"
                 className="ouiBreadcrumbs ouiControlBar__breadcrumbs ouiBreadcrumbs--truncate"
               >
-                <span
-                  className="ouiBreadcrumbWrapper"
+                <div
+                  className="ouiBreadcrumbWall"
                 >
-                  <OuiInnerText>
-                    <span
-                      aria-current="false"
-                      className="ouiBreadcrumb"
-                      title="src"
-                    >
-                      src
-                    </span>
-                  </OuiInnerText>
-                </span>
-                <span
+                  <div
+                    className="ouiBreadcrumbWrapper ouiBreadcrumbWrapper--first"
+                  >
+                    <OuiInnerText>
+                      <span
+                        aria-current="false"
+                        className="ouiBreadcrumb"
+                        title="src"
+                      >
+                        src
+                      </span>
+                    </OuiInnerText>
+                  </div>
+                </div>
+                <div
                   className="ouiBreadcrumbWrapper ouiBreadcrumbWrapper--last"
                 >
                   <OuiInnerText>
@@ -301,7 +313,7 @@ exports[`OuiControlBar props leftOffset is rendered 1`] = `
                       components
                     </span>
                   </OuiInnerText>
-                </span>
+                </div>
               </nav>
             </OuiBreadcrumbs>
             <OuiButton
@@ -493,18 +505,22 @@ exports[`OuiControlBar props maxHeight is rendered 1`] = `
                 aria-label="breadcrumb"
                 class="ouiBreadcrumbs ouiControlBar__breadcrumbs ouiBreadcrumbs--truncate"
               >
-                <span
-                  class="ouiBreadcrumbWrapper"
+                <div
+                  class="ouiBreadcrumbWall"
                 >
-                  <span
-                    aria-current="false"
-                    class="ouiBreadcrumb"
-                    title="src"
+                  <div
+                    class="ouiBreadcrumbWrapper ouiBreadcrumbWrapper--first"
                   >
-                    src
-                  </span>
-                </span>
-                <span
+                    <span
+                      aria-current="false"
+                      class="ouiBreadcrumb"
+                      title="src"
+                    >
+                      src
+                    </span>
+                  </div>
+                </div>
+                <div
                   class="ouiBreadcrumbWrapper ouiBreadcrumbWrapper--last"
                 >
                   <span
@@ -514,7 +530,7 @@ exports[`OuiControlBar props maxHeight is rendered 1`] = `
                   >
                     components
                   </span>
-                </span>
+                </div>
               </nav>
               <button
                 class="ouiButton ouiButton--ghost ouiButton--small ouiControlBar__button"
@@ -608,20 +624,24 @@ exports[`OuiControlBar props maxHeight is rendered 1`] = `
                 aria-label="breadcrumb"
                 className="ouiBreadcrumbs ouiControlBar__breadcrumbs ouiBreadcrumbs--truncate"
               >
-                <span
-                  className="ouiBreadcrumbWrapper"
+                <div
+                  className="ouiBreadcrumbWall"
                 >
-                  <OuiInnerText>
-                    <span
-                      aria-current="false"
-                      className="ouiBreadcrumb"
-                      title="src"
-                    >
-                      src
-                    </span>
-                  </OuiInnerText>
-                </span>
-                <span
+                  <div
+                    className="ouiBreadcrumbWrapper ouiBreadcrumbWrapper--first"
+                  >
+                    <OuiInnerText>
+                      <span
+                        aria-current="false"
+                        className="ouiBreadcrumb"
+                        title="src"
+                      >
+                        src
+                      </span>
+                    </OuiInnerText>
+                  </div>
+                </div>
+                <div
                   className="ouiBreadcrumbWrapper ouiBreadcrumbWrapper--last"
                 >
                   <OuiInnerText>
@@ -633,7 +653,7 @@ exports[`OuiControlBar props maxHeight is rendered 1`] = `
                       components
                     </span>
                   </OuiInnerText>
-                </span>
+                </div>
               </nav>
             </OuiBreadcrumbs>
             <OuiButton
@@ -824,18 +844,22 @@ exports[`OuiControlBar props mobile is rendered 1`] = `
                 aria-label="breadcrumb"
                 class="ouiBreadcrumbs ouiControlBar__breadcrumbs ouiBreadcrumbs--truncate"
               >
-                <span
-                  class="ouiBreadcrumbWrapper"
+                <div
+                  class="ouiBreadcrumbWall"
                 >
-                  <span
-                    aria-current="false"
-                    class="ouiBreadcrumb"
-                    title="src"
+                  <div
+                    class="ouiBreadcrumbWrapper ouiBreadcrumbWrapper--first"
                   >
-                    src
-                  </span>
-                </span>
-                <span
+                    <span
+                      aria-current="false"
+                      class="ouiBreadcrumb"
+                      title="src"
+                    >
+                      src
+                    </span>
+                  </div>
+                </div>
+                <div
                   class="ouiBreadcrumbWrapper ouiBreadcrumbWrapper--last"
                 >
                   <span
@@ -845,7 +869,7 @@ exports[`OuiControlBar props mobile is rendered 1`] = `
                   >
                     components
                   </span>
-                </span>
+                </div>
               </nav>
               <button
                 class="ouiButton ouiButton--ghost ouiButton--small ouiControlBar__button"
@@ -939,20 +963,24 @@ exports[`OuiControlBar props mobile is rendered 1`] = `
                 aria-label="breadcrumb"
                 className="ouiBreadcrumbs ouiControlBar__breadcrumbs ouiBreadcrumbs--truncate"
               >
-                <span
-                  className="ouiBreadcrumbWrapper"
+                <div
+                  className="ouiBreadcrumbWall"
                 >
-                  <OuiInnerText>
-                    <span
-                      aria-current="false"
-                      className="ouiBreadcrumb"
-                      title="src"
-                    >
-                      src
-                    </span>
-                  </OuiInnerText>
-                </span>
-                <span
+                  <div
+                    className="ouiBreadcrumbWrapper ouiBreadcrumbWrapper--first"
+                  >
+                    <OuiInnerText>
+                      <span
+                        aria-current="false"
+                        className="ouiBreadcrumb"
+                        title="src"
+                      >
+                        src
+                      </span>
+                    </OuiInnerText>
+                  </div>
+                </div>
+                <div
                   className="ouiBreadcrumbWrapper ouiBreadcrumbWrapper--last"
                 >
                   <OuiInnerText>
@@ -964,7 +992,7 @@ exports[`OuiControlBar props mobile is rendered 1`] = `
                       components
                     </span>
                   </OuiInnerText>
-                </span>
+                </div>
               </nav>
             </OuiBreadcrumbs>
             <OuiButton
@@ -1178,20 +1206,24 @@ exports[`OuiControlBar props position is rendered 1`] = `
             aria-label="breadcrumb"
             className="ouiBreadcrumbs ouiControlBar__breadcrumbs ouiBreadcrumbs--truncate"
           >
-            <span
-              className="ouiBreadcrumbWrapper"
+            <div
+              className="ouiBreadcrumbWall"
             >
-              <OuiInnerText>
-                <span
-                  aria-current="false"
-                  className="ouiBreadcrumb"
-                  title="src"
-                >
-                  src
-                </span>
-              </OuiInnerText>
-            </span>
-            <span
+              <div
+                className="ouiBreadcrumbWrapper ouiBreadcrumbWrapper--first"
+              >
+                <OuiInnerText>
+                  <span
+                    aria-current="false"
+                    className="ouiBreadcrumb"
+                    title="src"
+                  >
+                    src
+                  </span>
+                </OuiInnerText>
+              </div>
+            </div>
+            <div
               className="ouiBreadcrumbWrapper ouiBreadcrumbWrapper--last"
             >
               <OuiInnerText>
@@ -1203,7 +1235,7 @@ exports[`OuiControlBar props position is rendered 1`] = `
                   components
                 </span>
               </OuiInnerText>
-            </span>
+            </div>
           </nav>
         </OuiBreadcrumbs>
         <OuiButton
@@ -1379,18 +1411,22 @@ exports[`OuiControlBar props rightOffset is rendered 1`] = `
                 aria-label="breadcrumb"
                 class="ouiBreadcrumbs ouiControlBar__breadcrumbs ouiBreadcrumbs--truncate"
               >
-                <span
-                  class="ouiBreadcrumbWrapper"
+                <div
+                  class="ouiBreadcrumbWall"
                 >
-                  <span
-                    aria-current="false"
-                    class="ouiBreadcrumb"
-                    title="src"
+                  <div
+                    class="ouiBreadcrumbWrapper ouiBreadcrumbWrapper--first"
                   >
-                    src
-                  </span>
-                </span>
-                <span
+                    <span
+                      aria-current="false"
+                      class="ouiBreadcrumb"
+                      title="src"
+                    >
+                      src
+                    </span>
+                  </div>
+                </div>
+                <div
                   class="ouiBreadcrumbWrapper ouiBreadcrumbWrapper--last"
                 >
                   <span
@@ -1400,7 +1436,7 @@ exports[`OuiControlBar props rightOffset is rendered 1`] = `
                   >
                     components
                   </span>
-                </span>
+                </div>
               </nav>
               <button
                 class="ouiButton ouiButton--ghost ouiButton--small ouiControlBar__button"
@@ -1494,20 +1530,24 @@ exports[`OuiControlBar props rightOffset is rendered 1`] = `
                 aria-label="breadcrumb"
                 className="ouiBreadcrumbs ouiControlBar__breadcrumbs ouiBreadcrumbs--truncate"
               >
-                <span
-                  className="ouiBreadcrumbWrapper"
+                <div
+                  className="ouiBreadcrumbWall"
                 >
-                  <OuiInnerText>
-                    <span
-                      aria-current="false"
-                      className="ouiBreadcrumb"
-                      title="src"
-                    >
-                      src
-                    </span>
-                  </OuiInnerText>
-                </span>
-                <span
+                  <div
+                    className="ouiBreadcrumbWrapper ouiBreadcrumbWrapper--first"
+                  >
+                    <OuiInnerText>
+                      <span
+                        aria-current="false"
+                        className="ouiBreadcrumb"
+                        title="src"
+                      >
+                        src
+                      </span>
+                    </OuiInnerText>
+                  </div>
+                </div>
+                <div
                   className="ouiBreadcrumbWrapper ouiBreadcrumbWrapper--last"
                 >
                   <OuiInnerText>
@@ -1519,7 +1559,7 @@ exports[`OuiControlBar props rightOffset is rendered 1`] = `
                       components
                     </span>
                   </OuiInnerText>
-                </span>
+                </div>
               </nav>
             </OuiBreadcrumbs>
             <OuiButton
@@ -1710,18 +1750,22 @@ exports[`OuiControlBar props showContent is rendered 1`] = `
                 aria-label="breadcrumb"
                 class="ouiBreadcrumbs ouiControlBar__breadcrumbs ouiBreadcrumbs--truncate"
               >
-                <span
-                  class="ouiBreadcrumbWrapper"
+                <div
+                  class="ouiBreadcrumbWall"
                 >
-                  <span
-                    aria-current="false"
-                    class="ouiBreadcrumb"
-                    title="src"
+                  <div
+                    class="ouiBreadcrumbWrapper ouiBreadcrumbWrapper--first"
                   >
-                    src
-                  </span>
-                </span>
-                <span
+                    <span
+                      aria-current="false"
+                      class="ouiBreadcrumb"
+                      title="src"
+                    >
+                      src
+                    </span>
+                  </div>
+                </div>
+                <div
                   class="ouiBreadcrumbWrapper ouiBreadcrumbWrapper--last"
                 >
                   <span
@@ -1731,7 +1775,7 @@ exports[`OuiControlBar props showContent is rendered 1`] = `
                   >
                     components
                   </span>
-                </span>
+                </div>
               </nav>
               <button
                 class="ouiButton ouiButton--ghost ouiButton--small ouiControlBar__button"
@@ -1830,20 +1874,24 @@ exports[`OuiControlBar props showContent is rendered 1`] = `
                 aria-label="breadcrumb"
                 className="ouiBreadcrumbs ouiControlBar__breadcrumbs ouiBreadcrumbs--truncate"
               >
-                <span
-                  className="ouiBreadcrumbWrapper"
+                <div
+                  className="ouiBreadcrumbWall"
                 >
-                  <OuiInnerText>
-                    <span
-                      aria-current="false"
-                      className="ouiBreadcrumb"
-                      title="src"
-                    >
-                      src
-                    </span>
-                  </OuiInnerText>
-                </span>
-                <span
+                  <div
+                    className="ouiBreadcrumbWrapper ouiBreadcrumbWrapper--first"
+                  >
+                    <OuiInnerText>
+                      <span
+                        aria-current="false"
+                        className="ouiBreadcrumb"
+                        title="src"
+                      >
+                        src
+                      </span>
+                    </OuiInnerText>
+                  </div>
+                </div>
+                <div
                   className="ouiBreadcrumbWrapper ouiBreadcrumbWrapper--last"
                 >
                   <OuiInnerText>
@@ -1855,7 +1903,7 @@ exports[`OuiControlBar props showContent is rendered 1`] = `
                       components
                     </span>
                   </OuiInnerText>
-                </span>
+                </div>
               </nav>
             </OuiBreadcrumbs>
             <OuiButton
@@ -2051,18 +2099,22 @@ exports[`OuiControlBar props size is rendered 1`] = `
                 aria-label="breadcrumb"
                 class="ouiBreadcrumbs ouiControlBar__breadcrumbs ouiBreadcrumbs--truncate"
               >
-                <span
-                  class="ouiBreadcrumbWrapper"
+                <div
+                  class="ouiBreadcrumbWall"
                 >
-                  <span
-                    aria-current="false"
-                    class="ouiBreadcrumb"
-                    title="src"
+                  <div
+                    class="ouiBreadcrumbWrapper ouiBreadcrumbWrapper--first"
                   >
-                    src
-                  </span>
-                </span>
-                <span
+                    <span
+                      aria-current="false"
+                      class="ouiBreadcrumb"
+                      title="src"
+                    >
+                      src
+                    </span>
+                  </div>
+                </div>
+                <div
                   class="ouiBreadcrumbWrapper ouiBreadcrumbWrapper--last"
                 >
                   <span
@@ -2072,7 +2124,7 @@ exports[`OuiControlBar props size is rendered 1`] = `
                   >
                     components
                   </span>
-                </span>
+                </div>
               </nav>
               <button
                 class="ouiButton ouiButton--ghost ouiButton--small ouiControlBar__button"
@@ -2166,20 +2218,24 @@ exports[`OuiControlBar props size is rendered 1`] = `
                 aria-label="breadcrumb"
                 className="ouiBreadcrumbs ouiControlBar__breadcrumbs ouiBreadcrumbs--truncate"
               >
-                <span
-                  className="ouiBreadcrumbWrapper"
+                <div
+                  className="ouiBreadcrumbWall"
                 >
-                  <OuiInnerText>
-                    <span
-                      aria-current="false"
-                      className="ouiBreadcrumb"
-                      title="src"
-                    >
-                      src
-                    </span>
-                  </OuiInnerText>
-                </span>
-                <span
+                  <div
+                    className="ouiBreadcrumbWrapper ouiBreadcrumbWrapper--first"
+                  >
+                    <OuiInnerText>
+                      <span
+                        aria-current="false"
+                        className="ouiBreadcrumb"
+                        title="src"
+                      >
+                        src
+                      </span>
+                    </OuiInnerText>
+                  </div>
+                </div>
+                <div
                   className="ouiBreadcrumbWrapper ouiBreadcrumbWrapper--last"
                 >
                   <OuiInnerText>
@@ -2191,7 +2247,7 @@ exports[`OuiControlBar props size is rendered 1`] = `
                       components
                     </span>
                   </OuiInnerText>
-                </span>
+                </div>
               </nav>
             </OuiBreadcrumbs>
             <OuiButton

--- a/src/components/control_bar/__snapshots__/control_bar.test.tsx.snap
+++ b/src/components/control_bar/__snapshots__/control_bar.test.tsx.snap
@@ -26,9 +26,6 @@ exports[`OuiControlBar is rendered 1`] = `
       >
         src
       </span>
-      <div
-        class="ouiBreadcrumbSeparator"
-      />
       <span
         aria-current="page"
         class="ouiBreadcrumb ouiBreadcrumb--last"
@@ -163,9 +160,6 @@ exports[`OuiControlBar props leftOffset is rendered 1`] = `
                 >
                   src
                 </span>
-                <div
-                  class="ouiBreadcrumbSeparator"
-                />
                 <span
                   aria-current="page"
                   class="ouiBreadcrumb ouiBreadcrumb--last"
@@ -275,11 +269,6 @@ exports[`OuiControlBar props leftOffset is rendered 1`] = `
                     src
                   </span>
                 </OuiInnerText>
-                <OuiBreadcrumbSeparator>
-                  <div
-                    className="ouiBreadcrumbSeparator"
-                  />
-                </OuiBreadcrumbSeparator>
                 <OuiInnerText>
                   <span
                     aria-current="page"
@@ -487,9 +476,6 @@ exports[`OuiControlBar props maxHeight is rendered 1`] = `
                 >
                   src
                 </span>
-                <div
-                  class="ouiBreadcrumbSeparator"
-                />
                 <span
                   aria-current="page"
                   class="ouiBreadcrumb ouiBreadcrumb--last"
@@ -599,11 +585,6 @@ exports[`OuiControlBar props maxHeight is rendered 1`] = `
                     src
                   </span>
                 </OuiInnerText>
-                <OuiBreadcrumbSeparator>
-                  <div
-                    className="ouiBreadcrumbSeparator"
-                  />
-                </OuiBreadcrumbSeparator>
                 <OuiInnerText>
                   <span
                     aria-current="page"
@@ -810,9 +791,6 @@ exports[`OuiControlBar props mobile is rendered 1`] = `
                 >
                   src
                 </span>
-                <div
-                  class="ouiBreadcrumbSeparator"
-                />
                 <span
                   aria-current="page"
                   class="ouiBreadcrumb ouiBreadcrumb--last"
@@ -922,11 +900,6 @@ exports[`OuiControlBar props mobile is rendered 1`] = `
                     src
                   </span>
                 </OuiInnerText>
-                <OuiBreadcrumbSeparator>
-                  <div
-                    className="ouiBreadcrumbSeparator"
-                  />
-                </OuiBreadcrumbSeparator>
                 <OuiInnerText>
                   <span
                     aria-current="page"
@@ -1158,11 +1131,6 @@ exports[`OuiControlBar props position is rendered 1`] = `
                 src
               </span>
             </OuiInnerText>
-            <OuiBreadcrumbSeparator>
-              <div
-                className="ouiBreadcrumbSeparator"
-              />
-            </OuiBreadcrumbSeparator>
             <OuiInnerText>
               <span
                 aria-current="page"
@@ -1354,9 +1322,6 @@ exports[`OuiControlBar props rightOffset is rendered 1`] = `
                 >
                   src
                 </span>
-                <div
-                  class="ouiBreadcrumbSeparator"
-                />
                 <span
                   aria-current="page"
                   class="ouiBreadcrumb ouiBreadcrumb--last"
@@ -1466,11 +1431,6 @@ exports[`OuiControlBar props rightOffset is rendered 1`] = `
                     src
                   </span>
                 </OuiInnerText>
-                <OuiBreadcrumbSeparator>
-                  <div
-                    className="ouiBreadcrumbSeparator"
-                  />
-                </OuiBreadcrumbSeparator>
                 <OuiInnerText>
                   <span
                     aria-current="page"
@@ -1677,9 +1637,6 @@ exports[`OuiControlBar props showContent is rendered 1`] = `
                 >
                   src
                 </span>
-                <div
-                  class="ouiBreadcrumbSeparator"
-                />
                 <span
                   aria-current="page"
                   class="ouiBreadcrumb ouiBreadcrumb--last"
@@ -1794,11 +1751,6 @@ exports[`OuiControlBar props showContent is rendered 1`] = `
                     src
                   </span>
                 </OuiInnerText>
-                <OuiBreadcrumbSeparator>
-                  <div
-                    className="ouiBreadcrumbSeparator"
-                  />
-                </OuiBreadcrumbSeparator>
                 <OuiInnerText>
                   <span
                     aria-current="page"
@@ -2010,9 +1962,6 @@ exports[`OuiControlBar props size is rendered 1`] = `
                 >
                   src
                 </span>
-                <div
-                  class="ouiBreadcrumbSeparator"
-                />
                 <span
                   aria-current="page"
                   class="ouiBreadcrumb ouiBreadcrumb--last"
@@ -2122,11 +2071,6 @@ exports[`OuiControlBar props size is rendered 1`] = `
                     src
                   </span>
                 </OuiInnerText>
-                <OuiBreadcrumbSeparator>
-                  <div
-                    className="ouiBreadcrumbSeparator"
-                  />
-                </OuiBreadcrumbSeparator>
                 <OuiInnerText>
                   <span
                     aria-current="page"

--- a/src/components/control_bar/__snapshots__/control_bar.test.tsx.snap
+++ b/src/components/control_bar/__snapshots__/control_bar.test.tsx.snap
@@ -276,10 +276,10 @@ exports[`OuiControlBar props leftOffset is rendered 1`] = `
                 aria-label="breadcrumb"
                 className="ouiBreadcrumbs ouiControlBar__breadcrumbs ouiBreadcrumbs--truncate"
               >
-                <OuiInnerText>
-                  <span
-                    className="ouiBreadcrumbWrapper"
-                  >
+                <span
+                  className="ouiBreadcrumbWrapper"
+                >
+                  <OuiInnerText>
                     <span
                       aria-current="false"
                       className="ouiBreadcrumb"
@@ -287,12 +287,12 @@ exports[`OuiControlBar props leftOffset is rendered 1`] = `
                     >
                       src
                     </span>
-                  </span>
-                </OuiInnerText>
-                <OuiInnerText>
-                  <span
-                    className="ouiBreadcrumbWrapper ouiBreadcrumbWrapper--last"
-                  >
+                  </OuiInnerText>
+                </span>
+                <span
+                  className="ouiBreadcrumbWrapper ouiBreadcrumbWrapper--last"
+                >
+                  <OuiInnerText>
                     <span
                       aria-current="page"
                       className="ouiBreadcrumb ouiBreadcrumb--last"
@@ -300,8 +300,8 @@ exports[`OuiControlBar props leftOffset is rendered 1`] = `
                     >
                       components
                     </span>
-                  </span>
-                </OuiInnerText>
+                  </OuiInnerText>
+                </span>
               </nav>
             </OuiBreadcrumbs>
             <OuiButton
@@ -608,10 +608,10 @@ exports[`OuiControlBar props maxHeight is rendered 1`] = `
                 aria-label="breadcrumb"
                 className="ouiBreadcrumbs ouiControlBar__breadcrumbs ouiBreadcrumbs--truncate"
               >
-                <OuiInnerText>
-                  <span
-                    className="ouiBreadcrumbWrapper"
-                  >
+                <span
+                  className="ouiBreadcrumbWrapper"
+                >
+                  <OuiInnerText>
                     <span
                       aria-current="false"
                       className="ouiBreadcrumb"
@@ -619,12 +619,12 @@ exports[`OuiControlBar props maxHeight is rendered 1`] = `
                     >
                       src
                     </span>
-                  </span>
-                </OuiInnerText>
-                <OuiInnerText>
-                  <span
-                    className="ouiBreadcrumbWrapper ouiBreadcrumbWrapper--last"
-                  >
+                  </OuiInnerText>
+                </span>
+                <span
+                  className="ouiBreadcrumbWrapper ouiBreadcrumbWrapper--last"
+                >
+                  <OuiInnerText>
                     <span
                       aria-current="page"
                       className="ouiBreadcrumb ouiBreadcrumb--last"
@@ -632,8 +632,8 @@ exports[`OuiControlBar props maxHeight is rendered 1`] = `
                     >
                       components
                     </span>
-                  </span>
-                </OuiInnerText>
+                  </OuiInnerText>
+                </span>
               </nav>
             </OuiBreadcrumbs>
             <OuiButton
@@ -939,10 +939,10 @@ exports[`OuiControlBar props mobile is rendered 1`] = `
                 aria-label="breadcrumb"
                 className="ouiBreadcrumbs ouiControlBar__breadcrumbs ouiBreadcrumbs--truncate"
               >
-                <OuiInnerText>
-                  <span
-                    className="ouiBreadcrumbWrapper"
-                  >
+                <span
+                  className="ouiBreadcrumbWrapper"
+                >
+                  <OuiInnerText>
                     <span
                       aria-current="false"
                       className="ouiBreadcrumb"
@@ -950,12 +950,12 @@ exports[`OuiControlBar props mobile is rendered 1`] = `
                     >
                       src
                     </span>
-                  </span>
-                </OuiInnerText>
-                <OuiInnerText>
-                  <span
-                    className="ouiBreadcrumbWrapper ouiBreadcrumbWrapper--last"
-                  >
+                  </OuiInnerText>
+                </span>
+                <span
+                  className="ouiBreadcrumbWrapper ouiBreadcrumbWrapper--last"
+                >
+                  <OuiInnerText>
                     <span
                       aria-current="page"
                       className="ouiBreadcrumb ouiBreadcrumb--last"
@@ -963,8 +963,8 @@ exports[`OuiControlBar props mobile is rendered 1`] = `
                     >
                       components
                     </span>
-                  </span>
-                </OuiInnerText>
+                  </OuiInnerText>
+                </span>
               </nav>
             </OuiBreadcrumbs>
             <OuiButton
@@ -1178,10 +1178,10 @@ exports[`OuiControlBar props position is rendered 1`] = `
             aria-label="breadcrumb"
             className="ouiBreadcrumbs ouiControlBar__breadcrumbs ouiBreadcrumbs--truncate"
           >
-            <OuiInnerText>
-              <span
-                className="ouiBreadcrumbWrapper"
-              >
+            <span
+              className="ouiBreadcrumbWrapper"
+            >
+              <OuiInnerText>
                 <span
                   aria-current="false"
                   className="ouiBreadcrumb"
@@ -1189,12 +1189,12 @@ exports[`OuiControlBar props position is rendered 1`] = `
                 >
                   src
                 </span>
-              </span>
-            </OuiInnerText>
-            <OuiInnerText>
-              <span
-                className="ouiBreadcrumbWrapper ouiBreadcrumbWrapper--last"
-              >
+              </OuiInnerText>
+            </span>
+            <span
+              className="ouiBreadcrumbWrapper ouiBreadcrumbWrapper--last"
+            >
+              <OuiInnerText>
                 <span
                   aria-current="page"
                   className="ouiBreadcrumb ouiBreadcrumb--last"
@@ -1202,8 +1202,8 @@ exports[`OuiControlBar props position is rendered 1`] = `
                 >
                   components
                 </span>
-              </span>
-            </OuiInnerText>
+              </OuiInnerText>
+            </span>
           </nav>
         </OuiBreadcrumbs>
         <OuiButton
@@ -1494,10 +1494,10 @@ exports[`OuiControlBar props rightOffset is rendered 1`] = `
                 aria-label="breadcrumb"
                 className="ouiBreadcrumbs ouiControlBar__breadcrumbs ouiBreadcrumbs--truncate"
               >
-                <OuiInnerText>
-                  <span
-                    className="ouiBreadcrumbWrapper"
-                  >
+                <span
+                  className="ouiBreadcrumbWrapper"
+                >
+                  <OuiInnerText>
                     <span
                       aria-current="false"
                       className="ouiBreadcrumb"
@@ -1505,12 +1505,12 @@ exports[`OuiControlBar props rightOffset is rendered 1`] = `
                     >
                       src
                     </span>
-                  </span>
-                </OuiInnerText>
-                <OuiInnerText>
-                  <span
-                    className="ouiBreadcrumbWrapper ouiBreadcrumbWrapper--last"
-                  >
+                  </OuiInnerText>
+                </span>
+                <span
+                  className="ouiBreadcrumbWrapper ouiBreadcrumbWrapper--last"
+                >
+                  <OuiInnerText>
                     <span
                       aria-current="page"
                       className="ouiBreadcrumb ouiBreadcrumb--last"
@@ -1518,8 +1518,8 @@ exports[`OuiControlBar props rightOffset is rendered 1`] = `
                     >
                       components
                     </span>
-                  </span>
-                </OuiInnerText>
+                  </OuiInnerText>
+                </span>
               </nav>
             </OuiBreadcrumbs>
             <OuiButton
@@ -1830,10 +1830,10 @@ exports[`OuiControlBar props showContent is rendered 1`] = `
                 aria-label="breadcrumb"
                 className="ouiBreadcrumbs ouiControlBar__breadcrumbs ouiBreadcrumbs--truncate"
               >
-                <OuiInnerText>
-                  <span
-                    className="ouiBreadcrumbWrapper"
-                  >
+                <span
+                  className="ouiBreadcrumbWrapper"
+                >
+                  <OuiInnerText>
                     <span
                       aria-current="false"
                       className="ouiBreadcrumb"
@@ -1841,12 +1841,12 @@ exports[`OuiControlBar props showContent is rendered 1`] = `
                     >
                       src
                     </span>
-                  </span>
-                </OuiInnerText>
-                <OuiInnerText>
-                  <span
-                    className="ouiBreadcrumbWrapper ouiBreadcrumbWrapper--last"
-                  >
+                  </OuiInnerText>
+                </span>
+                <span
+                  className="ouiBreadcrumbWrapper ouiBreadcrumbWrapper--last"
+                >
+                  <OuiInnerText>
                     <span
                       aria-current="page"
                       className="ouiBreadcrumb ouiBreadcrumb--last"
@@ -1854,8 +1854,8 @@ exports[`OuiControlBar props showContent is rendered 1`] = `
                     >
                       components
                     </span>
-                  </span>
-                </OuiInnerText>
+                  </OuiInnerText>
+                </span>
               </nav>
             </OuiBreadcrumbs>
             <OuiButton
@@ -2166,10 +2166,10 @@ exports[`OuiControlBar props size is rendered 1`] = `
                 aria-label="breadcrumb"
                 className="ouiBreadcrumbs ouiControlBar__breadcrumbs ouiBreadcrumbs--truncate"
               >
-                <OuiInnerText>
-                  <span
-                    className="ouiBreadcrumbWrapper"
-                  >
+                <span
+                  className="ouiBreadcrumbWrapper"
+                >
+                  <OuiInnerText>
                     <span
                       aria-current="false"
                       className="ouiBreadcrumb"
@@ -2177,12 +2177,12 @@ exports[`OuiControlBar props size is rendered 1`] = `
                     >
                       src
                     </span>
-                  </span>
-                </OuiInnerText>
-                <OuiInnerText>
-                  <span
-                    className="ouiBreadcrumbWrapper ouiBreadcrumbWrapper--last"
-                  >
+                  </OuiInnerText>
+                </span>
+                <span
+                  className="ouiBreadcrumbWrapper ouiBreadcrumbWrapper--last"
+                >
+                  <OuiInnerText>
                     <span
                       aria-current="page"
                       className="ouiBreadcrumb ouiBreadcrumb--last"
@@ -2190,8 +2190,8 @@ exports[`OuiControlBar props size is rendered 1`] = `
                     >
                       components
                     </span>
-                  </span>
-                </OuiInnerText>
+                  </OuiInnerText>
+                </span>
               </nav>
             </OuiBreadcrumbs>
             <OuiButton

--- a/src/components/control_bar/__snapshots__/control_bar.test.tsx.snap
+++ b/src/components/control_bar/__snapshots__/control_bar.test.tsx.snap
@@ -20,18 +20,26 @@ exports[`OuiControlBar is rendered 1`] = `
       class="ouiBreadcrumbs ouiControlBar__breadcrumbs ouiBreadcrumbs--truncate"
     >
       <span
-        aria-current="false"
-        class="ouiBreadcrumb"
-        title="src"
+        class="ouiBreadcrumbWrapper"
       >
-        src
+        <span
+          aria-current="false"
+          class="ouiBreadcrumb"
+          title="src"
+        >
+          src
+        </span>
       </span>
       <span
-        aria-current="page"
-        class="ouiBreadcrumb ouiBreadcrumb--last"
-        title="components"
+        class="ouiBreadcrumbWrapper ouiBreadcrumbWrapper--last"
       >
-        components
+        <span
+          aria-current="page"
+          class="ouiBreadcrumb ouiBreadcrumb--last"
+          title="components"
+        >
+          components
+        </span>
       </span>
     </nav>
     <button
@@ -154,18 +162,26 @@ exports[`OuiControlBar props leftOffset is rendered 1`] = `
                 class="ouiBreadcrumbs ouiControlBar__breadcrumbs ouiBreadcrumbs--truncate"
               >
                 <span
-                  aria-current="false"
-                  class="ouiBreadcrumb"
-                  title="src"
+                  class="ouiBreadcrumbWrapper"
                 >
-                  src
+                  <span
+                    aria-current="false"
+                    class="ouiBreadcrumb"
+                    title="src"
+                  >
+                    src
+                  </span>
                 </span>
                 <span
-                  aria-current="page"
-                  class="ouiBreadcrumb ouiBreadcrumb--last"
-                  title="components"
+                  class="ouiBreadcrumbWrapper ouiBreadcrumbWrapper--last"
                 >
-                  components
+                  <span
+                    aria-current="page"
+                    class="ouiBreadcrumb ouiBreadcrumb--last"
+                    title="components"
+                  >
+                    components
+                  </span>
                 </span>
               </nav>
               <button
@@ -262,20 +278,28 @@ exports[`OuiControlBar props leftOffset is rendered 1`] = `
               >
                 <OuiInnerText>
                   <span
-                    aria-current="false"
-                    className="ouiBreadcrumb"
-                    title="src"
+                    className="ouiBreadcrumbWrapper"
                   >
-                    src
+                    <span
+                      aria-current="false"
+                      className="ouiBreadcrumb"
+                      title="src"
+                    >
+                      src
+                    </span>
                   </span>
                 </OuiInnerText>
                 <OuiInnerText>
                   <span
-                    aria-current="page"
-                    className="ouiBreadcrumb ouiBreadcrumb--last"
-                    title="components"
+                    className="ouiBreadcrumbWrapper ouiBreadcrumbWrapper--last"
                   >
-                    components
+                    <span
+                      aria-current="page"
+                      className="ouiBreadcrumb ouiBreadcrumb--last"
+                      title="components"
+                    >
+                      components
+                    </span>
                   </span>
                 </OuiInnerText>
               </nav>
@@ -470,18 +494,26 @@ exports[`OuiControlBar props maxHeight is rendered 1`] = `
                 class="ouiBreadcrumbs ouiControlBar__breadcrumbs ouiBreadcrumbs--truncate"
               >
                 <span
-                  aria-current="false"
-                  class="ouiBreadcrumb"
-                  title="src"
+                  class="ouiBreadcrumbWrapper"
                 >
-                  src
+                  <span
+                    aria-current="false"
+                    class="ouiBreadcrumb"
+                    title="src"
+                  >
+                    src
+                  </span>
                 </span>
                 <span
-                  aria-current="page"
-                  class="ouiBreadcrumb ouiBreadcrumb--last"
-                  title="components"
+                  class="ouiBreadcrumbWrapper ouiBreadcrumbWrapper--last"
                 >
-                  components
+                  <span
+                    aria-current="page"
+                    class="ouiBreadcrumb ouiBreadcrumb--last"
+                    title="components"
+                  >
+                    components
+                  </span>
                 </span>
               </nav>
               <button
@@ -578,20 +610,28 @@ exports[`OuiControlBar props maxHeight is rendered 1`] = `
               >
                 <OuiInnerText>
                   <span
-                    aria-current="false"
-                    className="ouiBreadcrumb"
-                    title="src"
+                    className="ouiBreadcrumbWrapper"
                   >
-                    src
+                    <span
+                      aria-current="false"
+                      className="ouiBreadcrumb"
+                      title="src"
+                    >
+                      src
+                    </span>
                   </span>
                 </OuiInnerText>
                 <OuiInnerText>
                   <span
-                    aria-current="page"
-                    className="ouiBreadcrumb ouiBreadcrumb--last"
-                    title="components"
+                    className="ouiBreadcrumbWrapper ouiBreadcrumbWrapper--last"
                   >
-                    components
+                    <span
+                      aria-current="page"
+                      className="ouiBreadcrumb ouiBreadcrumb--last"
+                      title="components"
+                    >
+                      components
+                    </span>
                   </span>
                 </OuiInnerText>
               </nav>
@@ -785,18 +825,26 @@ exports[`OuiControlBar props mobile is rendered 1`] = `
                 class="ouiBreadcrumbs ouiControlBar__breadcrumbs ouiBreadcrumbs--truncate"
               >
                 <span
-                  aria-current="false"
-                  class="ouiBreadcrumb"
-                  title="src"
+                  class="ouiBreadcrumbWrapper"
                 >
-                  src
+                  <span
+                    aria-current="false"
+                    class="ouiBreadcrumb"
+                    title="src"
+                  >
+                    src
+                  </span>
                 </span>
                 <span
-                  aria-current="page"
-                  class="ouiBreadcrumb ouiBreadcrumb--last"
-                  title="components"
+                  class="ouiBreadcrumbWrapper ouiBreadcrumbWrapper--last"
                 >
-                  components
+                  <span
+                    aria-current="page"
+                    class="ouiBreadcrumb ouiBreadcrumb--last"
+                    title="components"
+                  >
+                    components
+                  </span>
                 </span>
               </nav>
               <button
@@ -893,20 +941,28 @@ exports[`OuiControlBar props mobile is rendered 1`] = `
               >
                 <OuiInnerText>
                   <span
-                    aria-current="false"
-                    className="ouiBreadcrumb"
-                    title="src"
+                    className="ouiBreadcrumbWrapper"
                   >
-                    src
+                    <span
+                      aria-current="false"
+                      className="ouiBreadcrumb"
+                      title="src"
+                    >
+                      src
+                    </span>
                   </span>
                 </OuiInnerText>
                 <OuiInnerText>
                   <span
-                    aria-current="page"
-                    className="ouiBreadcrumb ouiBreadcrumb--last"
-                    title="components"
+                    className="ouiBreadcrumbWrapper ouiBreadcrumbWrapper--last"
                   >
-                    components
+                    <span
+                      aria-current="page"
+                      className="ouiBreadcrumb ouiBreadcrumb--last"
+                      title="components"
+                    >
+                      components
+                    </span>
                   </span>
                 </OuiInnerText>
               </nav>
@@ -1124,20 +1180,28 @@ exports[`OuiControlBar props position is rendered 1`] = `
           >
             <OuiInnerText>
               <span
-                aria-current="false"
-                className="ouiBreadcrumb"
-                title="src"
+                className="ouiBreadcrumbWrapper"
               >
-                src
+                <span
+                  aria-current="false"
+                  className="ouiBreadcrumb"
+                  title="src"
+                >
+                  src
+                </span>
               </span>
             </OuiInnerText>
             <OuiInnerText>
               <span
-                aria-current="page"
-                className="ouiBreadcrumb ouiBreadcrumb--last"
-                title="components"
+                className="ouiBreadcrumbWrapper ouiBreadcrumbWrapper--last"
               >
-                components
+                <span
+                  aria-current="page"
+                  className="ouiBreadcrumb ouiBreadcrumb--last"
+                  title="components"
+                >
+                  components
+                </span>
               </span>
             </OuiInnerText>
           </nav>
@@ -1316,18 +1380,26 @@ exports[`OuiControlBar props rightOffset is rendered 1`] = `
                 class="ouiBreadcrumbs ouiControlBar__breadcrumbs ouiBreadcrumbs--truncate"
               >
                 <span
-                  aria-current="false"
-                  class="ouiBreadcrumb"
-                  title="src"
+                  class="ouiBreadcrumbWrapper"
                 >
-                  src
+                  <span
+                    aria-current="false"
+                    class="ouiBreadcrumb"
+                    title="src"
+                  >
+                    src
+                  </span>
                 </span>
                 <span
-                  aria-current="page"
-                  class="ouiBreadcrumb ouiBreadcrumb--last"
-                  title="components"
+                  class="ouiBreadcrumbWrapper ouiBreadcrumbWrapper--last"
                 >
-                  components
+                  <span
+                    aria-current="page"
+                    class="ouiBreadcrumb ouiBreadcrumb--last"
+                    title="components"
+                  >
+                    components
+                  </span>
                 </span>
               </nav>
               <button
@@ -1424,20 +1496,28 @@ exports[`OuiControlBar props rightOffset is rendered 1`] = `
               >
                 <OuiInnerText>
                   <span
-                    aria-current="false"
-                    className="ouiBreadcrumb"
-                    title="src"
+                    className="ouiBreadcrumbWrapper"
                   >
-                    src
+                    <span
+                      aria-current="false"
+                      className="ouiBreadcrumb"
+                      title="src"
+                    >
+                      src
+                    </span>
                   </span>
                 </OuiInnerText>
                 <OuiInnerText>
                   <span
-                    aria-current="page"
-                    className="ouiBreadcrumb ouiBreadcrumb--last"
-                    title="components"
+                    className="ouiBreadcrumbWrapper ouiBreadcrumbWrapper--last"
                   >
-                    components
+                    <span
+                      aria-current="page"
+                      className="ouiBreadcrumb ouiBreadcrumb--last"
+                      title="components"
+                    >
+                      components
+                    </span>
                   </span>
                 </OuiInnerText>
               </nav>
@@ -1631,18 +1711,26 @@ exports[`OuiControlBar props showContent is rendered 1`] = `
                 class="ouiBreadcrumbs ouiControlBar__breadcrumbs ouiBreadcrumbs--truncate"
               >
                 <span
-                  aria-current="false"
-                  class="ouiBreadcrumb"
-                  title="src"
+                  class="ouiBreadcrumbWrapper"
                 >
-                  src
+                  <span
+                    aria-current="false"
+                    class="ouiBreadcrumb"
+                    title="src"
+                  >
+                    src
+                  </span>
                 </span>
                 <span
-                  aria-current="page"
-                  class="ouiBreadcrumb ouiBreadcrumb--last"
-                  title="components"
+                  class="ouiBreadcrumbWrapper ouiBreadcrumbWrapper--last"
                 >
-                  components
+                  <span
+                    aria-current="page"
+                    class="ouiBreadcrumb ouiBreadcrumb--last"
+                    title="components"
+                  >
+                    components
+                  </span>
                 </span>
               </nav>
               <button
@@ -1744,20 +1832,28 @@ exports[`OuiControlBar props showContent is rendered 1`] = `
               >
                 <OuiInnerText>
                   <span
-                    aria-current="false"
-                    className="ouiBreadcrumb"
-                    title="src"
+                    className="ouiBreadcrumbWrapper"
                   >
-                    src
+                    <span
+                      aria-current="false"
+                      className="ouiBreadcrumb"
+                      title="src"
+                    >
+                      src
+                    </span>
                   </span>
                 </OuiInnerText>
                 <OuiInnerText>
                   <span
-                    aria-current="page"
-                    className="ouiBreadcrumb ouiBreadcrumb--last"
-                    title="components"
+                    className="ouiBreadcrumbWrapper ouiBreadcrumbWrapper--last"
                   >
-                    components
+                    <span
+                      aria-current="page"
+                      className="ouiBreadcrumb ouiBreadcrumb--last"
+                      title="components"
+                    >
+                      components
+                    </span>
                   </span>
                 </OuiInnerText>
               </nav>
@@ -1956,18 +2052,26 @@ exports[`OuiControlBar props size is rendered 1`] = `
                 class="ouiBreadcrumbs ouiControlBar__breadcrumbs ouiBreadcrumbs--truncate"
               >
                 <span
-                  aria-current="false"
-                  class="ouiBreadcrumb"
-                  title="src"
+                  class="ouiBreadcrumbWrapper"
                 >
-                  src
+                  <span
+                    aria-current="false"
+                    class="ouiBreadcrumb"
+                    title="src"
+                  >
+                    src
+                  </span>
                 </span>
                 <span
-                  aria-current="page"
-                  class="ouiBreadcrumb ouiBreadcrumb--last"
-                  title="components"
+                  class="ouiBreadcrumbWrapper ouiBreadcrumbWrapper--last"
                 >
-                  components
+                  <span
+                    aria-current="page"
+                    class="ouiBreadcrumb ouiBreadcrumb--last"
+                    title="components"
+                  >
+                    components
+                  </span>
                 </span>
               </nav>
               <button
@@ -2064,20 +2168,28 @@ exports[`OuiControlBar props size is rendered 1`] = `
               >
                 <OuiInnerText>
                   <span
-                    aria-current="false"
-                    className="ouiBreadcrumb"
-                    title="src"
+                    className="ouiBreadcrumbWrapper"
                   >
-                    src
+                    <span
+                      aria-current="false"
+                      className="ouiBreadcrumb"
+                      title="src"
+                    >
+                      src
+                    </span>
                   </span>
                 </OuiInnerText>
                 <OuiInnerText>
                   <span
-                    aria-current="page"
-                    className="ouiBreadcrumb ouiBreadcrumb--last"
-                    title="components"
+                    className="ouiBreadcrumbWrapper ouiBreadcrumbWrapper--last"
                   >
-                    components
+                    <span
+                      aria-current="page"
+                      className="ouiBreadcrumb ouiBreadcrumb--last"
+                      title="components"
+                    >
+                      components
+                    </span>
                   </span>
                 </OuiInnerText>
               </nav>

--- a/src/components/header/__snapshots__/header.test.tsx.snap
+++ b/src/components/header/__snapshots__/header.test.tsx.snap
@@ -42,16 +42,20 @@ exports[`OuiHeader sections render breadcrumbs and props 1`] = `
     aria-label="breadcrumb"
     class="ouiBreadcrumbs ouiHeaderBreadcrumbs ouiBreadcrumbs--truncate"
   >
-    <span
-      class="ouiBreadcrumbWrapper ouiBreadcrumbWrapper--last"
+    <div
+      class="ouiBreadcrumbWall"
     >
-      <span
-        aria-current="page"
-        class="ouiBreadcrumb ouiBreadcrumb--last"
+      <div
+        class="ouiBreadcrumbWrapper ouiBreadcrumbWrapper--first ouiBreadcrumbWrapper--last"
       >
-        Breadcrumb
-      </span>
-    </span>
+        <span
+          aria-current="page"
+          class="ouiBreadcrumb ouiBreadcrumb--last"
+        >
+          Breadcrumb
+        </span>
+      </div>
+    </div>
   </nav>
 </div>
 `;

--- a/src/components/header/__snapshots__/header.test.tsx.snap
+++ b/src/components/header/__snapshots__/header.test.tsx.snap
@@ -43,10 +43,14 @@ exports[`OuiHeader sections render breadcrumbs and props 1`] = `
     class="ouiBreadcrumbs ouiHeaderBreadcrumbs ouiBreadcrumbs--truncate"
   >
     <span
-      aria-current="page"
-      class="ouiBreadcrumb ouiBreadcrumb--last"
+      class="ouiBreadcrumbWrapper ouiBreadcrumbWrapper--last"
     >
-      Breadcrumb
+      <span
+        aria-current="page"
+        class="ouiBreadcrumb ouiBreadcrumb--last"
+      >
+        Breadcrumb
+      </span>
     </span>
   </nav>
 </div>

--- a/src/components/header/header_breadcrumbs/__snapshots__/header_breadcrumbs.test.tsx.snap
+++ b/src/components/header/header_breadcrumbs/__snapshots__/header_breadcrumbs.test.tsx.snap
@@ -14,18 +14,12 @@ exports[`OuiHeaderBreadcrumbs is rendered 1`] = `
   >
     Animals
   </a>
-  <div
-    class="ouiBreadcrumbSeparator"
-  />
   <button
     class="ouiLink ouiLink--subdued ouiBreadcrumb"
     type="button"
   >
     Reptiles
   </button>
-  <div
-    class="ouiBreadcrumbSeparator"
-  />
   <a
     class="ouiLink ouiLink--subdued ouiBreadcrumb"
     href="#"
@@ -33,9 +27,6 @@ exports[`OuiHeaderBreadcrumbs is rendered 1`] = `
   >
     Boa constrictor
   </a>
-  <div
-    class="ouiBreadcrumbSeparator"
-  />
   <span
     aria-current="page"
     class="ouiBreadcrumb ouiBreadcrumb--last"

--- a/src/components/header/header_breadcrumbs/__snapshots__/header_breadcrumbs.test.tsx.snap
+++ b/src/components/header/header_breadcrumbs/__snapshots__/header_breadcrumbs.test.tsx.snap
@@ -6,19 +6,23 @@ exports[`OuiHeaderBreadcrumbs is rendered 1`] = `
   class="ouiBreadcrumbs ouiHeaderBreadcrumbs testClass1 testClass2 ouiBreadcrumbs--truncate"
   data-test-subj="test subject string"
 >
-  <span
-    class="ouiBreadcrumbWrapper"
+  <div
+    class="ouiBreadcrumbWall"
   >
-    <a
-      class="ouiLink ouiLink--subdued ouiBreadcrumb customClass"
-      data-test-subj="breadcrumbsAnimals"
-      href="#"
-      rel="noreferrer"
+    <div
+      class="ouiBreadcrumbWrapper ouiBreadcrumbWrapper--first"
     >
-      Animals
-    </a>
-  </span>
-  <span
+      <a
+        class="ouiLink ouiLink--subdued ouiBreadcrumb customClass"
+        data-test-subj="breadcrumbsAnimals"
+        href="#"
+        rel="noreferrer"
+      >
+        Animals
+      </a>
+    </div>
+  </div>
+  <div
     class="ouiBreadcrumbWrapper"
   >
     <button
@@ -27,8 +31,8 @@ exports[`OuiHeaderBreadcrumbs is rendered 1`] = `
     >
       Reptiles
     </button>
-  </span>
-  <span
+  </div>
+  <div
     class="ouiBreadcrumbWrapper"
   >
     <a
@@ -38,8 +42,8 @@ exports[`OuiHeaderBreadcrumbs is rendered 1`] = `
     >
       Boa constrictor
     </a>
-  </span>
-  <span
+  </div>
+  <div
     class="ouiBreadcrumbWrapper ouiBreadcrumbWrapper--last"
   >
     <span
@@ -48,6 +52,6 @@ exports[`OuiHeaderBreadcrumbs is rendered 1`] = `
     >
       Edit
     </span>
-  </span>
+  </div>
 </nav>
 `;

--- a/src/components/header/header_breadcrumbs/__snapshots__/header_breadcrumbs.test.tsx.snap
+++ b/src/components/header/header_breadcrumbs/__snapshots__/header_breadcrumbs.test.tsx.snap
@@ -6,32 +6,48 @@ exports[`OuiHeaderBreadcrumbs is rendered 1`] = `
   class="ouiBreadcrumbs ouiHeaderBreadcrumbs testClass1 testClass2 ouiBreadcrumbs--truncate"
   data-test-subj="test subject string"
 >
-  <a
-    class="ouiLink ouiLink--subdued ouiBreadcrumb customClass"
-    data-test-subj="breadcrumbsAnimals"
-    href="#"
-    rel="noreferrer"
-  >
-    Animals
-  </a>
-  <button
-    class="ouiLink ouiLink--subdued ouiBreadcrumb"
-    type="button"
-  >
-    Reptiles
-  </button>
-  <a
-    class="ouiLink ouiLink--subdued ouiBreadcrumb"
-    href="#"
-    rel="noreferrer"
-  >
-    Boa constrictor
-  </a>
   <span
-    aria-current="page"
-    class="ouiBreadcrumb ouiBreadcrumb--last"
+    class="ouiBreadcrumbWrapper"
   >
-    Edit
+    <a
+      class="ouiLink ouiLink--subdued ouiBreadcrumb customClass"
+      data-test-subj="breadcrumbsAnimals"
+      href="#"
+      rel="noreferrer"
+    >
+      Animals
+    </a>
+  </span>
+  <span
+    class="ouiBreadcrumbWrapper"
+  >
+    <button
+      class="ouiLink ouiLink--subdued ouiBreadcrumb"
+      type="button"
+    >
+      Reptiles
+    </button>
+  </span>
+  <span
+    class="ouiBreadcrumbWrapper"
+  >
+    <a
+      class="ouiLink ouiLink--subdued ouiBreadcrumb"
+      href="#"
+      rel="noreferrer"
+    >
+      Boa constrictor
+    </a>
+  </span>
+  <span
+    class="ouiBreadcrumbWrapper ouiBreadcrumbWrapper--last"
+  >
+    <span
+      aria-current="page"
+      class="ouiBreadcrumb ouiBreadcrumb--last"
+    >
+      Edit
+    </span>
   </span>
 </nav>
 `;

--- a/src/themes/oui/oui_colors_dark.scss
+++ b/src/themes/oui/oui_colors_dark.scss
@@ -62,6 +62,12 @@ $ouiColorChartBand: tint($ouiColorLightestShade, 2.5%);
 $ouiShadowColor: #000;
 $ouiShadowColorLarge: #000;
 
+// Breadcrumbs
+$ouiBreadcrumbBlueBackground: #163F66;
+$ouiBreadcrumbGrayBackground: #4C636F;
+$ouiBreadcrumbCollapsedLink: #FFF;
+$ouiBreadCrumbHoverColor: #B0B8BB;
+
 
 /* OUI -> EUI Aliases */
 $euiColorGhost: $ouiColorGhost;
@@ -97,4 +103,8 @@ $euiColorChartLines: $ouiColorChartLines;
 $euiColorChartBand: $ouiColorChartBand;
 $euiShadowColor: $ouiShadowColor;
 $euiShadowColorLarge: $ouiShadowColorLarge;
+$euiBreadcrumbBlueBackground: $ouiBreadcrumbBlueBackground;
+$euiBreadcrumbGrayBackground: $ouiBreadcrumbGrayBackground;
+$euiBreadcrumbCollapsedLink: $ouiBreadcrumbCollapsedLink;
+$euiBreadCrumbHoverColor: $ouiBreadCrumbHoverColor;
 /* End of Aliases */


### PR DESCRIPTION
### Description
Migrate breadcrumb style to OUI

![2022-11-21 10_05_03-Breadcrumbs - OpenSearch UI Framework](https://user-images.githubusercontent.com/6763209/203128282-addc0788-ac98-496b-9767-7d2122e1e603.png)
 
### Issues Resolved
#22 
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [x] All tests pass
  - [x] `yarn lint`
  - [x] `yarn test-unit`
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/oui/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
