### PR TITLE
Add release workflows

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,0 +1,18 @@
+name: Draft a release
+
+on:
+  push:
+    tags:
+      - "*"
+
+jobs:
+  draft_release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Release
+        uses: softprops/action-gh-release@v1
+        with:
+          draft: true
+          generate_release_notes: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # OUI
-## [`master`](https://github.com/opensearch-project/oui/tree/master)
+## [`main`](https://github.com/opensearch-project/oui/tree/main)
+
+- Add release workflows ([134](https://github.com/opensearch-project/oui/pull/133))
 
 ## [`1.0.0`](https://github.com/opensearch-project/oui/tree/1.0.0)
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,40 @@
+- [Overview](#overview)
+- [Branching](#branching)
+  - [Release Branching](#release-branching)
+  - [Feature Branches](#feature-branches)
+- [Release Labels](#release-labels)
+- [Releasing](#releasing)
+
+## Overview
+
+This document explains the release strategy for artifacts in this organization.
+
+## Branching
+
+### Release Branching
+
+Given the current major release of 1.0, projects in this organization maintain the following active branches.
+
+- **main**: The next _major_ release. This is the branch where all merges take place and code moves fast.
+- **1.x**: The next _minor_ release. Once a change is merged into `main`, decide whether to backport it to `1.x`.
+- **1.0**: The _current_ release. In between minor releases, only hotfixes (e.g. security) are backported to `1.0`.
+
+Label PRs with the next major version label (e.g. `2.0.0`) and merge changes into `main`. Label PRs that you believe need to be backported as `1.x` and `1.0`. Backport PRs by checking out the versioned branch, cherry-pick changes and open a PR against each target backport branch.
+
+### Feature Branches
+
+Do not create branches in the upstream repo, use your fork, for the exception of long lasting feature branches that require active collaboration from multiple developers. Name feature branches `feature/<thing>`. Once the work is merged to `main`, please make sure to delete the feature branch.
+
+## Release Labels
+
+Repositories create consistent release labels, such as `v1.0.0`, `v1.1.0` and `v2.0.0`, as well as `patch` and `backport`. Use release labels to target an issue or a PR for a given release.
+
+## Releasing
+
+The release process is standard across repositories in this org and is run by a release manager volunteering from amongst [maintainers](MAINTAINERS.md).
+
+1. Create a tag, e.g. v2.1.0, and push it to the GitHub repo.
+1. The [release-drafter.yml](.github/workflows/release-drafter.yml) will be automatically kicked off and a draft release will be created.
+1. This draft release triggers the [jenkins release workflow](https://build.ci.opensearch.org/job/oui-release/) as a result of which OUI is released on [npmjs](https://www.npmjs.com/package/@opensearch-project/oui).
+1. Once the above release workflow is successful, the drafted release on GitHub is published automatically.
+1. Increment "version" in package.json to the next patch release, e.g. v2.1.1. See [example](https://github.com/opensearch-project/opensearch-js/pull/318)

--- a/jenkins/release.JenkinsFile
+++ b/jenkins/release.JenkinsFile
@@ -1,0 +1,11 @@
+lib = library(identifier: 'jenkins@1.1.1', retriever: modernSCM([
+    $class: 'GitSCMSource',
+    remote: 'https://github.com/opensearch-project/opensearch-build-libraries.git',
+]))
+
+standardReleasePipelineWithGenericTrigger(
+    tokenIdCredential: 'jenkins-opensearch-js-generic-webhook-token',
+    causeString: 'A tag was cut on opensearch-project/opensearch-js repository causing this workflow to run',
+    publishRelease: true) {
+        publishToNpm(repository: 'https://github.com/opensearch-project/opensearch-js', tag: "$tag")
+    }

--- a/jenkins/release.JenkinsFile
+++ b/jenkins/release.JenkinsFile
@@ -5,7 +5,7 @@ lib = library(identifier: 'jenkins@1.1.1', retriever: modernSCM([
 
 standardReleasePipelineWithGenericTrigger(
     tokenIdCredential: 'jenkins-opensearch-js-generic-webhook-token',
-    causeString: 'A tag was cut on opensearch-project/opensearch-js repository causing this workflow to run',
+    causeString: 'A tag was cut on opensearch-project/oui repository causing this workflow to run',
     publishRelease: true) {
-        publishToNpm(repository: 'https://github.com/opensearch-project/opensearch-js', tag: "$tag")
+        publishToNpm(repository: 'https://github.com/gaiksaya/oui', tag: "$tag")
     }

--- a/jenkins/release.JenkinsFile
+++ b/jenkins/release.JenkinsFile
@@ -4,8 +4,8 @@ lib = library(identifier: 'jenkins@1.1.1', retriever: modernSCM([
 ]))
 
 standardReleasePipelineWithGenericTrigger(
-    tokenIdCredential: 'jenkins-opensearch-js-generic-webhook-token',
+    tokenIdCredential: 'jenkins-oui-generic-webhook-token',
     causeString: 'A tag was cut on opensearch-project/oui repository causing this workflow to run',
     publishRelease: true) {
-        publishToNpm(repository: 'https://github.com/gaiksaya/oui', tag: "$tag")
+        publishToNpm(repository: 'https://github.com/opensearch-project/oui', tag: "$tag")
     }

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "sayali-test-oui",
+  "name": "@opensearch-project/oui",
   "description": "OpenSearch UI Component Library",
   "version": "1.0.0",
   "license": "Apache-2.0",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@opensearch-project/oui",
+  "name": "sayali-test-oui",
   "description": "OpenSearch UI Component Library",
   "version": "1.0.0",
   "license": "Apache-2.0",


### PR DESCRIPTION
### Description
This change adds release workflows to publish OUI on https://www.npmjs.com/
Please see https://github.com/opensearch-project/opensearch-build/issues/1234 for design details of end to end workflow.

TL;DR:
When a tag is pushed to this repository, it will generate a draft release. The draft release will trigger the jenkins job (see Files Changed for attached jenkins file) that publishes the client to npmjs. Once the release is successful, the drafted release is published on GitHub.
 
### Issues Resolved
https://github.com/opensearch-project/opensearch-build/issues/2900
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] All tests pass
  - [ ] `yarn lint`
  - [ ] `yarn test-unit`
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/oui/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
