### PR TITLE
Bump qs from 6.5.3 to 6.11.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,7 +72,8 @@
     "**/eslint": "^7.10.0",
     "**/har-validator": "^5.1.5",
     "**/d3-color": "^3.1.0",
-    "**/@miksu/prettier/minimatch": "^3.0.8"
+    "**/@miksu/prettier/minimatch": "^3.0.8",
+    "**/request/qs": "^6.11.0"
   },
   "pre-commit": [
     "test-staged"

--- a/yarn.lock
+++ b/yarn.lock
@@ -13073,17 +13073,12 @@ q@^1.1.2:
   resolved "https://registry.yarnpkg.com/q/-/q-1.5.1.tgz#7e32f75b41381291d04611f1bf14109ac00651d7"
   integrity sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc=
 
-qs@6.11.0:
+qs@6.11.0, qs@^6.11.0, qs@~6.5.2:
   version "6.11.0"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.11.0.tgz#fd0d963446f7a65e1367e01abd85429453f0c37a"
   integrity sha512-MvjoMCJwEarSbUYk5O+nmoSzSutSsTwF85zcHPQ9OrlFoZOYIjaqBAJIqIXjptyD5vThxGq52Xu/MaJzRkIk4Q==
   dependencies:
     side-channel "^1.0.4"
-
-qs@~6.5.2:
-  version "6.5.3"
-  resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.3.tgz#3aeeffc91967ef6e35c0e488ef46fb296ab76aad"
-  integrity sha512-qxXIEh4pCGfHICj1mAJQ2/2XVZkjCDTcEgfoSQxc/fYivUZxTkk7L3bDBJSoNrEzXI17oUO5Dp07ktqE5KzczA==
 
 query-ast@^1.0.1, query-ast@^1.0.2:
   version "1.0.3"


### PR DESCRIPTION
### Description
Patch bump qs from 6.5.3 to 6.11.0
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [x] All tests pass
  - [x] `yarn lint`
  - [x] `yarn test-unit`
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/oui/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
