### PR TITLE
Update ramda from 0.25.0 to 0.27.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,7 +73,8 @@
     "**/har-validator": "^5.1.5",
     "**/d3-color": "^3.1.0",
     "**/@miksu/prettier/minimatch": "^3.0.8",
-    "**/request/qs": "^6.11.0"
+    "**/request/qs": "^6.11.0",
+    "nodegit/ramda": "^0.27.1"
   },
   "pre-commit": [
     "test-staged"

--- a/yarn.lock
+++ b/yarn.lock
@@ -13128,12 +13128,7 @@ railroad-diagrams@^1.0.0:
   resolved "https://registry.yarnpkg.com/railroad-diagrams/-/railroad-diagrams-1.0.0.tgz#eb7e6267548ddedfb899c1b90e57374559cddb7e"
   integrity sha1-635iZ1SN3t+4mcG5Dlc3RVnN234=
 
-ramda@^0.25.0:
-  version "0.25.0"
-  resolved "https://registry.yarnpkg.com/ramda/-/ramda-0.25.0.tgz#8fdf68231cffa90bc2f9460390a0cb74a29b29a9"
-  integrity sha512-GXpfrYVPwx3K7RQ6aYT8KPS8XViSXUVJT1ONhoKPE9VAleW42YE+U+8VEyGWt41EnEQW7gwecYJriTI0pKoecQ==
-
-ramda@^0.27.1:
+ramda@^0.25.0, ramda@^0.27.1:
   version "0.27.1"
   resolved "https://registry.yarnpkg.com/ramda/-/ramda-0.27.1.tgz#66fc2df3ef873874ffc2da6aa8984658abacf5c9"
   integrity sha512-PgIdVpn5y5Yns8vqb8FzBUEYn98V3xcPgawAkkgj0YJ0qDsnHCiNmZYfOGMgOvoB0eWFLpYbhxUR3mxfDIMvpw==


### PR DESCRIPTION
Signed-off-by: Matt Provost <provomat@amazon.com>

### Description
Update ramda from 0.25.0 to 0.27.1
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [x] All tests pass
  - [x] `yarn lint`
  - [x] `yarn test-unit`
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/oui/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
