### PR TITLE
[OUI Button]Changed the references of elastic.co to opensearch.org and changed To…

### DIFF
--- a/src-docs/src/views/button/button_as_link.js
+++ b/src-docs/src/views/button/button_as_link.js
@@ -23,18 +23,20 @@ export default () => (
   <Fragment>
     <OuiFlexGroup gutterSize="s" alignItems="center">
       <OuiFlexItem grow={false}>
-        <OuiButton href="http://www.elastic.co">Link to elastic.co</OuiButton>
+        <OuiButton href="https://opensearch.org/">
+          Link to OpenSearch.org
+        </OuiButton>
       </OuiFlexItem>
 
       <OuiFlexItem grow={false}>
-        <OuiButtonEmpty href="http://www.elastic.co">
-          Link to elastic.co
+        <OuiButtonEmpty href="https://opensearch.org/">
+          Link to OpenSearch.org
         </OuiButtonEmpty>
       </OuiFlexItem>
 
       <OuiFlexItem grow={false}>
         <OuiButtonIcon
-          href="http://www.elastic.co"
+          href="https://opensearch.org/"
           iconType="link"
           aria-label="This is a link"
         />
@@ -43,20 +45,20 @@ export default () => (
 
     <OuiFlexGroup gutterSize="s" alignItems="center">
       <OuiFlexItem grow={false}>
-        <OuiButton href="http://www.elastic.co" isDisabled>
+        <OuiButton href="https://opensearch.org/" isDisabled>
           Disabled link
         </OuiButton>
       </OuiFlexItem>
 
       <OuiFlexItem grow={false}>
-        <OuiButtonEmpty href="http://www.elastic.co" isDisabled>
+        <OuiButtonEmpty href="https://opensearch.org/" isDisabled>
           Disabled empty link
         </OuiButtonEmpty>
       </OuiFlexItem>
 
       <OuiFlexItem grow={false}>
         <OuiButtonIcon
-          href="http://www.elastic.co"
+          href="https://opensearch.org/"
           iconType="link"
           aria-label="This is a link"
           isDisabled

--- a/src-docs/src/views/button/button_ghost.js
+++ b/src-docs/src/views/button/button_ghost.js
@@ -79,7 +79,7 @@ export default () => {
           isSelected={toggle0On}
           fill={toggle0On}
           onClick={onToggle0Change}>
-          Toggle me
+          Toggle
         </OuiButton>
       </OuiFlexItem>
     </OuiFlexGroup>

--- a/src-docs/src/views/button/button_toggle.js
+++ b/src-docs/src/views/button/button_toggle.js
@@ -34,7 +34,7 @@ export default () => {
         onClick={() => {
           setToggle0On((isOn) => !isOn);
         }}>
-        {toggle0On ? 'Hey there good lookin' : 'Toggle me'}
+        {toggle0On ? 'Tada!' : 'Toggle'}
       </OuiButton>
       &emsp;
       <OuiButtonIcon
@@ -57,7 +57,7 @@ export default () => {
         onClick={() => {
           setToggle2On((isOn) => !isOn);
         }}>
-        Toggle me
+        Toggle
       </OuiButton>
       &emsp;
       <OuiButtonIcon


### PR DESCRIPTION
Signed-off-by: AbhishekReddy1127 <nallamsa@amazon.com>

### Description
Changed all the references of `elastic` to `opensearch.org` in the button docs and replaced the `toggle me` to `toggle` and changed the the example "changing content" when the hollow button labeled "toggle" is clicked, the button copy changes to "Hey there good lookin" and now it is  changed from "`Hey there good lookin`" to "`Tada!`"
![Screen Shot 2023-01-12 at 1 29 17 PM](https://user-images.githubusercontent.com/62020972/212189275-bc09ff4d-d5d8-43c3-b9c1-7400c409c4c9.png)
![Screen Shot 2023-01-12 at 1 29 35 PM](https://user-images.githubusercontent.com/62020972/212189280-3e6d67ed-c1cf-465d-9cb3-4e534413037d.png)
![Screen Shot 2023-01-12 at 1 28 57 PM](https://user-images.githubusercontent.com/62020972/212189378-baf00397-68f8-4a5d-811f-373ac4871391.png)

 
### Issues Resolved
#195 
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [x] All tests pass
  - [x] `yarn lint`
  - [x] `yarn test-unit`
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/oui/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
