### PR TITLE
Removed Outdated References of elastic and updated with Opensearch.org

### DIFF
--- a/src-docs/src/views/tabs/tabs.js
+++ b/src-docs/src/views/tabs/tabs.js
@@ -47,9 +47,9 @@ const tabs = [
   },
   {
     id: 'elastic_link',
-    name: 'Elastic Website',
+    name: 'OpenSearch Website',
     disabled: false,
-    href: 'https://www.elastic.co/',
+    href: 'https://opensearch.org/',
   },
 ];
 


### PR DESCRIPTION
Signed-off-by: AbhishekReddy1127 <nallamsa@amazon.com>

### Description
Removed the Outdated references of `elastic` and updated that with `opensearch`in the Tabs section
![Screen Shot 2023-01-12 at 3 24 07 PM](https://user-images.githubusercontent.com/62020972/212202415-41106106-3fc6-48a9-b28d-64fb29c6d991.png)

 
### Issues Resolved
#217 
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [x] All tests pass
  - [ ] `yarn lint`
  - [ ] `yarn test-unit`
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/oui/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
