### PR TITLE
Removed outdated reference and updated text in OUI doc steps

### DIFF
--- a/src-docs/src/views/steps/status.js
+++ b/src-docs/src/views/steps/status.js
@@ -19,9 +19,7 @@ export default () => {
   let completeButton;
   if (status !== 'complete') {
     completeButton = (
-      <OuiButton onClick={() => setStatus('complete')}>
-        You complete me
-      </OuiButton>
+      <OuiButton onClick={() => setStatus('complete')}>Submit</OuiButton>
     );
   } else {
     completeButton = (
@@ -33,7 +31,7 @@ export default () => {
   if (status !== 'warning') {
     warningButton = (
       <OuiButton color="warning" onClick={() => setStatus('warning')}>
-        Uh oh!
+        Warning
       </OuiButton>
     );
   } else {
@@ -48,7 +46,7 @@ export default () => {
   if (status !== 'danger') {
     dangerButton = (
       <OuiButton color="danger" onClick={() => setStatus('danger')}>
-        Something terrible
+        Danger
       </OuiButton>
     );
   } else {

--- a/src-docs/src/views/steps/steps_complex.js
+++ b/src-docs/src/views/steps/steps_complex.js
@@ -67,7 +67,7 @@ const steps = [
         </p>
         <p>
           Go to <strong>Overview &gt;&gt; Endpoints</strong> note{' '}
-          <strong>Elasticsearch</strong> as <OuiCode>&lt;thing&gt;</OuiCode>.
+          <strong>OpenSearch</strong> as <OuiCode>&lt;thing&gt;</OuiCode>.
         </p>
       </OuiText>
     ),


### PR DESCRIPTION
Signed-off-by: AbhishekReddy1127 <nallamsa@amazon.com>

### Description
Removed the outdated reference of Elasticsearch and replaced it with Opensearch and changed the text in the step status.

![Screen Shot 2023-01-13 at 7 09 37 AM](https://user-images.githubusercontent.com/62020972/212353273-34a16a35-0365-4abc-baae-eacceba325be.png)
![Screen Shot 2023-01-13 at 7 10 04 AM](https://user-images.githubusercontent.com/62020972/212353293-a71684ce-d760-4b5d-af90-b17921b65027.png)

 
### Issues Resolved
#216 
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [x] All tests pass
  - [x] `yarn lint`
  - [x] `yarn test-unit`
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/oui/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
