### PR TITLE
Removed smokeMoster from Optional styling

### DIFF
--- a/src-docs/src/views/tree_view/compressed.js
+++ b/src-docs/src/views/tree_view/compressed.js
@@ -81,11 +81,6 @@ export default () => {
         },
       ],
     },
-    {
-      label: 'smokeMonster',
-      id: 'smokeMonster',
-      icon: <OuiToken size="xs" iconType="tokenMethod" />,
-    },
   ];
 
   return (


### PR DESCRIPTION
Signed-off-by: AbhishekReddy1127 <nallamsa@amazon.com>

### Description
Removed smokeMoster from the optional styling section.
![Screen Shot 2023-01-13 at 7 35 45 AM](https://user-images.githubusercontent.com/62020972/212359220-61c1a996-9426-46a9-81e3-92bb181e24a1.png)

 
### Issues Resolved
#214 
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [x] All tests pass
  - [x] `yarn lint`
  - [x] `yarn test-unit`
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/oui/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
