### PR TITLE
Fix docs site default theme

### DIFF
--- a/src-docs/src/components/with_theme/theme_context.tsx
+++ b/src-docs/src/components/with_theme/theme_context.tsx
@@ -17,7 +17,7 @@ import { applyTheme } from '../../services';
 const THEME_NAMES = OUI_THEMES.map(({ value }) => value);
 
 const defaultState = {
-  theme: THEME_NAMES[2],
+  theme: THEME_NAMES[0],
   changeTheme: (themeValue: OUI_THEME['value']) => {
     applyTheme(themeValue);
   },


### PR DESCRIPTION
Signed-off-by: Matt Provost <provomat@amazon.com>

### Description
New users to the docs site are presented with an empty page because the default theme is not set correctly. It is trying to reference a theme that was removed, thus resulting in an error and nothing gets displayed.
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [x] All tests pass
  - [x] `yarn lint`
  - [x] `yarn test-unit`
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/oui/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
