### PR TITLE
 Removing message text in the examples section

### DIFF
--- a/src-docs/src/views/modal/confirm_modal_loading.js
+++ b/src-docs/src/views/modal/confirm_modal_loading.js
@@ -51,7 +51,6 @@ export default () => {
         onCancel={closeModal}
         onConfirm={() => {
           closeModal();
-          window.alert('Shame on you!');
         }}
         confirmButtonText="Delete"
         cancelButtonText="Cancel"


### PR DESCRIPTION
Signed-off-by: AbhishekReddy1127 <nallamsa@amazon.com>

### Description
Removed the unwanted alert text in the section Section: Loading and disabling confirm button > Show loading confirm modal

https://user-images.githubusercontent.com/62020972/213620799-c43a1ca7-b449-4f0e-89f9-9a67b53cde59.mov


 
### Issues Resolved
#176 
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [x] All tests pass
  - [x] `yarn lint`
  - [x] `yarn test-unit`
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/oui/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
