### PR TITLE
[OUI Docs] Updated the content for the Empty prompt

### DIFF
--- a/src-docs/src/views/empty_prompt/custom.js
+++ b/src-docs/src/views/empty_prompt/custom.js
@@ -23,9 +23,7 @@ export default () => (
       <Fragment>
         <p>
           Pellentesque habitant morbi tristique senectus et netus et malesuada
-          fames ac turpis egestas. Donec accumsan, nulla sed blandit semper.
-        </p>
-        <p>
+          fames ac turpis egestas. Donec accumsan, nulla sed blandit semper
           tell&rsquo;us est convallis mauris, eget consequat mi lacus non ante.
         </p>
       </Fragment>

--- a/src-docs/src/views/empty_prompt/custom.js
+++ b/src-docs/src/views/empty_prompt/custom.js
@@ -15,23 +15,24 @@ import { OuiEmptyPrompt, OuiButton } from '../../../../src/components';
 
 export default () => (
   <OuiEmptyPrompt
-    iconType="dataVisualizer"
+    iconType="database"
     iconColor="default"
-    title={<h2>You have no spice</h2>}
+    title={<h2>No data available</h2>}
     titleSize="xs"
     body={
       <Fragment>
         <p>
-          Navigators use massive amounts of spice to gain a limited form of
-          prescience. This allows them to safely navigate interstellar space,
-          enabling trade and travel throughout the galaxy.
+          Pellentesque habitant morbi tristique senectus et netus et malesuada
+          fames ac turpis egestas. Donec accumsan, nulla sed blandit semper.
         </p>
-        <p>You&rsquo;ll need spice to rule Arrakis, young Atreides.</p>
+        <p>
+          tell&rsquo;us est convallis mauris, eget consequat mi lacus non ante.
+        </p>
       </Fragment>
     }
     actions={
       <OuiButton size="s" color="primary" fill>
-        Harvest spice
+        Connect to a data source
       </OuiButton>
     }
   />

--- a/src-docs/src/views/empty_prompt/empty_prompt.js
+++ b/src-docs/src/views/empty_prompt/empty_prompt.js
@@ -21,9 +21,7 @@ export default () => (
       <Fragment>
         <p>
           Pellentesque habitant morbi tristique senectus et netus et malesuada
-          fames ac turpis egestas. Donec accumsan, nulla sed blandit semper.
-        </p>
-        <p>
+          fames ac turpis egestas. Donec accumsan, nulla sed blandit semper
           tell&rsquo;us est convallis mauris, eget consequat mi lacus non ante.
         </p>
       </Fragment>

--- a/src-docs/src/views/empty_prompt/empty_prompt.js
+++ b/src-docs/src/views/empty_prompt/empty_prompt.js
@@ -15,21 +15,22 @@ import { OuiEmptyPrompt, OuiButton } from '../../../../src/components';
 
 export default () => (
   <OuiEmptyPrompt
-    iconType="editorStrike"
-    title={<h2>You have no spice</h2>}
+    iconType="database"
+    title={<h2>No data available</h2>}
     body={
       <Fragment>
         <p>
-          Navigators use massive amounts of spice to gain a limited form of
-          prescience. This allows them to safely navigate interstellar space,
-          enabling trade and travel throughout the galaxy.
+          Pellentesque habitant morbi tristique senectus et netus et malesuada
+          fames ac turpis egestas. Donec accumsan, nulla sed blandit semper.
         </p>
-        <p>You&rsquo;ll need spice to rule Arrakis, young Atreides.</p>
+        <p>
+          tell&rsquo;us est convallis mauris, eget consequat mi lacus non ante.
+        </p>
       </Fragment>
     }
     actions={
       <OuiButton color="primary" fill>
-        Harvest spice
+        Connect to a data source
       </OuiButton>
     }
   />

--- a/src-docs/src/views/empty_prompt/empty_prompt_example.js
+++ b/src-docs/src/views/empty_prompt/empty_prompt_example.js
@@ -22,7 +22,7 @@ import EmptyPrompt from './empty_prompt';
 const emptyPromptSource = require('!!raw-loader!./empty_prompt');
 const emptyPromptSnippet = `<OuiEmptyPrompt
   iconType="editorStrike"
-  title={<h2>You have no spice</h2>}
+  title={<h2>No data available</h2>}
   body={bodyContent}
   actions={actions}
 />`;
@@ -31,7 +31,7 @@ import Custom from './custom';
 const customSource = require('!!raw-loader!./custom');
 const customSnippet = `<OuiEmptyPrompt
   iconType="editorStrike"
-  title={<h2>You have no spice</h2>}
+  title={<h2>No data available</h2>}
   titleSize="xs"
   body={bodyContent}
   actions={actions}
@@ -40,7 +40,7 @@ const customSnippet = `<OuiEmptyPrompt
 import Simple from './simple';
 const simpleSource = require('!!raw-loader!./simple');
 const simpleSnippet = `<OuiEmptyPrompt
-  title={<h2>You have no spice</h2>}
+  title={<h2>No data available</h2>}
   actions={multipleActions}
 />`;
 

--- a/src-docs/src/views/empty_prompt/empty_prompt_loading.js
+++ b/src-docs/src/views/empty_prompt/empty_prompt_loading.js
@@ -15,7 +15,7 @@ import { OuiEmptyPrompt, OuiLoadingLogo } from '../../../../src/components';
 
 export default () => (
   <OuiEmptyPrompt
-    icon={<OuiLoadingLogo logo="logoKibana" size="xl" />}
+    icon={<OuiLoadingLogo logo="visPie" size="xl" />}
     title={<h2>Loading Dashboards</h2>}
   />
 );

--- a/src-docs/src/views/empty_prompt/empty_prompt_states.js
+++ b/src-docs/src/views/empty_prompt/empty_prompt_states.js
@@ -52,7 +52,7 @@ export default () => {
       break;
     case 'empty':
       emptyPromptProps = {
-        iconType: 'dashboardApp',
+        iconType: 'visAreaStacked',
         iconColor: 'default',
         title: <h2>Dashboards</h2>,
         body: <p>You don&apos;t have any dashboards yet.</p>,
@@ -66,7 +66,7 @@ export default () => {
 
     default:
       emptyPromptProps = {
-        icon: <OuiLoadingLogo logo="logoKibana" size="xl" />,
+        icon: <OuiLoadingLogo logo="visPie" size="xl" />,
         title: <h2>Loading Dashboards</h2>,
       };
       break;

--- a/src-docs/src/views/empty_prompt/playground.js
+++ b/src-docs/src/views/empty_prompt/playground.js
@@ -46,7 +46,7 @@ export default () => {
   propsToUse.actions.type = PropTypes.String;
   propsToUse.body.type = PropTypes.String;
   propsToUse.body.value =
-    'Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. Donec accumsan, nulla sed blandit semper.';
+    'Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. Donec accumsan, nulla sed blandit semper, tellus est convallis mauris, eget consequat mi lacus non ante.';
 
   propsToUse.iconType = iconValidator(propsToUse.iconType, 'database');
 

--- a/src-docs/src/views/empty_prompt/playground.js
+++ b/src-docs/src/views/empty_prompt/playground.js
@@ -24,7 +24,7 @@ export default () => {
 
   propsToUse.title = {
     ...propsToUse.title,
-    value: '<h2>You have no spice</h2>',
+    value: '<h2>No data available</h2>',
     type: PropTypes.ReactNode,
   };
 
@@ -45,11 +45,10 @@ export default () => {
 
   propsToUse.actions.type = PropTypes.String;
   propsToUse.body.type = PropTypes.String;
-  propsToUse.body.value = `Navigators use massive amounts of spice to gain a limited form of
-    prescience. This allows them to safely navigate interstellar space,
-    enabling trade and travel throughout the galaxy.`;
+  propsToUse.body.value =
+    'Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. Donec accumsan, nulla sed blandit semper.';
 
-  propsToUse.iconType = iconValidator(propsToUse.iconType, 'editorStrike');
+  propsToUse.iconType = iconValidator(propsToUse.iconType, 'database');
 
   return {
     config: {

--- a/src-docs/src/views/empty_prompt/simple.js
+++ b/src-docs/src/views/empty_prompt/simple.js
@@ -19,12 +19,12 @@ import {
 
 export default () => (
   <OuiEmptyPrompt
-    title={<h2>You have no spice</h2>}
+    title={<h2>No data available</h2>}
     actions={[
       <OuiButton color="primary" fill>
-        Harvest spice
+        Connect to data source
       </OuiButton>,
-      <OuiButtonEmpty color="danger">Sabotage all spice fields</OuiButtonEmpty>,
+      <OuiButtonEmpty color="primary">Read documentation</OuiButtonEmpty>,
     ]}
   />
 );


### PR DESCRIPTION
Signed-off-by: AbhishekReddy1127 <nallamsa@amazon.com>

### Description
Updated the content in the section Empty Prompt.



https://user-images.githubusercontent.com/62020972/218584367-e0107ccb-6571-4e3a-af06-e8f30d8455b7.mov


 
### Issues Resolved
#246 
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [x] All tests pass
  - [x] `yarn lint`
  - [x] `yarn test-unit`
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/oui/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
