### PR TITLE
[OUI Docs] Removed the link in the section ColorPalattes

### DIFF
--- a/src-docs/src/views/color_palette/color_palette_example.js
+++ b/src-docs/src/views/color_palette/color_palette_example.js
@@ -10,8 +10,6 @@
  */
 
 import React from 'react';
-import { Link } from 'react-router-dom';
-
 import { renderToHtml } from '../../services';
 
 import { GuideSectionTypes } from '../../components';
@@ -106,10 +104,9 @@ export const ColorPaletteExample = {
             demographic-based data sets.
           </p>
           <p>
-            OUI provides the following common palettes for quantitative data and{' '}
-            <Link to="/elastic-charts/creating-charts">charts</Link>. Just pass
-            in the number of steps needed and the function will interpolate
-            between the colors.
+            OUI provides the following common palettes for quantitative data and
+            charts. Just pass in the number of steps needed and the function
+            will interpolate between the colors.
           </p>
           <OuiCallOut
             color="warning"


### PR DESCRIPTION
### Description
Removes the link that points to the elastic charts in the section color palettes.
![Screenshot 2023-02-14 at 3 18 30 PM](https://user-images.githubusercontent.com/62020972/218866510-fb9deb54-4f69-46e0-8561-939e9f5e8f92.png)

 
### Issues Resolved
#304 
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [x] All tests pass
  - [x] `yarn lint`
  - [x] `yarn test-unit`
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/oui/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
