### PR TITLE
[OUI Docs] Deprecated kibana references

### DIFF
--- a/src-docs/src/views/expression/columns.js
+++ b/src-docs/src/views/expression/columns.js
@@ -26,8 +26,8 @@ export default () => {
     isOpen: false,
     value: (
       <Fragment>
-        <p>.kibana_task_manager,</p>
-        <p>kibana_sample_data_ecommerce</p>
+        <p>.opensearch_dashboards_task_manager,</p>
+        <p>opensearch_dashboards_sample_data_ecommerce</p>
       </Fragment>
     ),
   });
@@ -39,19 +39,19 @@ export default () => {
 
   const options = [
     {
-      label: '.kibana_task_manager',
+      label: '.opensearch_dashboards_task_manager',
     },
     {
-      label: 'kibana_sample_data_ecommerce',
+      label: 'opensearch_dashboards_sample_data_ecommerce',
     },
     {
-      label: '.kibana-event-log-8.0.0-000001',
+      label: '.opensearch_dashboards-event-log-8.0.0-000001',
     },
     {
-      label: 'kibana_sample_data_flights',
+      label: 'opensearch_dashboards_sample_data_flights',
     },
     {
-      label: '.kibana-event-log-8.0.0',
+      label: '.opensearch_dashboards-event-log-8.0.0',
     },
   ];
 
@@ -193,7 +193,7 @@ export default () => {
       <OuiExpression
         display="columns"
         description="Except"
-        value="kibana_sample_data_ky_counties"
+        value="opensearch_dashboards_sample_data_ky_counties"
       />
       <OuiSpacer />
       <OuiTitle size="xxs">
@@ -203,7 +203,7 @@ export default () => {
         description="join"
         display="columns"
         descriptionWidth={50}
-        value="kibana_sample_data_ky_avl"
+        value="opensearch_dashboards_sample_data_ky_avl"
         onClick={() => {}}
       />
     </div>

--- a/src-docs/src/views/expression/stringing.tsx
+++ b/src-docs/src/views/expression/stringing.tsx
@@ -18,11 +18,11 @@ export default () => (
     <OuiExpression description="Select" value="count(*)" onClick={() => {}} />
     <OuiExpression
       description="From"
-      value="kibana_sample_data_ky_counties left"
+      value="opensearch_dashboards_sample_data_ky_counties left"
     />
     <OuiExpression
       description="join"
-      value="kibana_sample_data_ky_avl right"
+      value="opensearch_dashboards_sample_data_ky_avl right"
       onClick={() => {}}
     />
     <OuiExpression description="on" value="left.smis = right.kytccountynmbr" />

--- a/src-docs/src/views/expression/truncate.js
+++ b/src-docs/src/views/expression/truncate.js
@@ -17,8 +17,10 @@ const value = 'and a very long string as value';
 const description = 'some very very long description';
 const nodes = (
   <Fragment>
-    <p className="oui-textTruncate">.kibana_task_manager</p>
-    <p className="oui-textTruncate">kibana_sample_data_ecommerce</p>
+    <p className="oui-textTruncate">.opensearch_dashboards_task_manager</p>
+    <p className="oui-textTruncate">
+      opensearch_dashboards_sample_data_ecommerce
+    </p>
   </Fragment>
 );
 


### PR DESCRIPTION
### Description
Updated the Kibana references to opensearch dashboards in the section expression.
![Screenshot 2023-02-20 at 6 34 25 PM](https://user-images.githubusercontent.com/62020972/220220261-2b383684-8dc4-45a9-a612-7a374774d8c6.png)
![Screenshot 2023-02-20 at 6 34 31 PM](https://user-images.githubusercontent.com/62020972/220220263-a459eb91-e5bd-4a26-a2f1-51ae996b88ae.png)
![Screenshot 2023-02-20 at 6 34 49 PM](https://user-images.githubusercontent.com/62020972/220220265-d21a0de1-05d0-45c9-a23c-2d5b41176f01.png)

 
### Issues Resolved
#287 
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [x] All tests pass
  - [x] `yarn lint`
  - [x] `yarn test-unit`
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/oui/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
