### PR TITLE
[OUI Docs] Updated the podcast to vedio

### DIFF
--- a/src-docs/src/views/aspect_ratio/aspect_ratio.js
+++ b/src-docs/src/views/aspect_ratio/aspect_ratio.js
@@ -28,7 +28,7 @@ export default () => (
         title="Elastic is a search company"
         width="560"
         height="315"
-        src="https://www.youtube.com/embed/yJarWSLRM24"
+        src="https://www.youtube.com/embed/yO96yqpcycY"
         frameBorder="0"
         allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture"
         allowFullScreen
@@ -44,7 +44,7 @@ export default () => (
         title="Elastic is a search company"
         width="560"
         height="315"
-        src="https://www.youtube.com/embed/yJarWSLRM24"
+        src="https://www.youtube.com/embed/yO96yqpcycY"
         frameBorder="0"
         allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture"
         allowFullScreen

--- a/src-docs/src/views/aspect_ratio/aspect_ratio.js
+++ b/src-docs/src/views/aspect_ratio/aspect_ratio.js
@@ -57,7 +57,7 @@ export default () => (
     <OuiSpacer size="s" />
     <OuiAspectRatio width={220} height={150} maxWidth={500}>
       <iframe
-        src="https://app.stitcher.com/splayer/f/13377/54057816"
+        src="https://www.youtube.com/embed/yO96yqpcycY"
         title="something"
         frameBorder="0"
         scrolling="no"

--- a/src-docs/src/views/aspect_ratio/playground.js
+++ b/src-docs/src/views/aspect_ratio/playground.js
@@ -27,7 +27,7 @@ export default () => {
     title="Elastic is a search company"
     width="560"
     height="315"
-    src="https://www.youtube.com/embed/yJarWSLRM24"
+    src="https://www.youtube.com/embed/yO96yqpcycY"
     frameBorder="0"
     allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture"
     allowFullScreen


### PR DESCRIPTION
### Description
Updated the podcast to the suggested youtube vedio in the section Aspect ratio.
![Screenshot 2023-02-21 at 5 15 18 PM](https://user-images.githubusercontent.com/62020972/220480638-6889d2c4-5098-4580-b811-714265926f54.png)

 
### Issues Resolved
#375 
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [x] All tests pass
  - [x] `yarn lint`
  - [x] `yarn test-unit`
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/oui/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
