### PR TITLE
Readme Opensearch Logo linking to non-existent file [CCI]

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
-<img src="https://opensearch.org/assets/img/opensearch-logo-themed.svg" height="64px">
-
+![OpenSearch logo](https://opensearch.org/assets/img/opensearch-logo-themed.svg)
 # OpenSearch UI Framework
 
 - [Welcome!](#welcome)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![OpenSearch logo](OpenSearch.svg)
+<img src="https://opensearch.org/assets/img/opensearch-logo-themed.svg" height="64px">
 
 # OpenSearch UI Framework
 


### PR DESCRIPTION
### Description
This fix changes the logo linking, as it was leading to a non-existent file. Instead, it uses the logo asset that is stored externally on the OpenSearch website.
 
### Issues Resolved
Closes #564
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] All tests pass
  - [ ] `yarn lint`
  - [ ] `yarn test-unit`
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/oui/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
