### PR TITLE
[CCI] Add deprecation comments to OuiLoadingElastic and OuiLoadingKibana

### DIFF
--- a/src/components/loading/__snapshots__/loading_elastic.test.tsx.snap
+++ b/src/components/loading/__snapshots__/loading_elastic.test.tsx.snap
@@ -1,0 +1,61 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`OuiLoadingElastic is rendered 1`] = `
+<span
+  aria-label="aria-label"
+  class="ouiLoadingElastic ouiLoadingElastic--medium testClass1 testClass2"
+  data-test-subj="test subject string"
+>
+  <span
+    data-ouiicon-type="logoOpenSearch"
+  />
+</span>
+`;
+
+exports[`OuiLoadingElastic size l is rendered 1`] = `
+<span
+  aria-label="aria-label"
+  class="ouiLoadingElastic ouiLoadingElastic--large testClass1 testClass2"
+  data-test-subj="test subject string"
+>
+  <span
+    data-ouiicon-type="logoOpenSearch"
+  />
+</span>
+`;
+
+exports[`OuiLoadingElastic size m is rendered 1`] = `
+<span
+  aria-label="aria-label"
+  class="ouiLoadingElastic ouiLoadingElastic--medium testClass1 testClass2"
+  data-test-subj="test subject string"
+>
+  <span
+    data-ouiicon-type="logoOpenSearch"
+  />
+</span>
+`;
+
+exports[`OuiLoadingElastic size xl is rendered 1`] = `
+<span
+  aria-label="aria-label"
+  class="ouiLoadingElastic ouiLoadingElastic--xLarge testClass1 testClass2"
+  data-test-subj="test subject string"
+>
+  <span
+    data-ouiicon-type="logoOpenSearch"
+  />
+</span>
+`;
+
+exports[`OuiLoadingElastic size xxl is rendered 1`] = `
+<span
+  aria-label="aria-label"
+  class="ouiLoadingElastic ouiLoadingElastic--xxLarge testClass1 testClass2"
+  data-test-subj="test subject string"
+>
+  <span
+    data-ouiicon-type="logoOpenSearch"
+  />
+</span>
+`;

--- a/src/components/loading/__snapshots__/loading_kibana.test.tsx.snap
+++ b/src/components/loading/__snapshots__/loading_kibana.test.tsx.snap
@@ -18,7 +18,9 @@ exports[`OuiLoadingKibana is rendered 1`] = `
 
 exports[`OuiLoadingKibana size l is rendered 1`] = `
 <span
-  class="ouiLoadingKibana ouiLoadingKibana--large"
+  aria-label="aria-label"
+  class="ouiLoadingKibana ouiLoadingKibana--large testClass1 testClass2"
+  data-test-subj="test subject string"
 >
   <span
     class="ouiLoadingKibana__icon"
@@ -32,7 +34,9 @@ exports[`OuiLoadingKibana size l is rendered 1`] = `
 
 exports[`OuiLoadingKibana size m is rendered 1`] = `
 <span
-  class="ouiLoadingKibana ouiLoadingKibana--medium"
+  aria-label="aria-label"
+  class="ouiLoadingKibana ouiLoadingKibana--medium testClass1 testClass2"
+  data-test-subj="test subject string"
 >
   <span
     class="ouiLoadingKibana__icon"
@@ -46,7 +50,9 @@ exports[`OuiLoadingKibana size m is rendered 1`] = `
 
 exports[`OuiLoadingKibana size xl is rendered 1`] = `
 <span
-  class="ouiLoadingKibana ouiLoadingKibana--xLarge"
+  aria-label="aria-label"
+  class="ouiLoadingKibana ouiLoadingKibana--xLarge testClass1 testClass2"
+  data-test-subj="test subject string"
 >
   <span
     class="ouiLoadingKibana__icon"

--- a/src/components/loading/loading_elastic.test.tsx
+++ b/src/components/loading/loading_elastic.test.tsx
@@ -1,0 +1,37 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React from 'react';
+import { render, mount } from 'enzyme';
+import { requiredProps } from '../../test';
+import { getDeprecatedMessage } from '../../utils';
+import { OuiLoadingElastic, SIZES, WARNING } from './loading_elastic';
+
+describe('OuiLoadingElastic', () => {
+  test('is rendered', () => {
+    const component = render(<OuiLoadingElastic {...requiredProps} />);
+
+    expect(component).toMatchSnapshot();
+  });
+
+  describe('size', () => {
+    SIZES.forEach((size) => {
+      test(`${size} is rendered`, () => {
+        const component = render(
+          <OuiLoadingElastic {...requiredProps} size={size} />
+        );
+
+        expect(component).toMatchSnapshot();
+      });
+    });
+  });
+
+  it('should console warning about a deprecated component', () => {
+    console.warn = jest.fn();
+    mount(<OuiLoadingElastic {...requiredProps} />);
+
+    expect(console.warn).toHaveBeenCalledWith(getDeprecatedMessage(WARNING));
+  });
+});

--- a/src/components/loading/loading_elastic.tsx
+++ b/src/components/loading/loading_elastic.tsx
@@ -32,6 +32,7 @@ import React, { HTMLAttributes, FunctionComponent } from 'react';
 import classNames from 'classnames';
 import { CommonProps, keysOf } from '../common';
 import { OuiIcon } from '../icon';
+import { deprecated } from '../../utils';
 
 const sizeToClassNameMap = {
   m: 'ouiLoadingElastic--medium',
@@ -42,11 +43,14 @@ const sizeToClassNameMap = {
 
 export const SIZES = keysOf(sizeToClassNameMap);
 
+export const WARNING =
+  'OuiLoadingElastic is deprecated in favor of OuiLoadingDashboards and will be removed in v2.0.0.';
+
 export interface OuiLoadingElasticProps {
   size?: keyof typeof sizeToClassNameMap;
 }
 
-export const OuiLoadingElastic: FunctionComponent<
+const OuiLoadingElasticComponent: FunctionComponent<
   CommonProps & HTMLAttributes<HTMLDivElement> & OuiLoadingElasticProps
 > = ({ size = 'm', className, ...rest }) => {
   const classes = classNames(
@@ -61,3 +65,10 @@ export const OuiLoadingElastic: FunctionComponent<
     </span>
   );
 };
+
+/**
+ * @deprecated OuiLoadingElastic is deprecated in favor of OuiLoadingDashboards and will be removed in v2.0.0.
+ */
+export const OuiLoadingElastic = deprecated(WARNING)(
+  OuiLoadingElasticComponent
+);

--- a/src/components/loading/loading_kibana.test.tsx
+++ b/src/components/loading/loading_kibana.test.tsx
@@ -29,10 +29,10 @@
  */
 
 import React from 'react';
-import { render } from 'enzyme';
-import { requiredProps } from '../../test/required_props';
-
-import { OuiLoadingKibana, SIZES } from './loading_kibana';
+import { render, mount } from 'enzyme';
+import { requiredProps } from '../../test';
+import { getDeprecatedMessage } from '../../utils';
+import { OuiLoadingKibana, SIZES, WARNING } from './loading_kibana';
 
 describe('OuiLoadingKibana', () => {
   test('is rendered', () => {
@@ -44,10 +44,19 @@ describe('OuiLoadingKibana', () => {
   describe('size', () => {
     SIZES.forEach((size) => {
       test(`${size} is rendered`, () => {
-        const component = render(<OuiLoadingKibana size={size} />);
+        const component = render(
+          <OuiLoadingKibana {...requiredProps} size={size} />
+        );
 
         expect(component).toMatchSnapshot();
       });
     });
+  });
+
+  it('should console warning about a deprecated component', () => {
+    console.warn = jest.fn();
+    mount(<OuiLoadingKibana {...requiredProps} />);
+
+    expect(console.warn).toHaveBeenCalledWith(getDeprecatedMessage(WARNING));
   });
 });

--- a/src/components/loading/loading_kibana.tsx
+++ b/src/components/loading/loading_kibana.tsx
@@ -32,6 +32,7 @@ import React, { HTMLAttributes, FunctionComponent } from 'react';
 import classNames from 'classnames';
 import { CommonProps, keysOf } from '../common';
 import { OuiIcon } from '../icon';
+import { deprecated } from '../../utils';
 
 const sizeToClassNameMap = {
   m: 'ouiLoadingKibana--medium',
@@ -41,15 +42,15 @@ const sizeToClassNameMap = {
 
 export const SIZES = keysOf(sizeToClassNameMap);
 
+export const WARNING =
+  'OuiLoadingKibana is deprecated in favor of OuiLoadingLogo and will be removed in v2.0.0.';
+
 export type OuiLoadingKibanaProps = CommonProps &
   HTMLAttributes<HTMLDivElement> & {
     size?: keyof typeof sizeToClassNameMap;
   };
 
-/**
- * **DEPRECATED** Use OuiLoadingLogo instead
- */
-export const OuiLoadingKibana: FunctionComponent<OuiLoadingKibanaProps> = ({
+const OuiLoadingKibanaComponent: FunctionComponent<OuiLoadingKibanaProps> = ({
   size = 'm',
   className,
   ...rest
@@ -68,3 +69,8 @@ export const OuiLoadingKibana: FunctionComponent<OuiLoadingKibanaProps> = ({
     </span>
   );
 };
+
+/**
+ * @deprecated OuiLoadingKibana is deprecated in favor of OuiLoadingLogo and will be removed in v2.0.0.
+ */
+export const OuiLoadingKibana = deprecated(WARNING)(OuiLoadingKibanaComponent);

--- a/src/utils/deprecated/__snapshots__/deprecated.test.tsx.snap
+++ b/src/utils/deprecated/__snapshots__/deprecated.test.tsx.snap
@@ -1,0 +1,3 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`deprecated should render component 1`] = `<div />`;

--- a/src/utils/deprecated/deprecated.test.tsx
+++ b/src/utils/deprecated/deprecated.test.tsx
@@ -1,0 +1,39 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React from 'react';
+import { mount, render } from 'enzyme';
+import { deprecated, getDeprecatedMessage } from './deprecated';
+
+describe('deprecated', () => {
+  const warning = 'This component is deprecated in favor of another.';
+
+  it('should console warning', () => {
+    console.warn = jest.fn();
+
+    const Component = () => <div />;
+    const DeprecatedComponent = deprecated(warning)(Component);
+    mount(<DeprecatedComponent />);
+
+    expect(console.warn).toHaveBeenCalledWith(getDeprecatedMessage(warning));
+  });
+
+  it('should render component', () => {
+    console.warn = jest.fn();
+
+    const Component = () => <div />;
+    const DeprecatedComponent = deprecated(warning)(Component);
+
+    const component = render(<DeprecatedComponent />);
+    expect(component).toMatchSnapshot();
+  });
+
+  it('should properly name DeprecatedWrapper function', () => {
+    const Component = () => <div />;
+    const DeprecatedComponent = deprecated(warning)(Component);
+
+    expect(DeprecatedComponent.name).toEqual('Component');
+  });
+});

--- a/src/utils/deprecated/deprecated.tsx
+++ b/src/utils/deprecated/deprecated.tsx
@@ -1,0 +1,27 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React, { useEffect } from 'react';
+
+export const getDeprecatedMessage = (message: string): string =>
+  `[DEPRECATED] ${message}`;
+
+export const deprecated = (message: string) => {
+  return <T extends React.ComponentType<any>>(Component: T): T => {
+    const DeprecatedWrapper = (props: React.ComponentProps<T>) => {
+      useEffect(() => {
+        console.warn(getDeprecatedMessage(message));
+      }, []);
+
+      return <Component {...props} />;
+    };
+
+    Object.defineProperty(DeprecatedWrapper, 'name', {
+      value: Component.displayName || Component.name,
+    });
+
+    return DeprecatedWrapper as T;
+  };
+};

--- a/src/utils/deprecated/index.ts
+++ b/src/utils/deprecated/index.ts
@@ -1,0 +1,6 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+export * from './deprecated';

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -29,3 +29,4 @@
  */
 
 export * from './prop_types';
+export * from './deprecated';


### PR DESCRIPTION
### Description
Added deprecation comments to OuiLoadingElastic and OuiLoadingKibana
- Used JSDoc deprecated tag

<img width="650" alt="Screenshot 2023-03-19 at 13 19 59" src="https://user-images.githubusercontent.com/17855243/226160196-05603323-3ad2-4e2b-892a-eb2e782de39f.png">

- Added `deprecated` component to console deprecation warning

<img width="400" alt="Screenshot 2023-03-19 at 12 49 49" src="https://user-images.githubusercontent.com/17855243/226160191-ae311520-5161-4265-960c-898aca22d4ff.png">

### Issues Resolved
https://github.com/opensearch-project/oui/issues/266
 
### Check List
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
- [x] All tests pass
  - [x] `yarn lint`
  - [x] `yarn test-unit`
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/oui/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
