### PR TITLE
[CCI] Change OuiTitle size property to m in tooltip example

### DIFF
--- a/src-docs/src/views/tool_tip/tool_tip_example.js
+++ b/src-docs/src/views/tool_tip/tool_tip_example.js
@@ -76,7 +76,7 @@ export const ToolTipExample = {
             to the edge of the screen.
           </p>
 
-          <OuiTitle size="md">
+          <OuiTitle size="m">
             <h2>Applying tooltips to custom components</h2>
           </OuiTitle>
 


### PR DESCRIPTION
### Description
Changed `OuiTitle` size property to `m` in `tool_tip_example.js` file
 
### Issues Resolved
https://github.com/opensearch-project/oui/issues/607
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [x] All tests pass
  - [x] `yarn lint`
  - [x] `yarn test-unit`
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/oui/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
