### PR TITLE
Remove usage of important from breadcrumbs

### DIFF
--- a/src/components/breadcrumbs/_breadcrumbs.scss
+++ b/src/components/breadcrumbs/_breadcrumbs.scss
@@ -16,7 +16,8 @@
 
 .ouiBreadcrumbs {
   @include ouiFontSizeS;
-  margin-bottom: -$ouiSizeXS; /* 1 */
+  margin-bottom: -$ouiSizeXS;
+  /* 1 */
   display: flex;
   align-items: center;
   flex-wrap: wrap;
@@ -29,10 +30,6 @@
 
   &:not(.ouiBreadcrumb--last) {
     color: $ouiTextSubduedColor;
-
-    &:hover {
-      color: $ouiBreadCrumbHoverColor !important; // sass-lint:disable-line no-important
-    }
   }
 }
 
@@ -43,16 +40,10 @@
 .ouiBreadcrumb--collapsed {
   flex-shrink: 0;
   color: $ouiBreadcrumbCollapsedLink;
-  vertical-align: top !important; // sass-lint:disable-line no-important
-}
-
-.ouiBreadcrumb__collapsedLink:hover {
-  color: $ouiBreadCrumbHoverColor !important; // sass-lint:disable-line no-important
 }
 
 .ouiBreadcrumbs__inPopover .ouiBreadcrumb--last {
   font-weight: $ouiFontWeightRegular;
-  color: $ouiColorDarkShade !important; // sass-lint:disable-line no-important
 }
 
 .ouiBreadcrumbs--truncate {
@@ -95,7 +86,8 @@
   padding: $ouiSizeXS - 2.5 $ouiSizeL - $ouiSizeXS;
 
   &:not(.ouiBreadcrumbWrapper--first) {
-    margin-bottom: $ouiSizeXS; /* 1 */
+    margin-bottom: $ouiSizeXS;
+    /* 1 */
   }
 
   &:not(.ouiBreadcrumbWrapper--last) {
@@ -107,7 +99,8 @@
   background-image: linear-gradient(to right, $ouiBreadcrumbGrayBackground 0 $ouiSizeM, transparent $ouiSizeM);
   border-radius: $ouiSizeXS;
   overflow: hidden;
-  margin-bottom: $ouiSizeXS; /* 1 */
+  margin-bottom: $ouiSizeXS;
+  /* 1 */
 }
 
 .ouiBreadcrumbWrapper--last {

--- a/src/components/breadcrumbs/breadcrumbs.tsx
+++ b/src/components/breadcrumbs/breadcrumbs.tsx
@@ -41,7 +41,7 @@ import classNames from 'classnames';
 import { CommonProps } from '../common';
 import { OuiI18n } from '../i18n';
 import { OuiInnerText } from '../inner_text';
-import { OuiLink } from '../link';
+import { OuiLink, OuiLinkColor } from '../link';
 import { OuiPopover } from '../popover';
 import { OuiIcon } from '../icon';
 import { throttle } from '../../services';
@@ -196,6 +196,7 @@ export const OuiBreadcrumbs: FunctionComponent<OuiBreadcrumbsProps> = ({
   max = 5,
   ...rest
 }) => {
+  const isBreadCrumInPopover = className === 'ouiBreadcrumbs__inPopover';
   const [currentBreakpoint, setCurrentBreakpoint] = useState(
     getBreakpoint(typeof window === 'undefined' ? -Infinity : window.innerWidth)
   );
@@ -226,9 +227,10 @@ export const OuiBreadcrumbs: FunctionComponent<OuiBreadcrumbsProps> = ({
       className: breadcrumbClassName,
       ...breadcrumbRest
     } = breadcrumb;
-
     const isFirstBreadcrumb = index === 0;
     const isLastBreadcrumb = index === breadcrumbs.length - 1;
+    const lastBreadCrumbColor: OuiLinkColor =
+      isBreadCrumInPopover && isLastBreadcrumb ? 'coin' : 'subdued';
 
     const breadcrumbWrapperClasses = classNames('ouiBreadcrumbWrapper', {
       'ouiBreadcrumbWrapper--first': isFirstBreadcrumb,
@@ -264,7 +266,7 @@ export const OuiBreadcrumbs: FunctionComponent<OuiBreadcrumbsProps> = ({
           {(ref, innerText) => (
             <OuiLink
               ref={ref}
-              color={isLastBreadcrumb ? 'text' : 'subdued'}
+              color={lastBreadCrumbColor}
               onClick={onClick}
               href={href}
               className={breadcrumbClasses}

--- a/src/components/link/__snapshots__/link.test.tsx.snap
+++ b/src/components/link/__snapshots__/link.test.tsx.snap
@@ -29,6 +29,13 @@ exports[`OuiLink button respects the type property 1`] = `
 />
 `;
 
+exports[`OuiLink coin is rendered 1`] = `
+<button
+  class="ouiLink ouiLink--coin"
+  type="button"
+/>
+`;
+
 exports[`OuiLink danger is rendered 1`] = `
 <button
   class="ouiLink ouiLink--danger"

--- a/src/components/link/_link.scss
+++ b/src/components/link/_link.scss
@@ -19,6 +19,7 @@ $ouiLinkColors: (
   danger: $ouiColorDangerText,
   text: $ouiTextColor,
   ghost: $ouiColorGhost,
+  coin: $ouiColorDarkShade,
 );
 
 .ouiLink {
@@ -34,7 +35,8 @@ $ouiLinkColors: (
   }
 
   // Create color modifiers based on the map
-  @each $name, $color in $ouiLinkColors {
+  @each $name,
+  $color in $ouiLinkColors {
     &.ouiLink--#{$name} {
       color: $color;
 
@@ -53,7 +55,8 @@ $ouiLinkColors: (
 }
 
 // Make button OuiLink's text selectable
-button.ouiLink { // sass-lint:disable-line no-qualifying-elements
+button.ouiLink {
+  // sass-lint:disable-line no-qualifying-elements
   user-select: text;
 }
 

--- a/src/components/link/link.tsx
+++ b/src/components/link/link.tsx
@@ -52,7 +52,8 @@ export type OuiLinkColor =
   | 'danger'
   | 'warning'
   | 'text'
-  | 'ghost';
+  | 'ghost'
+  | 'coin';
 
 const colorsToClassNameMap: { [color in OuiLinkColor]: string } = {
   primary: 'ouiLink--primary',
@@ -64,6 +65,7 @@ const colorsToClassNameMap: { [color in OuiLinkColor]: string } = {
   warning: 'ouiLink--warning',
   ghost: 'ouiLink--ghost',
   text: 'ouiLink--text',
+  coin: 'ouiLink--coin',
 };
 
 export const COLORS = keysOf(colorsToClassNameMap);


### PR DESCRIPTION
### Description
Removed the usage of important for the breadcrumbs and ensured that it works as before.

<img width="983" alt="Screenshot 2023-03-23 at 11 50 44 AM" src="https://user-images.githubusercontent.com/62020972/227262960-8bf5697d-17db-4c68-bc7a-f5187e89e3c7.png">
<img width="1017" alt="Screenshot 2023-03-23 at 11 52 15 AM" src="https://user-images.githubusercontent.com/62020972/227262963-b4696603-ed09-4fc1-acd2-f5f13e437b8e.png">

 
### Issues Resolved
Fixes #376 
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [x] All tests pass
  - [x] `yarn lint`
  - [x] `yarn test-unit`
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/oui/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
