### PR TITLE
Add build artifacts to release

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -13,8 +13,24 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+      - name: Setup Node
+        uses: actions/setup-node@v3
+        with:
+          node-version-file: '.nvmrc'
+          registry-url: 'https://registry.npmjs.org'
+      - name: Setup Yarn
+        run: |
+          npm uninstall -g yarn
+          npm i -g yarn@1.22.10
+          yarn install --frozen-lockfile
+      - name: Generate build
+        run: |
+          yarn build
+          yarn pack --filename oui.tar.gz
       - name: Release
         uses: softprops/action-gh-release@v1
         with:
           draft: true
           generate_release_notes: true
+          files: |
+            oui.tar.gz

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -27,10 +27,12 @@ jobs:
         run: |
           yarn build
           yarn pack --filename oui.tar.gz
+          mkdir oui && mv oui.tar.gz oui/oui.tar.gz
+          tar -cvf artifacts.tar.gz oui
       - name: Release
         uses: softprops/action-gh-release@v1
         with:
           draft: true
           generate_release_notes: true
           files: |
-            oui.tar.gz
+            artifacts.tar.gz


### PR DESCRIPTION
### Description
Adds build artifacts to the release drafter workflow. By running `yarn build` before drafting the release, we can make sure releases include all of the compiled JS and CSS needed by consumers
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [x] All tests pass
  - [x] `yarn lint`
  - [x] `yarn test-unit`
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/oui/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
