### PR TITLE
[CCI] Migrate from faker to @faker-js/faker

### DIFF
--- a/package.json
+++ b/package.json
@@ -120,6 +120,7 @@
     "vfile": "^4.2.0"
   },
   "devDependencies": {
+    "@faker-js/faker": "^7.6.0",
     "@axe-core/puppeteer": "^4.1.1",
     "@babel/cli": "^7.10.5",
     "@babel/core": "^7.11.4",
@@ -189,7 +190,6 @@
     "eslint-plugin-react": "^7.21.3",
     "eslint-plugin-react-hooks": "^4.1.2",
     "expose-gc": "^1.0.0",
-    "faker": "^4.1.0",
     "file-loader": "^6.1.0",
     "findup": "^0.1.5",
     "fork-ts-checker-webpack-plugin": "^5.1.0",

--- a/src-docs/src/views/datagrid/additional_controls.js
+++ b/src-docs/src/views/datagrid/additional_controls.js
@@ -10,7 +10,7 @@
  */
 
 import React, { useState, useCallback, Fragment } from 'react';
-import { fake } from 'faker';
+import { faker } from '@faker-js/faker';
 
 import {
   OuiDataGrid,
@@ -40,13 +40,17 @@ const data = [];
 
 for (let i = 1; i < 20; i++) {
   data.push({
-    name: fake('{{name.lastName}}, {{name.firstName}} {{name.suffix}}'),
-    email: fake('{{internet.email}}'),
-    city: (
-      <OuiLink href="http://google.com">{fake('{{address.city}}')}</OuiLink>
+    name: faker.helpers.fake(
+      '{{name.lastName}}, {{name.firstName}} {{name.suffix}}'
     ),
-    country: fake('{{address.country}}'),
-    account: fake('{{finance.account}}'),
+    email: faker.helpers.fake('{{internet.email}}'),
+    city: (
+      <OuiLink href="http://google.com">
+        {faker.helpers.fake('{{address.city}}')}
+      </OuiLink>
+    ),
+    country: faker.helpers.fake('{{address.country}}'),
+    account: faker.helpers.fake('{{finance.account}}'),
   });
 }
 

--- a/src-docs/src/views/datagrid/column_actions.js
+++ b/src-docs/src/views/datagrid/column_actions.js
@@ -10,7 +10,7 @@
  */
 
 import React, { useState, useCallback } from 'react';
-import { fake } from 'faker';
+import { faker } from '@faker-js/faker';
 
 import { OuiDataGrid, OuiAvatar } from '../../../../src/components/';
 
@@ -68,14 +68,16 @@ for (let i = 1; i < 5; i++) {
     avatar: (
       <OuiAvatar
         size="s"
-        name={fake('{{name.lastName}}, {{name.firstName}}')}
+        name={faker.helpers.fake('{{name.lastName}}, {{name.firstName}}')}
       />
     ),
-    name: fake('{{name.lastName}}, {{name.firstName}} {{name.suffix}}'),
-    email: fake('{{internet.email}}'),
-    city: fake('{{address.city}}'),
-    country: fake('{{address.country}}'),
-    account: fake('{{finance.account}}'),
+    name: faker.helpers.fake(
+      '{{name.lastName}}, {{name.firstName}} {{name.suffix}}'
+    ),
+    email: faker.helpers.fake('{{internet.email}}'),
+    city: faker.helpers.fake('{{address.city}}'),
+    country: faker.helpers.fake('{{address.country}}'),
+    account: faker.helpers.fake('{{finance.account}}'),
   });
 }
 

--- a/src-docs/src/views/datagrid/column_cell_actions.js
+++ b/src-docs/src/views/datagrid/column_cell_actions.js
@@ -10,7 +10,7 @@
  */
 
 import React, { useState, useCallback } from 'react';
-import { fake } from 'faker';
+import { faker } from '@faker-js/faker';
 
 import { OuiDataGrid, OuiAvatar } from '../../../../src/components/';
 
@@ -115,14 +115,16 @@ for (let i = 1; i < 5; i++) {
     avatar: (
       <OuiAvatar
         size="s"
-        name={fake('{{name.lastName}}, {{name.firstName}}')}
+        name={faker.helpers.fake('{{name.lastName}}, {{name.firstName}}')}
       />
     ),
-    name: fake('{{name.lastName}}, {{name.firstName}} {{name.suffix}}'),
-    email: fake('{{internet.email}}'),
-    city: fake('{{address.city}}'),
-    country: fake('{{address.country}}'),
-    account: fake('{{finance.account}}'),
+    name: faker.helpers.fake(
+      '{{name.lastName}}, {{name.firstName}} {{name.suffix}}'
+    ),
+    email: faker.helpers.fake('{{internet.email}}'),
+    city: faker.helpers.fake('{{address.city}}'),
+    country: faker.helpers.fake('{{address.country}}'),
+    account: faker.helpers.fake('{{finance.account}}'),
   });
 }
 

--- a/src-docs/src/views/datagrid/column_widths.js
+++ b/src-docs/src/views/datagrid/column_widths.js
@@ -10,7 +10,7 @@
  */
 
 import React, { useState, useCallback } from 'react';
-import { fake } from 'faker';
+import { faker } from '@faker-js/faker';
 
 import { OuiDataGrid, OuiAvatar } from '../../../../src/components/';
 
@@ -45,14 +45,16 @@ for (let i = 1; i < 5; i++) {
     avatar: (
       <OuiAvatar
         size="s"
-        name={fake('{{name.lastName}}, {{name.firstName}}')}
+        name={faker.helpers.fake('{{name.lastName}}, {{name.firstName}}')}
       />
     ),
-    name: fake('{{name.lastName}}, {{name.firstName}} {{name.suffix}}'),
-    email: fake('{{internet.email}}'),
-    city: fake('{{address.city}}'),
-    country: fake('{{address.country}}'),
-    account: fake('{{finance.account}}'),
+    name: faker.helpers.fake(
+      '{{name.lastName}}, {{name.firstName}} {{name.suffix}}'
+    ),
+    email: faker.helpers.fake('{{internet.email}}'),
+    city: faker.helpers.fake('{{address.city}}'),
+    country: faker.helpers.fake('{{address.country}}'),
+    account: faker.helpers.fake('{{finance.account}}'),
   });
 }
 

--- a/src-docs/src/views/datagrid/container.js
+++ b/src-docs/src/views/datagrid/container.js
@@ -10,7 +10,7 @@
  */
 
 import React, { useState, useCallback } from 'react';
-import { fake } from 'faker';
+import { faker } from '@faker-js/faker';
 
 import { OuiDataGrid, OuiPanel, OuiLink } from '../../../../src/components/';
 
@@ -36,13 +36,17 @@ const data = [];
 
 for (let i = 1; i < 20; i++) {
   data.push({
-    name: fake('{{name.lastName}}, {{name.firstName}} {{name.suffix}}'),
-    email: fake('{{internet.email}}'),
-    city: (
-      <OuiLink href="http://google.com">{fake('{{address.city}}')}</OuiLink>
+    name: faker.helpers.fake(
+      '{{name.lastName}}, {{name.firstName}} {{name.suffix}}'
     ),
-    country: fake('{{address.country}}'),
-    account: fake('{{finance.account}}'),
+    email: faker.helpers.fake('{{internet.email}}'),
+    city: (
+      <OuiLink href="http://google.com">
+        {faker.helpers.fake('{{address.city}}')}
+      </OuiLink>
+    ),
+    country: faker.helpers.fake('{{address.country}}'),
+    account: faker.helpers.fake('{{finance.account}}'),
   });
 }
 

--- a/src-docs/src/views/datagrid/control_columns.js
+++ b/src-docs/src/views/datagrid/control_columns.js
@@ -17,7 +17,7 @@ import React, {
   useState,
   Fragment,
 } from 'react';
-import { fake } from 'faker';
+import { faker } from '@faker-js/faker';
 
 import {
   OuiDataGrid,
@@ -72,14 +72,16 @@ for (let i = 1; i < 500; i++) {
     avatar: (
       <OuiAvatar
         size="s"
-        name={fake('{{name.lastName}}, {{name.firstName}}')}
+        name={faker.helpers.fake('{{name.lastName}}, {{name.firstName}}')}
       />
     ),
-    name: fake('{{name.lastName}}, {{name.firstName}} {{name.suffix}}'),
-    email: fake('{{internet.email}}'),
-    city: fake('{{address.city}}'),
-    country: fake('{{address.country}}'),
-    account: fake('{{finance.account}}'),
+    name: faker.helpers.fake(
+      '{{name.lastName}}, {{name.firstName}} {{name.suffix}}'
+    ),
+    email: faker.helpers.fake('{{internet.email}}'),
+    city: faker.helpers.fake('{{address.city}}'),
+    country: faker.helpers.fake('{{address.country}}'),
+    account: faker.helpers.fake('{{finance.account}}'),
   });
 }
 

--- a/src-docs/src/views/datagrid/datagrid.js
+++ b/src-docs/src/views/datagrid/datagrid.js
@@ -19,7 +19,7 @@ import React, {
   useContext,
   useRef,
 } from 'react';
-import { fake } from 'faker';
+import { faker } from '@faker-js/faker';
 
 import {
   OuiDataGrid,
@@ -36,31 +36,33 @@ const DataContext = createContext();
 const raw_data = [];
 
 for (let i = 1; i < 100; i++) {
-  const email = fake('{{internet.email}}');
-  const name = fake('{{name.lastName}}, {{name.firstName}}');
-  const suffix = fake('{{name.suffix}}');
+  const email = faker.helpers.fake('{{internet.email}}');
+  const name = faker.helpers.fake('{{name.lastName}}, {{name.firstName}}');
+  const suffix = faker.helpers.fake('{{name.suffix}}');
   raw_data.push({
     name: {
       formatted: `${name} ${suffix}`,
       raw: name,
     },
     email: {
-      formatted: <OuiLink href="">{fake('{{internet.email}}')}</OuiLink>,
+      formatted: (
+        <OuiLink href="">{faker.helpers.fake('{{internet.email}}')}</OuiLink>
+      ),
       raw: email,
     },
     location: (
       <Fragment>
-        {`${fake('{{address.city}}')}, `}
+        {`${faker.helpers.fake('{{address.city}}')}, `}
         <OuiLink href="https://google.com">
-          {fake('{{address.country}}')}
+          {faker.helpers.fake('{{address.country}}')}
         </OuiLink>
       </Fragment>
     ),
-    date: fake('{{date.past}}'),
-    account: fake('{{finance.account}}'),
-    amount: fake('${{commerce.price}}'),
-    phone: fake('{{phone.phoneNumber}}'),
-    version: fake('{{system.semver}}'),
+    date: faker.helpers.fake('{{date.past}}'),
+    account: faker.helpers.fake('{{finance.account}}'),
+    amount: faker.helpers.fake('${{commerce.price}}'),
+    phone: faker.helpers.fake('{{phone.number}}'),
+    version: faker.helpers.fake('{{system.semver}}'),
   });
 }
 

--- a/src-docs/src/views/datagrid/focus.js
+++ b/src-docs/src/views/datagrid/focus.js
@@ -11,7 +11,7 @@
 
 /* eslint-disable jsx-a11y/accessible-emoji */
 import React, { useState, useCallback, useMemo } from 'react';
-import { fake } from 'faker';
+import { faker } from '@faker-js/faker';
 
 import {
   OuiDataGrid,
@@ -30,17 +30,17 @@ const data = [];
 
 for (let i = 0; i < 10; i++) {
   data.push([
-    <span>{fake('{{name.firstName}}')}</span>,
-    <span>{fake('{{name.firstName}}')}</span>,
+    <span>{faker.helpers.fake('{{name.firstName}}')}</span>,
+    <span>{faker.helpers.fake('{{name.firstName}}')}</span>,
 
     <span>
       <OuiLink href="#/tabular-content/data-grid-focus">
-        {fake('{{internet.email}}')}
+        {faker.helpers.fake('{{internet.email}}')}
       </OuiLink>
     </span>,
     <span>
       <OuiLink href="#/tabular-content/data-grid-focus">
-        {fake('{{internet.email}}')}
+        {faker.helpers.fake('{{internet.email}}')}
       </OuiLink>
     </span>,
 

--- a/src-docs/src/views/datagrid/footer_row.js
+++ b/src-docs/src/views/datagrid/footer_row.js
@@ -10,7 +10,7 @@
  */
 
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
-import { fake } from 'faker';
+import { faker } from '@faker-js/faker';
 
 import {
   OuiDataGrid,
@@ -23,11 +23,13 @@ const raw_data = [];
 
 for (let i = 1; i < 20; i++) {
   raw_data.push({
-    name: fake('{{name.lastName}}, {{name.firstName}} {{name.suffix}}'),
-    date: fake('{{date.past}}'),
-    amount: fake('${{commerce.price}}'),
-    phone: fake('{{phone.phoneNumber}}'),
-    version: fake('{{system.semver}}'),
+    name: faker.helpers.fake(
+      '{{name.lastName}}, {{name.firstName}} {{name.suffix}}'
+    ),
+    date: faker.helpers.fake('{{date.past}}'),
+    amount: faker.helpers.fake('${{commerce.price}}'),
+    phone: faker.helpers.fake('{{phone.number}}'),
+    version: faker.helpers.fake('{{system.semver}}'),
   });
 }
 

--- a/src-docs/src/views/datagrid/in_memory.js
+++ b/src-docs/src/views/datagrid/in_memory.js
@@ -10,7 +10,7 @@
  */
 
 import React, { Fragment, useCallback, useMemo, useState } from 'react';
-import { fake } from 'faker';
+import { faker } from '@faker-js/faker';
 
 import { OuiDataGrid, OuiLink } from '../../../../src/components/';
 
@@ -46,21 +46,25 @@ const raw_data = [];
 
 for (let i = 1; i < 100; i++) {
   raw_data.push({
-    name: fake('{{name.lastName}}, {{name.firstName}} {{name.suffix}}'),
-    email: <OuiLink href="">{fake('{{internet.email}}')}</OuiLink>,
+    name: faker.helpers.fake(
+      '{{name.lastName}}, {{name.firstName}} {{name.suffix}}'
+    ),
+    email: (
+      <OuiLink href="">{faker.helpers.fake('{{internet.email}}')}</OuiLink>
+    ),
     location: (
       <Fragment>
-        {`${fake('{{address.city}}')}, `}
+        {`${faker.helpers.fake('{{address.city}}')}, `}
         <OuiLink href="https://google.com">
-          {fake('{{address.country}}')}
+          {faker.helpers.fake('{{address.country}}')}
         </OuiLink>
       </Fragment>
     ),
-    date: fake('{{date.past}}'),
-    account: fake('{{finance.account}}'),
-    amount: fake('${{commerce.price}}'),
-    phone: fake('{{phone.phoneNumber}}'),
-    version: fake('{{system.semver}}'),
+    date: faker.helpers.fake('{{date.past}}'),
+    account: faker.helpers.fake('{{finance.account}}'),
+    amount: faker.helpers.fake('${{commerce.price}}'),
+    phone: faker.helpers.fake('{{phone.number}}'),
+    version: faker.helpers.fake('{{system.semver}}'),
   });
 }
 

--- a/src-docs/src/views/datagrid/in_memory_enhancements.js
+++ b/src-docs/src/views/datagrid/in_memory_enhancements.js
@@ -10,7 +10,7 @@
  */
 
 import React, { Fragment, useCallback, useMemo, useState } from 'react';
-import { fake } from 'faker';
+import { faker } from '@faker-js/faker';
 
 import { OuiDataGrid, OuiLink } from '../../../../src/components/';
 
@@ -45,21 +45,25 @@ const raw_data = [];
 
 for (let i = 1; i < 100; i++) {
   raw_data.push({
-    name: fake('{{name.lastName}}, {{name.firstName}} {{name.suffix}}'),
-    email: <OuiLink href="">{fake('{{internet.email}}')}</OuiLink>,
+    name: faker.helpers.fake(
+      '{{name.lastName}}, {{name.firstName}} {{name.suffix}}'
+    ),
+    email: (
+      <OuiLink href="">{faker.helpers.fake('{{internet.email}}')}</OuiLink>
+    ),
     location: (
       <Fragment>
-        {`${fake('{{address.city}}')}, `}
+        {`${faker.helpers.fake('{{address.city}}')}, `}
         <OuiLink href="https://google.com">
-          {fake('{{address.country}}')}
+          {faker.helpers.fake('{{address.country}}')}
         </OuiLink>
       </Fragment>
     ),
-    date: fake('{{date.past}}'),
-    account: fake('{{finance.account}}'),
-    amount: fake('${{commerce.price}}'),
-    phone: fake('{{phone.phoneNumber}}'),
-    version: fake('{{system.semver}}'),
+    date: faker.helpers.fake('{{date.past}}'),
+    account: faker.helpers.fake('{{finance.account}}'),
+    amount: faker.helpers.fake('${{commerce.price}}'),
+    phone: faker.helpers.fake('{{phone.number}}'),
+    version: faker.helpers.fake('{{system.semver}}'),
   });
 }
 

--- a/src-docs/src/views/datagrid/in_memory_pagination.js
+++ b/src-docs/src/views/datagrid/in_memory_pagination.js
@@ -10,7 +10,7 @@
  */
 
 import React, { Fragment, useCallback, useMemo, useState } from 'react';
-import { fake } from 'faker';
+import { faker } from '@faker-js/faker';
 
 import { OuiDataGrid, OuiLink } from '../../../../src/components/';
 
@@ -45,21 +45,25 @@ const raw_data = [];
 
 for (let i = 1; i < 100; i++) {
   raw_data.push({
-    name: fake('{{name.lastName}}, {{name.firstName}} {{name.suffix}}'),
-    email: <OuiLink href="">{fake('{{internet.email}}')}</OuiLink>,
+    name: faker.helpers.fake(
+      '{{name.lastName}}, {{name.firstName}} {{name.suffix}}'
+    ),
+    email: (
+      <OuiLink href="">{faker.helpers.fake('{{internet.email}}')}</OuiLink>
+    ),
     location: (
       <Fragment>
-        {`${fake('{{address.city}}')}, `}
+        {`${faker.helpers.fake('{{address.city}}')}, `}
         <OuiLink href="https://google.com">
-          {fake('{{address.country}}')}
+          {faker.helpers.fake('{{address.country}}')}
         </OuiLink>
       </Fragment>
     ),
-    date: fake('{{date.past}}'),
-    account: fake('{{finance.account}}'),
-    amount: fake('${{commerce.price}}'),
-    phone: fake('{{phone.phoneNumber}}'),
-    version: fake('{{system.semver}}'),
+    date: faker.helpers.fake('{{date.past}}'),
+    account: faker.helpers.fake('{{finance.account}}'),
+    amount: faker.helpers.fake('${{commerce.price}}'),
+    phone: faker.helpers.fake('{{phone.number}}'),
+    version: faker.helpers.fake('{{system.semver}}'),
   });
 }
 

--- a/src-docs/src/views/datagrid/in_memory_sorting.js
+++ b/src-docs/src/views/datagrid/in_memory_sorting.js
@@ -10,7 +10,7 @@
  */
 
 import React, { Fragment, useCallback, useMemo, useState } from 'react';
-import { fake } from 'faker';
+import { faker } from '@faker-js/faker';
 
 import { OuiDataGrid, OuiLink } from '../../../../src/components/';
 
@@ -45,21 +45,25 @@ const raw_data = [];
 
 for (let i = 1; i < 100; i++) {
   raw_data.push({
-    name: fake('{{name.lastName}}, {{name.firstName}} {{name.suffix}}'),
-    email: <OuiLink href="">{fake('{{internet.email}}')}</OuiLink>,
+    name: faker.helpers.fake(
+      '{{name.lastName}}, {{name.firstName}} {{name.suffix}}'
+    ),
+    email: (
+      <OuiLink href="">{faker.helpers.fake('{{internet.email}}')}</OuiLink>
+    ),
     location: (
       <Fragment>
-        {`${fake('{{address.city}}')}, `}
+        {`${faker.helpers.fake('{{address.city}}')}, `}
         <OuiLink href="https://google.com">
-          {fake('{{address.country}}')}
+          {faker.helpers.fake('{{address.country}}')}
         </OuiLink>
       </Fragment>
     ),
-    date: fake('{{date.past}}'),
-    account: fake('{{finance.account}}'),
-    amount: fake('${{commerce.price}}'),
-    phone: fake('{{phone.phoneNumber}}'),
-    version: fake('{{system.semver}}'),
+    date: faker.helpers.fake('{{date.past}}'),
+    account: faker.helpers.fake('{{finance.account}}'),
+    amount: faker.helpers.fake('${{commerce.price}}'),
+    phone: faker.helpers.fake('{{phone.number}}'),
+    version: faker.helpers.fake('{{system.semver}}'),
   });
 }
 

--- a/src-docs/src/views/datagrid/row_height_options.js
+++ b/src-docs/src/views/datagrid/row_height_options.js
@@ -17,7 +17,7 @@ import React, {
   useMemo,
   useEffect,
 } from 'react';
-import { fake } from 'faker';
+import { faker } from '@faker-js/faker';
 
 import { OuiDataGrid, OuiText } from '../../../../src/components/';
 
@@ -48,8 +48,8 @@ function RenderCellValue({ rowIndex, columnId }) {
 
   if (data[rowIndex] == null) {
     data[rowIndex] = {
-      name: fake('{{lorem.text}}'),
-      text: fake('{{lorem.text}}'),
+      name: faker.helpers.fake('{{lorem.text}}'),
+      text: faker.helpers.fake('{{lorem.text}}'),
     };
   }
 

--- a/src-docs/src/views/datagrid/schema.js
+++ b/src-docs/src/views/datagrid/schema.js
@@ -10,7 +10,7 @@
  */
 
 import React, { useState, useCallback } from 'react';
-import { fake } from 'faker';
+import { faker } from '@faker-js/faker';
 
 import {
   OuiDataGrid,
@@ -55,29 +55,35 @@ for (let i = 1; i < 5; i++) {
     franchise = 'Oranges';
     json = JSON.stringify([
       {
-        default: fake('{{name.lastName}}, {{name.firstName}} {{name.suffix}}'),
-        boolean: fake('{{random.boolean}}'),
-        numeric: fake('{{finance.account}}'),
-        currency: fake('${{finance.amount}}'),
-        date: fake('{{date.past}}'),
-        custom: fake('{{date.past}}'),
+        default: faker.helpers.fake(
+          '{{name.lastName}}, {{name.firstName}} {{name.suffix}}'
+        ),
+        boolean: faker.helpers.fake('{{datatype.boolean}}'),
+        numeric: faker.helpers.fake('{{finance.account}}'),
+        currency: faker.helpers.fake('${{finance.amount}}'),
+        date: faker.helpers.fake('{{date.past}}'),
+        custom: faker.helpers.fake('{{date.past}}'),
       },
     ]);
   } else {
     franchise = 'Apples';
     json = JSON.stringify([
       {
-        name: fake('{{name.lastName}}, {{name.firstName}} {{name.suffix}}'),
+        name: faker.helpers.fake(
+          '{{name.lastName}}, {{name.firstName}} {{name.suffix}}'
+        ),
       },
     ]);
   }
 
   storeData.push({
-    default: fake('{{name.lastName}}, {{name.firstName}} {{name.suffix}}'),
-    boolean: fake('{{random.boolean}}'),
-    numeric: fake('{{finance.account}}'),
-    currency: fake('${{finance.amount}}'),
-    datetime: fake('{{date.past}}'),
+    default: faker.helpers.fake(
+      '{{name.lastName}}, {{name.firstName}} {{name.suffix}}'
+    ),
+    boolean: faker.helpers.fake('{{datatype.boolean}}'),
+    numeric: faker.helpers.fake('{{finance.account}}'),
+    currency: faker.helpers.fake('${{finance.amount}}'),
+    datetime: faker.helpers.fake('{{date.past}}'),
     json: json,
     custom: franchise,
   });

--- a/src-docs/src/views/datagrid/styling.js
+++ b/src-docs/src/views/datagrid/styling.js
@@ -10,7 +10,7 @@
  */
 
 import React, { useState, Fragment, useCallback } from 'react';
-import { fake } from 'faker';
+import { faker } from '@faker-js/faker';
 
 import {
   OuiDataGrid,
@@ -54,14 +54,16 @@ for (let i = 1; i < 6; i++) {
     avatar: (
       <OuiAvatar
         size="s"
-        name={fake('{{name.lastName}}, {{name.firstName}}')}
+        name={faker.helpers.fake('{{name.lastName}}, {{name.firstName}}')}
       />
     ),
-    name: fake('{{name.lastName}}, {{name.firstName}} {{name.suffix}}'),
-    email: fake('{{internet.email}}'),
-    city: fake('{{address.city}}'),
-    country: fake('{{address.country}}'),
-    account: fake('{{finance.account}}'),
+    name: faker.helpers.fake(
+      '{{name.lastName}}, {{name.firstName}} {{name.suffix}}'
+    ),
+    email: faker.helpers.fake('{{internet.email}}'),
+    city: faker.helpers.fake('{{address.city}}'),
+    country: faker.helpers.fake('{{address.country}}'),
+    account: faker.helpers.fake('{{finance.account}}'),
   });
 }
 

--- a/src-docs/src/views/datagrid/virtualization.js
+++ b/src-docs/src/views/datagrid/virtualization.js
@@ -18,7 +18,7 @@ import React, {
   useMemo,
   useEffect,
 } from 'react';
-import { fake } from 'faker';
+import { faker } from '@faker-js/faker';
 
 import {
   OuiDataGrid,
@@ -77,25 +77,25 @@ function RenderCellValue({ rowIndex, columnId }) {
   }, [adjustMountedCellCount]);
 
   if (data[rowIndex] == null) {
-    const email = fake('{{internet.email}}');
-    const name = fake('{{name.lastName}}, {{name.firstName}}');
-    const suffix = fake('{{name.suffix}}');
+    const email = faker.helpers.fake('{{internet.email}}');
+    const name = faker.helpers.fake('{{name.lastName}}, {{name.firstName}}');
+    const suffix = faker.helpers.fake('{{name.suffix}}');
     data[rowIndex] = {
       name: `${name} ${suffix}`,
       email: <OuiLink href="">{email}</OuiLink>,
       location: (
         <Fragment>
-          {`${fake('{{address.city}}')}, `}
+          {`${faker.helpers.fake('{{address.city}}')}, `}
           <OuiLink href="https://google.com">
-            {fake('{{address.country}}')}
+            {faker.helpers.fake('{{address.country}}')}
           </OuiLink>
         </Fragment>
       ),
-      date: fake('{{date.past}}'),
-      account: fake('{{finance.account}}'),
-      amount: fake('${{commerce.price}}'),
-      phone: fake('{{phone.phoneNumber}}'),
-      version: fake('{{system.semver}}'),
+      date: faker.helpers.fake('{{date.past}}'),
+      account: faker.helpers.fake('{{finance.account}}'),
+      amount: faker.helpers.fake('${{commerce.price}}'),
+      phone: faker.helpers.fake('{{phone.number}}'),
+      version: faker.helpers.fake('{{system.semver}}'),
     };
   }
 

--- a/src-docs/src/views/datagrid/virtualization_constrained.js
+++ b/src-docs/src/views/datagrid/virtualization_constrained.js
@@ -18,7 +18,7 @@ import React, {
   useMemo,
   useEffect,
 } from 'react';
-import { fake } from 'faker';
+import { faker } from '@faker-js/faker';
 
 import {
   OuiDataGrid,
@@ -75,25 +75,25 @@ function RenderCellValue({ rowIndex, columnId }) {
   }, [adjustMountedCellCount]);
 
   if (data[rowIndex] == null) {
-    const email = fake('{{internet.email}}');
-    const name = fake('{{name.lastName}}, {{name.firstName}}');
-    const suffix = fake('{{name.suffix}}');
+    const email = faker.helpers.fake('{{internet.email}}');
+    const name = faker.helpers.fake('{{name.lastName}}, {{name.firstName}}');
+    const suffix = faker.helpers.fake('{{name.suffix}}');
     data[rowIndex] = {
       name: `${name} ${suffix}`,
       email: <OuiLink href="">{email}</OuiLink>,
       location: (
         <Fragment>
-          {`${fake('{{address.city}}')}, `}
+          {`${faker.helpers.fake('{{address.city}}')}, `}
           <OuiLink href="https://google.com">
-            {fake('{{address.country}}')}
+            {faker.helpers.fake('{{address.country}}')}
           </OuiLink>
         </Fragment>
       ),
-      date: fake('{{date.past}}'),
-      account: fake('{{finance.account}}'),
-      amount: fake('${{commerce.price}}'),
-      phone: fake('{{phone.phoneNumber}}'),
-      version: fake('{{system.semver}}'),
+      date: faker.helpers.fake('{{date.past}}'),
+      account: faker.helpers.fake('{{finance.account}}'),
+      amount: faker.helpers.fake('${{commerce.price}}'),
+      phone: faker.helpers.fake('{{phone.number}}'),
+      version: faker.helpers.fake('{{system.semver}}'),
     };
   }
 

--- a/src-docs/src/views/image/float.js
+++ b/src-docs/src/views/image/float.js
@@ -12,7 +12,7 @@
 import React from 'react';
 
 import { OuiImage, OuiText } from '../../../../src/components';
-import { fake } from 'faker';
+import { faker } from '@faker-js/faker';
 
 export default () => (
   <OuiText>
@@ -26,9 +26,9 @@ export default () => (
       alt="Random nature image"
       src="https://picsum.photos/800/500"
     />
-    <p>{fake('{{lorem.paragraphs}}')}</p>
-    <p>{fake('{{lorem.paragraphs}}')}</p>
-    <p>{fake('{{lorem.paragraphs}}')}</p>
+    <p>{faker.helpers.fake('{{lorem.paragraphs}}')}</p>
+    <p>{faker.helpers.fake('{{lorem.paragraphs}}')}</p>
+    <p>{faker.helpers.fake('{{lorem.paragraphs}}')}</p>
     <OuiImage
       size="l"
       float="left"
@@ -39,7 +39,7 @@ export default () => (
       alt="Random nature image"
       src="https://picsum.photos/300/300"
     />
-    <p>{fake('{{lorem.paragraphs}}')}</p>
-    <p>{fake('{{lorem.paragraphs}}')}</p>
+    <p>{faker.helpers.fake('{{lorem.paragraphs}}')}</p>
+    <p>{faker.helpers.fake('{{lorem.paragraphs}}')}</p>
   </OuiText>
 );

--- a/src-docs/src/views/resizable_container/resizable_container_basic.js
+++ b/src-docs/src/views/resizable_container/resizable_container_basic.js
@@ -11,13 +11,13 @@
 
 import React from 'react';
 import { OuiText, OuiResizableContainer } from '../../../../src/components';
-import { fake } from 'faker';
+import { faker } from '@faker-js/faker';
 
 const text = (
   <>
-    <p>{fake('{{lorem.paragraphs}}')}</p>
-    <p>{fake('{{lorem.paragraphs}}')}</p>
-    <p>{fake('{{lorem.paragraphs}}')}</p>
+    <p>{faker.helpers.fake('{{lorem.paragraphs}}')}</p>
+    <p>{faker.helpers.fake('{{lorem.paragraphs}}')}</p>
+    <p>{faker.helpers.fake('{{lorem.paragraphs}}')}</p>
   </>
 );
 

--- a/src-docs/src/views/resizable_container/resizable_container_reset_values.js
+++ b/src-docs/src/views/resizable_container/resizable_container_reset_values.js
@@ -19,13 +19,13 @@ import {
   OuiButton,
   OuiSpacer,
 } from '../../../../src/components';
-import { fake } from 'faker';
+import { faker } from '@faker-js/faker';
 
 const text = (
   <>
-    <p>{fake('{{lorem.paragraphs}}')}</p>
-    <p>{fake('{{lorem.paragraphs}}')}</p>
-    <p>{fake('{{lorem.paragraphs}}')}</p>
+    <p>{faker.helpers.fake('{{lorem.paragraphs}}')}</p>
+    <p>{faker.helpers.fake('{{lorem.paragraphs}}')}</p>
+    <p>{faker.helpers.fake('{{lorem.paragraphs}}')}</p>
   </>
 );
 

--- a/src-docs/src/views/resizable_container/resizable_container_vertical.js
+++ b/src-docs/src/views/resizable_container/resizable_container_vertical.js
@@ -12,13 +12,13 @@
 import React from 'react';
 
 import { OuiText, OuiResizableContainer } from '../../../../src/components';
-import { fake } from 'faker';
+import { faker } from '@faker-js/faker';
 
 const text = (
   <>
-    <p>{fake('{{lorem.paragraphs}}')}</p>
-    <p>{fake('{{lorem.paragraphs}}')}</p>
-    <p>{fake('{{lorem.paragraphs}}')}</p>
+    <p>{faker.helpers.fake('{{lorem.paragraphs}}')}</p>
+    <p>{faker.helpers.fake('{{lorem.paragraphs}}')}</p>
+    <p>{faker.helpers.fake('{{lorem.paragraphs}}')}</p>
   </>
 );
 

--- a/src-docs/src/views/resizable_container/resizable_panel_collapsible.js
+++ b/src-docs/src/views/resizable_container/resizable_panel_collapsible.js
@@ -20,12 +20,12 @@ import {
   OuiSpacer,
   OuiPage,
 } from '../../../../src/components';
-import { fake } from 'faker';
+import { faker } from '@faker-js/faker';
 
 const texts = [];
 
 for (let i = 0; i < 4; i++) {
-  texts.push(<p>{fake('{{lorem.paragraph}}')}</p>);
+  texts.push(<p>{faker.helpers.fake('{{lorem.paragraph}}')}</p>);
 }
 
 export default () => {

--- a/src-docs/src/views/resizable_container/resizable_panel_collapsible_options.js
+++ b/src-docs/src/views/resizable_container/resizable_panel_collapsible_options.js
@@ -20,12 +20,12 @@ import {
   OuiText,
   OuiPage,
 } from '../../../../src/components';
-import { fake } from 'faker';
+import { faker } from '@faker-js/faker';
 
 const texts = [];
 
 for (let i = 0; i < 4; i++) {
-  texts.push(<p>{fake('{{lorem.paragraph}}')}</p>);
+  texts.push(<p>{faker.helpers.fake('{{lorem.paragraph}}')}</p>);
 }
 
 export default () => {

--- a/src-docs/src/views/resizable_container/resizable_panel_collapsible_responsive.js
+++ b/src-docs/src/views/resizable_container/resizable_panel_collapsible_responsive.js
@@ -21,12 +21,12 @@ import {
   OuiPage,
 } from '../../../../src/components';
 import { useIsWithinBreakpoints } from '../../../../src/services';
-import { fake } from 'faker';
+import { faker } from '@faker-js/faker';
 
 const texts = [];
 
 for (let i = 0; i < 4; i++) {
-  texts.push(<p>{fake('{{lorem.paragraph}}')}</p>);
+  texts.push(<p>{faker.helpers.fake('{{lorem.paragraph}}')}</p>);
 }
 
 export default () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1164,6 +1164,11 @@
     minimatch "^3.0.4"
     strip-json-comments "^3.1.1"
 
+"@faker-js/faker@^7.6.0":
+  version "7.6.0"
+  resolved "https://registry.yarnpkg.com/@faker-js/faker/-/faker-7.6.0.tgz#9ea331766084288634a9247fcd8b84f16ff4ba07"
+  integrity sha512-XK6BTq1NDMo9Xqw/YkYyGjSsg44fbNwYRx7QK2CuoQgyy+f1rrTDHoExVM5PsyXCtfl2vs2vVJ0MN0yN6LppRw==
+
 "@fisker/parse-srcset@1.0.2":
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/@fisker/parse-srcset/-/parse-srcset-1.0.2.tgz#6e051549fbf77ab5febda5176720e85aea70e80e"
@@ -6621,11 +6626,6 @@ extsprintf@^1.2.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/extsprintf/-/extsprintf-1.4.0.tgz#e2689f8f356fad62cca65a3a91c5df5f9551692f"
   integrity sha1-4mifjzVvrWLMplo6kcXfX5VRaS8=
-
-faker@^4.1.0:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/faker/-/faker-4.1.0.tgz#1e45bbbecc6774b3c195fad2835109c6d748cc3f"
-  integrity sha1-HkW7vsxndLPBlfrSg1EJxtdIzD8=
 
 fast-deep-equal@^3.1.1:
   version "3.1.1"
@@ -13543,7 +13543,7 @@ request-promise-native@^1.0.5:
     stealthy-require "^1.1.1"
     tough-cookie "^2.3.3"
 
-request@^2.87.0, request@^2.88.0:
+request@^2.87.0:
   version "2.88.0"
   resolved "https://registry.yarnpkg.com/request/-/request-2.88.0.tgz#9c2fca4f7d35b592efe57c7f0a55e81052124fef"
   integrity sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==


### PR DESCRIPTION
### Description
Migrate from `faker` to `@faker-js/faker`. 

The main goal is not to update `faker` as done in https://github.com/opensearch-project/oui/pull/653, but to discard it immediately and migrate to `@faker-js/faker`.
 
### Issues Resolved
https://github.com/opensearch-project/oui/issues/594
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [X] All tests pass
  - [X] `yarn lint`
  - [X] `yarn test-unit`
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/oui/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
