### PR TITLE
Publish OUI to npmjs using tarball

### DIFF
--- a/jenkins/release.JenkinsFile
+++ b/jenkins/release.JenkinsFile
@@ -1,4 +1,4 @@
-lib = library(identifier: 'jenkins@2.3.0', retriever: modernSCM([
+lib = library(identifier: 'jenkins@3.0.0', retriever: modernSCM([
     $class: 'GitSCMSource',
     remote: 'https://github.com/opensearch-project/opensearch-build-libraries.git',
 ]))
@@ -9,6 +9,7 @@ standardReleasePipelineWithGenericTrigger(
     downloadReleaseAsset: true,
     publishRelease: true) {
         publishToNpm(
+            publicationType: 'artifact',
             artifactPath: "${WORKSPACE}/oui/oui.tar.gz"
-        )
+            )
     }

--- a/jenkins/release.JenkinsFile
+++ b/jenkins/release.JenkinsFile
@@ -1,4 +1,4 @@
-lib = library(identifier: 'jenkins@1.1.1', retriever: modernSCM([
+lib = library(identifier: 'jenkins@2.3.0', retriever: modernSCM([
     $class: 'GitSCMSource',
     remote: 'https://github.com/opensearch-project/opensearch-build-libraries.git',
 ]))
@@ -6,6 +6,9 @@ lib = library(identifier: 'jenkins@1.1.1', retriever: modernSCM([
 standardReleasePipelineWithGenericTrigger(
     tokenIdCredential: 'jenkins-oui-generic-webhook-token',
     causeString: 'A tag was cut on opensearch-project/oui repository causing this workflow to run',
+    downloadReleaseAsset: true,
     publishRelease: true) {
-        publishToNpm(repository: 'https://github.com/opensearch-project/oui', tag: "$tag")
+        publishToNpm(
+            artifactPath: "${WORKSPACE}/oui/oui.tar.gz"
+        )
     }


### PR DESCRIPTION
Depends on https://github.com/opensearch-project/oui/pull/636 and https://github.com/opensearch-project/opensearch-build-libraries/pull/177

### Description
Changes the way OUI is published to npmjs.org. See attached issue for more details. The dependent PRs need to go in first. Keeping it in draft till then.
 
### Issues Resolved
 closes https://github.com/opensearch-project/opensearch-build/issues/3312
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] All tests pass
  - [ ] `yarn lint`
  - [ ] `yarn test-unit`
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/oui/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
