### PR TITLE
[CCI] Move OuiBottomBar default inline styles to the CSS file

### DIFF
--- a/src/components/bottom_bar/__snapshots__/bottom_bar.test.tsx.snap
+++ b/src/components/bottom_bar/__snapshots__/bottom_bar.test.tsx.snap
@@ -6,7 +6,6 @@ Array [
     aria-label="aria-label"
     class="ouiBottomBar ouiBottomBar--fixed ouiBottomBar--paddingMedium testClass1 testClass2"
     data-test-subj="test subject string"
-    style="left:0;right:0;bottom:0"
   >
     <h2
       class="ouiScreenReaderOnly"
@@ -29,7 +28,6 @@ Array [
   <section
     aria-label="Page level controls"
     class="ouiBottomBar ouiBottomBar--fixed ouiBottomBar--paddingMedium"
-    style="left:0;right:0;bottom:0"
   >
     <h2
       class="ouiScreenReaderOnly"
@@ -50,7 +48,6 @@ exports[`OuiBottomBar props bodyClassName is rendered 1`] = `
 <section
   aria-label="Page level controls"
   class="ouiBottomBar ouiBottomBar--fixed ouiBottomBar--paddingMedium"
-  style="left: 0px; right: 0px; bottom: 0px;"
 >
   <h2
     class="ouiScreenReaderOnly"
@@ -65,7 +62,6 @@ Array [
   <section
     aria-label="This should have been label"
     class="ouiBottomBar ouiBottomBar--fixed ouiBottomBar--paddingMedium"
-    style="left:0;right:0;bottom:0"
   >
     <h2
       class="ouiScreenReaderOnly"
@@ -87,7 +83,6 @@ Array [
   <section
     aria-label="Page level controls"
     class="ouiBottomBar ouiBottomBar--fixed ouiBottomBar--paddingLarge"
-    style="left:0;right:0;bottom:0"
   >
     <h2
       class="ouiScreenReaderOnly"
@@ -109,7 +104,6 @@ Array [
   <section
     aria-label="Page level controls"
     class="ouiBottomBar ouiBottomBar--fixed ouiBottomBar--paddingMedium"
-    style="left:0;right:0;bottom:0"
   >
     <h2
       class="ouiScreenReaderOnly"
@@ -131,7 +125,6 @@ Array [
   <section
     aria-label="Page level controls"
     class="ouiBottomBar ouiBottomBar--fixed"
-    style="left:0;right:0;bottom:0"
   >
     <h2
       class="ouiScreenReaderOnly"
@@ -153,7 +146,6 @@ Array [
   <section
     aria-label="Page level controls"
     class="ouiBottomBar ouiBottomBar--fixed ouiBottomBar--paddingSmall"
-    style="left:0;right:0;bottom:0"
   >
     <h2
       class="ouiScreenReaderOnly"
@@ -175,7 +167,6 @@ Array [
   <section
     aria-label="Page level controls"
     class="ouiBottomBar ouiBottomBar--fixed ouiBottomBar--paddingMedium"
-    style="left:0;right:0;bottom:0"
   >
     <h2
       class="ouiScreenReaderOnly"
@@ -219,7 +210,6 @@ Array [
   <section
     aria-label="Page level controls"
     class="ouiBottomBar ouiBottomBar--static ouiBottomBar--paddingMedium"
-    style="left:0;right:0;bottom:0"
   >
     <h2
       class="ouiScreenReaderOnly"
@@ -241,7 +231,6 @@ Array [
   <section
     aria-label="Page level controls"
     class="ouiBottomBar ouiBottomBar--sticky ouiBottomBar--paddingMedium"
-    style="left:0;right:0;bottom:0"
   >
     <h2
       class="ouiScreenReaderOnly"
@@ -263,7 +252,7 @@ Array [
   <section
     aria-label="Page level controls"
     class="ouiBottomBar ouiBottomBar--fixed ouiBottomBar--paddingMedium"
-    style="left:12px;right:0;bottom:0"
+    style="left:12px"
   >
     <h2
       class="ouiScreenReaderOnly"
@@ -285,7 +274,6 @@ Array [
   <section
     aria-label="Page level controls"
     class="ouiBottomBar ouiBottomBar--fixed ouiBottomBar--paddingMedium"
-    style="left:0;right:0;bottom:0"
   >
     <h2
       class="ouiScreenReaderOnly"

--- a/src/components/bottom_bar/_bottom_bar.scss
+++ b/src/components/bottom_bar/_bottom_bar.scss
@@ -10,6 +10,10 @@
  */
 
 .ouiBottomBar {
+  bottom: 0;
+  left: 0;
+  right: 0;
+
   @include ouiBottomShadowFlat($ouiShadowColorLarge);
   background: $ouiHeaderDarkBackgroundColor;
   color: $ouiColorGhost;

--- a/src/components/bottom_bar/bottom_bar.tsx
+++ b/src/components/bottom_bar/bottom_bar.tsx
@@ -132,9 +132,9 @@ export const OuiBottomBar = forwardRef<
       bodyClassName,
       landmarkHeading,
       usePortal = true,
-      left = 0,
-      right = 0,
-      bottom = 0,
+      left,
+      right,
+      bottom,
       top,
       style,
       ...rest

--- a/src/components/page/__snapshots__/page_template.test.tsx.snap
+++ b/src/components/page/__snapshots__/page_template.test.tsx.snap
@@ -1098,7 +1098,6 @@ exports[`OuiPageTemplate with bottomBar is rendered 1`] = `
     <section
       aria-label="Page level controls"
       class="ouiBottomBar ouiBottomBar--sticky"
-      style="left:0;right:0;bottom:0"
     >
       <h2
         class="ouiScreenReaderOnly"


### PR DESCRIPTION
### Description
Moved OuiBottomBar default inline styles to the CSS file
 
### Issues Resolved
https://github.com/opensearch-project/oui/issues/693
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [x] All tests pass
  - [x] `yarn lint`
  - [x] `yarn test-unit`
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/oui/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
