### PR TITLE
Fix aliasing regression in post install script

### DIFF
--- a/scripts/postinstall.js
+++ b/scripts/postinstall.js
@@ -33,7 +33,10 @@ if (!INIT_CWD?.startsWith?.(PWD)) {
 
     for (const entry of fs.readdirSync(src, { withFileTypes: true })) {
       const srcItem = path.join(src, entry.name);
-      const destItem = path.join(dest, entry.name);
+      const destItem = path
+        .join(dest, entry.name)
+        .replace('oui', 'eui')
+        .replace('cascadia', 'amsterdam');
 
       if (entry.isDirectory()) copyDirectory(srcItem, destItem);
       else fs.copyFileSync(srcItem, destItem);


### PR DESCRIPTION
### Description
Previously, in https://github.com/opensearch-project/oui/commit/9abf87e5c5ffcf970d0b45c5fa7db0ea8f7c18df, there was an aliasing regression in `scripts/postinstall.js`. Essentially it didn't rename files to their EUI counterpart. This PR fixes that and prepares OUI for the 1.1 release
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [x] All tests pass
  - [x] `yarn lint`
  - [x] `yarn test-unit`
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/oui/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
