### PR TITLE
[CCI] Add functionality to OuiBottomBar to have the same width as the container element

### DIFF
--- a/src-docs/src/views/app_view.js
+++ b/src-docs/src/views/app_view.js
@@ -97,7 +97,7 @@ export class AppView extends Component {
             />
           </OuiErrorBoundary>
 
-          <OuiPageBody panelled>
+          <OuiPageBody id="page-main-section" panelled>
             <OuiContext i18n={i18n}>
               <ThemeContext.Consumer>
                 {(context) => {

--- a/src-docs/src/views/bottom_bar/bottom_bar_container_width.js
+++ b/src-docs/src/views/bottom_bar/bottom_bar_container_width.js
@@ -1,0 +1,44 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React, { useState } from 'react';
+
+import {
+  OuiBottomBar,
+  OuiButton,
+  OuiFlexGroup,
+  OuiFlexItem,
+} from '../../../../src/components';
+
+export default () => {
+  const [isBottomBarVisible, setBottomBarVisibility] = useState(null);
+
+  return (
+    <div>
+      <OuiButton
+        buttonSize="m"
+        color="primary"
+        onClick={() => setBottomBarVisibility((prevVal) => !prevVal)}>
+        {isBottomBarVisible ? 'Hide' : 'Show'} bottom bar
+      </OuiButton>
+
+      {isBottomBarVisible && (
+        <OuiBottomBar left="unset" containerElementId="page-main-section">
+          <OuiFlexGroup justifyContent="flexEnd">
+            <OuiFlexItem grow={false}>
+              <OuiButton
+                onClick={() => setBottomBarVisibility(false)}
+                color="ghost"
+                size="s"
+                iconType="cross">
+                Close
+              </OuiButton>
+            </OuiFlexItem>
+          </OuiFlexGroup>
+        </OuiBottomBar>
+      )}
+    </div>
+  );
+};

--- a/src-docs/src/views/bottom_bar/bottom_bar_example.js
+++ b/src-docs/src/views/bottom_bar/bottom_bar_example.js
@@ -24,6 +24,9 @@ const bottomBarSource = require('!!raw-loader!./bottom_bar');
 import BottomBarDisplacement from './bottom_bar_displacement';
 const bottomBarDisplacementSource = require('!!raw-loader!./bottom_bar_displacement');
 
+import BottomBarContainerWidth from './bottom_bar_container_width';
+const bottomBarContainerWidthSource = require('!!raw-loader!./bottom_bar_container_width');
+
 import BottomBarPosition from './bottom_bar_position';
 import { OuiCallOut } from '../../../../src/components/call_out';
 const bottomBarPositionSource = require('!!raw-loader!./bottom_bar_position');
@@ -128,6 +131,30 @@ export const BottomBarExample = {
       props: { OuiBottomBar },
       demo: <BottomBarDisplacement />,
       snippet: `<OuiBottomBar affordForDisplacement={false}>
+  <!-- Content goes here -->
+</OuiBottomBar>`,
+    },
+    {
+      title: 'Container width',
+      source: [
+        {
+          type: GuideSectionTypes.JS,
+          code: bottomBarContainerWidthSource,
+        },
+      ],
+      text: (
+        <p>
+          The props <OuiCode>containerElementRef</OuiCode> and{' '}
+          <OuiCode>containerElementId</OuiCode> are optional and can be used to
+          control how the component determines its width. They allow you to
+          specify a container element, and the component will take the width of
+          that element instead of its default behavior of taking up the full
+          width available to it.
+        </p>
+      ),
+      props: { OuiBottomBar },
+      demo: <BottomBarContainerWidth />,
+      snippet: `<OuiBottomBar left="unset" containerElementId="page-main-section">
   <!-- Content goes here -->
 </OuiBottomBar>`,
     },

--- a/src-docs/src/views/resize_observer/resize_observer_hook.js
+++ b/src-docs/src/views/resize_observer/resize_observer_hook.js
@@ -36,7 +36,7 @@ export const ResizeObserverHookExample = () => {
   };
 
   const resizeRef = useRef();
-  const dimensions = useResizeObserver(resizeRef.current);
+  const dimensions = useResizeObserver({ elementRef: resizeRef });
 
   return (
     <div>

--- a/src/components/datagrid/data_grid_body.tsx
+++ b/src/components/datagrid/data_grid_body.tsx
@@ -363,15 +363,21 @@ export const OuiDataGridBody: FunctionComponent<OuiDataGridBodyProps> = (
     gridStyles,
   } = props;
 
-  const [headerRowRef, setHeaderRowRef] = useState<HTMLDivElement | null>(null);
-  const [footerRowRef, setFooterRowRef] = useState<HTMLDivElement | null>(null);
+  const headerRowRef = useRef<HTMLDivElement>(null);
+  const footerRowRef = useRef<HTMLDivElement>(null);
 
   useMutationObserver(headerRowRef, handleHeaderMutation, {
     subtree: true,
     childList: true,
   });
-  const { height: headerRowHeight } = useResizeObserver(headerRowRef, 'height');
-  const { height: footerRowHeight } = useResizeObserver(footerRowRef, 'height');
+  const { height: headerRowHeight } = useResizeObserver({
+    elementRef: headerRowRef,
+    observableDimension: 'height',
+  });
+  const { height: footerRowHeight } = useResizeObserver({
+    elementRef: footerRowRef,
+    observableDimension: 'height',
+  });
 
   const startRow = pagination ? pagination.pageIndex * pagination.pageSize : 0;
   let endRow = pagination
@@ -462,7 +468,7 @@ export const OuiDataGridBody: FunctionComponent<OuiDataGridBodyProps> = (
   const headerRow = useMemo(() => {
     return (
       <OuiDataGridHeaderRow
-        ref={setHeaderRowRef}
+        ref={headerRowRef}
         switchColumnPos={switchColumnPos}
         setVisibleColumns={setVisibleColumns}
         leadingControlColumns={leadingControlColumns}
@@ -494,7 +500,7 @@ export const OuiDataGridBody: FunctionComponent<OuiDataGridBodyProps> = (
     if (renderFooterCellValue == null) return null;
     return (
       <OuiDataGridFooterRow
-        ref={setFooterRowRef}
+        ref={footerRowRef}
         leadingControlColumns={leadingControlColumns}
         trailingControlColumns={trailingControlColumns}
         columns={columns}
@@ -641,7 +647,7 @@ export const OuiDataGridBody: FunctionComponent<OuiDataGridBodyProps> = (
   const [width, setWidth] = useState<number | undefined>(undefined);
 
   const wrapperRef = useRef<HTMLDivElement | null>(null);
-  const wrapperDimensions = useResizeObserver(wrapperRef.current);
+  const wrapperDimensions = useResizeObserver({ elementRef: wrapperRef });
 
   // reset height constraint when rowCount changes
   useEffect(() => {

--- a/src/components/flyout/flyout.tsx
+++ b/src/components/flyout/flyout.tsx
@@ -44,7 +44,6 @@ import classnames from 'classnames';
 import {
   keys,
   OuiWindowEvent,
-  useCombinedRefs,
   OuiBreakpointSize,
   isWithinMinBreakpoint,
   throttle,
@@ -250,16 +249,10 @@ const OuiFlyout = forwardRef(
       // reacts every 50ms to resize changes and always gets the final update
     }, 50);
 
-    /**
-     * Setting up the refs on the actual flyout element in order to
-     * accommodate for the `isPushed` state by adding padding to the body equal to the width of the element
-     */
-    const [resizeRef, setResizeRef] = useState<ComponentPropsWithRef<T> | null>(
-      null
-    );
-    const setRef = useCombinedRefs([setResizeRef, ref]);
-    // TODO: Allow this hooke to be conditional
-    const dimensions = useResizeObserver(resizeRef as Element);
+    const dimensions = useResizeObserver({
+      elementRef: ref as MutableRefObject<ComponentPropsWithRef<T> | null>,
+      shouldObserve: isPushed,
+    });
 
     useEffect(() => {
       // This class doesn't actually do anything by OUI, but is nice to add for consumers (JIC)
@@ -374,7 +367,7 @@ const OuiFlyout = forwardRef(
         className={classes}
         tabIndex={-1}
         style={newStyle || style}
-        ref={setRef}>
+        ref={ref}>
         {closeButton}
         {children}
       </Element>

--- a/src/components/markdown_editor/markdown_editor_drop_zone.tsx
+++ b/src/components/markdown_editor/markdown_editor_drop_zone.tsx
@@ -28,7 +28,7 @@
  * under the License.
  */
 
-import React, { FunctionComponent, useEffect } from 'react';
+import React, { FunctionComponent, useEffect, useRef } from 'react';
 import classNames from 'classnames';
 import { useDropzone } from 'react-dropzone';
 import { OuiMarkdownEditorFooter } from './markdown_editor_footer';
@@ -102,15 +102,12 @@ export const OuiMarkdownEditorDropZone: FunctionComponent<OuiMarkdownEditorDropZ
     'ouiMarkdownEditorDropZone--isDraggingError': isDraggingError,
   });
 
-  const [
-    editorFooterRef,
-    setEditorFooterRef,
-  ] = React.useState<HTMLDivElement | null>(null);
+  const editorFooterRef = useRef<HTMLDivElement>(null);
 
-  const { height: editorFooterHeight } = useResizeObserver(
-    editorFooterRef,
-    'height'
-  );
+  const { height: editorFooterHeight } = useResizeObserver({
+    elementRef: editorFooterRef,
+    observableDimension: 'height',
+  });
 
   useEffect(() => {
     if (editorFooterHeight !== 0) {
@@ -222,7 +219,7 @@ export const OuiMarkdownEditorDropZone: FunctionComponent<OuiMarkdownEditorDropZ
     <div {...getRootProps()} className={classes}>
       {children}
       <OuiMarkdownEditorFooter
-        ref={setEditorFooterRef}
+        ref={editorFooterRef}
         uiPlugins={uiPlugins}
         openFiles={() => {
           setHasUnacceptedItems(false);

--- a/src/components/observer/mutation_observer/mutation_observer.test.tsx
+++ b/src/components/observer/mutation_observer/mutation_observer.test.tsx
@@ -28,7 +28,7 @@
  * under the License.
  */
 
-import React, { FunctionComponent, useState } from 'react';
+import React, { FunctionComponent, useRef } from 'react';
 import { mount } from 'enzyme';
 import { OuiMutationObserver, useMutationObserver } from './mutation_observer';
 import { sleep } from '../../../test';
@@ -73,12 +73,12 @@ describe('useMutationObserver', () => {
 
     const mutationCallback = jest.fn();
     const Wrapper: FunctionComponent<{}> = jest.fn(({ children }) => {
-      const [ref, setRef] = useState<Element | null>(null);
+      const ref = useRef<HTMLDivElement>(null);
       useMutationObserver(ref, mutationCallback, {
         childList: true,
         subtree: true,
       });
-      return <div ref={setRef}>{children}</div>;
+      return <div ref={ref}>{children}</div>;
     });
 
     const component = mount(<Wrapper children={<div>Hello World</div>} />);

--- a/src/components/observer/mutation_observer/mutation_observer.ts
+++ b/src/components/observer/mutation_observer/mutation_observer.ts
@@ -28,7 +28,7 @@
  * under the License.
  */
 
-import { ReactNode, useEffect } from 'react';
+import { ReactNode, RefObject, useEffect } from 'react';
 
 import { OuiObserver } from '../observer';
 
@@ -87,23 +87,20 @@ const makeMutationObserver = (
 };
 
 export const useMutationObserver = (
-  container: Element | null,
+  elementRef: RefObject<any>,
   callback: MutationCallback,
   observerOptions?: MutationObserverInit
 ) => {
-  useEffect(
-    () => {
-      if (container != null) {
-        const observer = makeMutationObserver(
-          container,
-          observerOptions,
-          callback
-        );
-        return () => observer.disconnect();
-      }
-    },
+  useEffect(() => {
+    if (elementRef.current != null) {
+      const observer = makeMutationObserver(
+        elementRef.current,
+        observerOptions,
+        callback
+      );
+      return () => observer.disconnect();
+    }
     // ignore changing observerOptions
-    // eslint-disable-next-line
-    [container, callback]
-  );
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [elementRef, callback]);
 };

--- a/src/components/observer/resize_observer/resize_observer.test.tsx
+++ b/src/components/observer/resize_observer/resize_observer.test.tsx
@@ -28,7 +28,7 @@
  * under the License.
  */
 
-import React, { FunctionComponent, useState } from 'react';
+import React, { FunctionComponent, useRef } from 'react';
 import { mount } from 'enzyme';
 import { OuiResizeObserver, useResizeObserver } from './resize_observer';
 import { sleep } from '../../../test';
@@ -105,9 +105,9 @@ describe.skip('testResizeObservers', () => {
       expect.assertions(2);
 
       const Wrapper: FunctionComponent<{}> = jest.fn(({ children }) => {
-        const [ref, setRef] = useState<Element | null>(null);
-        useResizeObserver(ref);
-        return <div ref={setRef}>{children}</div>;
+        const ref = useRef<HTMLDivElement>(null);
+        useResizeObserver({ elementRef: ref });
+        return <div ref={ref}>{children}</div>;
       });
 
       const component = mount(<Wrapper children={<div>Hello World</div>} />);

--- a/src/components/resizable_container/resizable_container.tsx
+++ b/src/components/resizable_container/resizable_container.tsx
@@ -129,10 +129,10 @@ export const OuiResizableContainer: FunctionComponent<OuiResizableContainerProps
     onPanelWidthChange,
   });
 
-  const containerSize = useResizeObserver(
-    containerRef.current,
-    isHorizontal ? 'width' : 'height'
-  );
+  const containerSize = useResizeObserver({
+    elementRef: containerRef,
+    observableDimension: isHorizontal ? 'width' : 'height',
+  });
 
   const initialize = useCallback(() => {
     actions.initContainer(isHorizontal);


### PR DESCRIPTION
### Description
1) Added functionality to OuiBottomBar to have the same width as the container element.

https://user-images.githubusercontent.com/17855243/231955485-19222a05-6a9b-4fc4-874e-3870b31207f9.mov

--- 
2) Fixed the bug in `useResizeObserver` when the hook failed to immediately detect changes and consequently did not promptly return the intended result.

![imgonline-com-ua-twotoone-kvwEt9fjTaP](https://user-images.githubusercontent.com/17855243/231967316-3edc6a03-5c63-4e38-ada7-0cd581a28ab2.jpg)


### Issues Resolved
https://github.com/opensearch-project/oui/issues/707
 
### Check List
- [x] New functionality includes testing.
- [x] New functionality has been documented.
- [x] All tests pass
  - [x] `yarn lint`
  - [x] `yarn test-unit`
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/oui/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
