### PR TITLE
Update changelog with 1.1 info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 
 - Add release workflows ([134](https://github.com/opensearch-project/oui/pull/133))
 
+## [`1.1.1`](https://github.com/opensearch-project/oui/tree/1.1.1)
+
+- Revert "Rectify super date picker functionality" ([#724](https://github.com/opensearch-project/oui/pull/724))
+
 ## [`1.1.0`](https://github.com/opensearch-project/oui/tree/1.1.0)
 
 - Bump sass-loader to 10.4.1 ([#715](https://github.com/opensearch-project/oui/pull/715))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,27 @@
 
 - Add release workflows ([134](https://github.com/opensearch-project/oui/pull/133))
 
+## [`1.1.0`](https://github.com/opensearch-project/oui/tree/1.1.0)
+
+- Bump sass-loader to 10.4.1 ([#715](https://github.com/opensearch-project/oui/pull/715))
+- Revert updated breadcrumb styling ([#706](https://github.com/opensearch-project/oui/pull/706))
+- Update loader-utils to 1.4.2 ([#704](https://github.com/opensearch-project/oui/pull/704))
+- Fix aliasing issue ([#702](https://github.com/opensearch-project/oui/pull/702))
+- Add icons for Dashboards 2.7 ([#685](https://github.com/opensearch-project/oui/pull/685))
+- Rectify super date picker functionality ([#682](https://github.com/opensearch-project/oui/pull/682))
+- Remove docs folder ([#678](https://github.com/opensearch-project/oui/pull/678))
+- Add leading slash to test in .npmignore ([#690](https://github.com/opensearch-project/oui/pull/690))
+- Bump node-sass from 7.0.1 to 8.0.0 ([#673](https://github.com/opensearch-project/oui/pull/673))
+- Publish OUI to npmjs using tarball ([#667](https://github.com/opensearch-project/oui/pull/667))
+- Add build artifacts to release ([#664](https://github.com/opensearch-project/oui/pull/664))
+- Create OuiLoadingDashboards component ([#620](https://github.com/opensearch-project/oui/pull/620))
+- Fix yo-doc and yo-component crashes ([#616](https://github.com/opensearch-project/oui/pull/616))
+- Update logo_opensearch.js file ([#614](https://github.com/opensearch-project/oui/pull/614))
+- Change OuiTitle size property to m in tooltip example ([#612](https://github.com/opensearch-project/oui/pull/612))
+- Readme Opensearch Logo linking to non-existent file ([#589](https://github.com/opensearch-project/oui/pull/589))
+- Remove Elastic references from .md docs ([#588](https://github.com/opensearch-project/oui/pull/588))
+- Fix deprecated webpack configuration ([#586](https://github.com/opensearch-project/oui/pull/586))
+
 ## [`1.0.0`](https://github.com/opensearch-project/oui/tree/1.0.0)
 
 - Initial forked public release


### PR DESCRIPTION
### Description
Adds 1.1.0 release changes to changelog. These changes were gotten from this diff: https://github.com/opensearch-project/oui/compare/1.0...1.1

Question to reviewers: I think we're changing which branches we're going to be backporting to, so should this be backported to `1.x` as well as `1.1`, or just `1.x`?
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [x] All tests pass
  - [x] `yarn lint`
  - [x] `yarn test-unit`
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/oui/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
