### PR TITLE
[Data Grid] Fix logic when pageSize larger than number of rows

### DIFF
--- a/src/components/datagrid/data_grid.tsx
+++ b/src/components/datagrid/data_grid.tsx
@@ -715,10 +715,6 @@ export const OuiDataGrid: FunctionComponent<OuiDataGridProps> = (props) => {
     ...rest
   } = props;
 
-  if (pagination) {
-    pagination.pageSize = Math.min(pagination.pageSize, rowCount);
-  }
-
   const [isFullScreen, setIsFullScreen] = useState(false);
   const [gridWidth, setGridWidth] = useState(0);
 

--- a/src/components/datagrid/data_grid.tsx
+++ b/src/components/datagrid/data_grid.tsx
@@ -715,6 +715,10 @@ export const OuiDataGrid: FunctionComponent<OuiDataGridProps> = (props) => {
     ...rest
   } = props;
 
+  if (pagination) {
+    pagination.pageSize = Math.min(pagination.pageSize, rowCount);
+  }
+
   const [isFullScreen, setIsFullScreen] = useState(false);
   const [gridWidth, setGridWidth] = useState(0);
 

--- a/src/components/datagrid/data_grid_body.tsx
+++ b/src/components/datagrid/data_grid_body.tsx
@@ -629,7 +629,7 @@ export const OuiDataGridBody: FunctionComponent<OuiDataGridBodyProps> = (
   }, [getRowHeight]);
 
   const rowCountToAffordFor = pagination
-    ? pagination.pageSize
+    ? Math.min(pagination.pageSize, rowCount)
     : visibleRowIndices.length;
   const unconstrainedHeight =
     defaultHeight * rowCountToAffordFor + headerRowHeight + footerRowHeight;


### PR DESCRIPTION
### Description
There is a bug with DataGrid component, when there is less number of rows with data than number of rows per page, the DataGrid component is rendered with height equal to number of rows per page, instead of number of actual rows. This results in an empty unused space. 

For example, when there is 99 rows but the number of rows is 120, the table is rendered with height that fits 120 rows, and not 99. Screenshot:
<img width="1166" alt="image" src="https://user-images.githubusercontent.com/67782303/233143337-27e2b639-1bf2-475d-82d2-56a9be51da42.png">
The issue is even more evident when we make number of rows per page even larger (e.g. 1000 per page). I explained more in the issue https://github.com/opensearch-project/oui/issues/699 where I provided a sandbox.

After fix:
<img width="1133" alt="image" src="https://user-images.githubusercontent.com/67782303/233144281-93154c7a-fda5-44ae-98d6-343d49f0fdaa.png">
You might notice that the rows per page is 99 in the screenshot (actual number of rows), but the options show 120 ( they usually are provided by the developer), so I'm not sure if this okay. 
### Issues Resolved
Fixes https://github.com/opensearch-project/oui/issues/699
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [x] All tests pass
  - [x] `yarn lint`
  - [x] `yarn test-unit`
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/oui/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
