### PR TITLE
[CCI] Add github-merit-badger workflow

### DIFF
--- a/.github/workflows/github-workflow-badger.yml
+++ b/.github/workflows/github-workflow-badger.yml
@@ -1,0 +1,20 @@
+name: github-merit-badger
+on:
+  pull_request_target:
+    types:
+      - opened
+
+jobs:
+  call-action:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - uses: aws-github-ops/github-merit-badger@v0.0.98
+        id: merit-badger
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          badges: '[first-time-contributor,repeat-contributor,valued-contributor,seasoned-contributor,all-star-contributor,distinguished-contributor]'
+          thresholds: '[0,3,6,13,25,50]'
+          badge-type: 'achievement'
+          ignore-usernames: '[opensearch-ci-bot, dependabot, opensearch-trigger-bot]'


### PR DESCRIPTION
### Description
Add github-merit-badger workflow, taken from https://github.com/opensearch-project/OpenSearch-Dashboards/pull/3721

### Issues Resolved
https://github.com/opensearch-project/oui/issues/638
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [X] All tests pass
  - [X] `yarn lint`
  - [X] `yarn test-unit`
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/oui/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
