### PR TITLE
Deprecate ```iconType``` and ```iconProps``` from ```OuiPageHeader```

### DIFF
--- a/src/components/page/page_header/page_header.tsx
+++ b/src/components/page/page_header/page_header.tsx
@@ -64,9 +64,6 @@ export type OuiPageHeaderProps = CommonProps &
     bottomBorder?: boolean;
   };
 
-/**
- * @deprecated The `iconType` and `iconProps` properties are deprecated and will be removed in the future.
- */
 export const OuiPageHeader: FunctionComponent<OuiPageHeaderProps> = ({
   className,
   restrictWidth = false,

--- a/src/components/page/page_header/page_header.tsx
+++ b/src/components/page/page_header/page_header.tsx
@@ -28,7 +28,7 @@
  * under the License.
  */
 
-import React, { FunctionComponent, HTMLAttributes } from 'react';
+import React, { FunctionComponent, HTMLAttributes, useEffect } from 'react';
 import classNames from 'classnames';
 import { CommonProps, keysOf } from '../../common';
 import {
@@ -64,6 +64,9 @@ export type OuiPageHeaderProps = CommonProps &
     bottomBorder?: boolean;
   };
 
+/**
+ * @deprecated The `iconType` and `iconProps` properties are deprecated and will be removed in the future.
+ */
 export const OuiPageHeader: FunctionComponent<OuiPageHeaderProps> = ({
   className,
   restrictWidth = false,
@@ -91,6 +94,14 @@ export const OuiPageHeader: FunctionComponent<OuiPageHeaderProps> = ({
     restrictWidth,
     style
   );
+
+  useEffect(() => {
+    if (iconType || iconProps) {
+      console.warn(
+        'WARNING: The `iconType` and `iconProps` properties in `OuiPageHeader` are deprecated and will be removed in the future. Please update your code accordingly.'
+      );
+    }
+  }, [iconType, iconProps]);
 
   const classes = classNames(
     'ouiPageHeader',

--- a/src/components/page/page_header/page_header_content.tsx
+++ b/src/components/page/page_header/page_header_content.tsx
@@ -58,10 +58,12 @@ export type OuiPageHeaderContentTitle = {
   pageTitle?: ReactNode;
   /**
    * Optional icon to place to the left of the title
+   * @deprecated The `iconType` prop is deprecated and will be removed in the future.
    */
   iconType?: IconType;
   /**
    * Additional OuiIcon props to apply to the optional icon
+   * @deprecated The `iconProps` prop is deprecated and will be removed in the future.
    */
   iconProps?: Partial<Omit<OuiIconProps, 'type'>>;
 };


### PR DESCRIPTION
### Description
Deprecated ```iconType``` and ```iconProps``` as according to the https://github.com/opensearch-project/oui/issues/644 they will no longer be used/supported.
 
### Issues Resolved
First (out of 2) PR to solve https://github.com/opensearch-project/oui/issues/644
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [x] All tests pass
  - [ ] `yarn lint`
  - [ ] `yarn test-unit`
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/oui/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
