### PR TITLE
Fix combo box onFocus bug

### DIFF
--- a/src/components/combo_box/combo_box.tsx
+++ b/src/components/combo_box/combo_box.tsx
@@ -558,6 +558,10 @@ export class OuiComboBox<T> extends Component<
   };
 
   onComboBoxFocus: FocusEventHandler<HTMLInputElement> = (event) => {
+    if (this.state.hasFocus) {
+      return;
+    }
+
     if (this.props.onFocus) {
       this.props.onFocus(event);
     }
@@ -951,6 +955,7 @@ export class OuiComboBox<T> extends Component<
       onBlur,
       onChange,
       onCreateOption,
+      onFocus,
       onSearchChange,
       options,
       placeholder,


### PR DESCRIPTION
### Description
Previously, if `isLoading` was set in `onFocus`, options wouldn't be added when they were clicked. The issue stemmed from `onFocus` not being removed from the list of props passed to the root element of combo box. Essentially, `onFocus` would be called twice, once from the root element and once from `OuiComboBoxInput`. This meant that if you clicked an option, the root element's `onFocus` would fire, cancelling the option selection.

This bug is super nuanced so if you need more context, I can add it. Basically, just taking it out of the `rest` object fixes the bug.

### Issues Resolved
Fixes #696

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [x] All tests pass
  - [x] `yarn lint`
  - [x] `yarn test-unit`
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/oui/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
