### PR TITLE
Revert "Update breadcrumbs to new styling (#131) (#379)"

### DIFF
--- a/src/components/breadcrumbs/__snapshots__/breadcrumbs.test.tsx.snap
+++ b/src/components/breadcrumbs/__snapshots__/breadcrumbs.test.tsx.snap
@@ -6,86 +6,73 @@ exports[`OuiBreadcrumbs is rendered 1`] = `
   class="ouiBreadcrumbs testClass1 testClass2 ouiBreadcrumbs--truncate"
   data-test-subj="test subject string"
 >
+  <a
+    class="ouiLink ouiLink--subdued ouiBreadcrumb customClass"
+    data-test-subj="breadcrumbsAnimals"
+    href="#"
+    rel="noreferrer"
+  >
+    Animals
+  </a>
   <div
-    class="ouiBreadcrumbWall"
+    class="ouiBreadcrumbSeparator"
+  />
+  <span
+    aria-current="false"
+    class="ouiBreadcrumb"
+  >
+    Metazoans
+  </span>
+  <div
+    class="ouiBreadcrumbSeparator"
+  />
+  <div
+    class="ouiPopover ouiPopover--anchorDownCenter ouiBreadcrumb ouiBreadcrumb--collapsed"
   >
     <div
-      class="ouiBreadcrumbWrapper ouiBreadcrumbWrapper--first"
+      class="ouiPopover__anchor"
     >
-      <a
-        class="ouiLink ouiLink--subdued ouiBreadcrumb customClass"
-        data-test-subj="breadcrumbsAnimals"
-        href="#"
-        rel="noreferrer"
+      <button
+        aria-label="Show collapsed breadcrumbs"
+        class="ouiLink ouiLink--subdued ouiBreadcrumb__collapsedLink"
+        title="Show collapsed breadcrumbs"
+        type="button"
       >
-        Animals
-      </a>
+        … 
+        <span
+          data-ouiicon-type="arrowDown"
+        />
+      </button>
     </div>
   </div>
   <div
-    class="ouiBreadcrumbWrapper"
+    class="ouiBreadcrumbSeparator"
+  />
+  <button
+    class="ouiLink ouiLink--subdued ouiBreadcrumb"
+    type="button"
   >
-    <span
-      aria-current="false"
-      class="ouiBreadcrumb"
-    >
-      Metazoans
-    </span>
-  </div>
+    Reptiles
+  </button>
   <div
-    class="ouiBreadcrumbWrapper ouiBreadcrumbWrapper--collapsed"
+    class="ouiBreadcrumbSeparator"
+  />
+  <a
+    class="ouiLink ouiLink--subdued ouiBreadcrumb ouiBreadcrumb--truncate"
+    href="#"
+    rel="noreferrer"
   >
-    <div
-      class="ouiPopover ouiPopover--anchorDownCenter ouiBreadcrumb ouiBreadcrumb--collapsed"
-    >
-      <div
-        class="ouiPopover__anchor"
-      >
-        <button
-          aria-label="Show collapsed breadcrumbs"
-          class="ouiLink ouiLink--subdued ouiBreadcrumb__collapsedLink"
-          title="Show collapsed breadcrumbs"
-          type="button"
-        >
-          … 
-          <span
-            data-ouiicon-type="arrowDown"
-          />
-        </button>
-      </div>
-    </div>
-  </div>
+    Boa constrictor
+  </a>
   <div
-    class="ouiBreadcrumbWrapper"
+    class="ouiBreadcrumbSeparator"
+  />
+  <span
+    aria-current="page"
+    class="ouiBreadcrumb ouiBreadcrumb--last"
   >
-    <button
-      class="ouiLink ouiLink--subdued ouiBreadcrumb"
-      type="button"
-    >
-      Reptiles
-    </button>
-  </div>
-  <div
-    class="ouiBreadcrumbWrapper ouiBreadcrumbWrapper--truncate"
-  >
-    <a
-      class="ouiLink ouiLink--subdued ouiBreadcrumb ouiBreadcrumb--truncate"
-      href="#"
-      rel="noreferrer"
-    >
-      Boa constrictor
-    </a>
-  </div>
-  <div
-    class="ouiBreadcrumbWrapper ouiBreadcrumbWrapper--last"
-  >
-    <span
-      aria-current="page"
-      class="ouiBreadcrumb ouiBreadcrumb--last"
-    >
-      Edit
-    </span>
-  </div>
+    Edit
+  </span>
 </nav>
 `;
 
@@ -94,93 +81,78 @@ exports[`OuiBreadcrumbs props max doesn't break when max exceeds the number of b
   aria-label="breadcrumb"
   class="ouiBreadcrumbs ouiBreadcrumbs--truncate"
 >
-  <div
-    class="ouiBreadcrumbWall"
+  <a
+    class="ouiLink ouiLink--subdued ouiBreadcrumb customClass"
+    data-test-subj="breadcrumbsAnimals"
+    href="#"
+    rel="noreferrer"
   >
-    <div
-      class="ouiBreadcrumbWrapper ouiBreadcrumbWrapper--first"
-    >
-      <a
-        class="ouiLink ouiLink--subdued ouiBreadcrumb customClass"
-        data-test-subj="breadcrumbsAnimals"
-        href="#"
-        rel="noreferrer"
-      >
-        Animals
-      </a>
-    </div>
-  </div>
+    Animals
+  </a>
   <div
-    class="ouiBreadcrumbWrapper"
+    class="ouiBreadcrumbSeparator"
+  />
+  <span
+    aria-current="false"
+    class="ouiBreadcrumb"
   >
-    <span
-      aria-current="false"
-      class="ouiBreadcrumb"
-    >
-      Metazoans
-    </span>
-  </div>
+    Metazoans
+  </span>
   <div
-    class="ouiBreadcrumbWrapper"
+    class="ouiBreadcrumbSeparator"
+  />
+  <span
+    aria-current="false"
+    class="ouiBreadcrumb"
   >
-    <span
-      aria-current="false"
-      class="ouiBreadcrumb"
-    >
-      Chordates
-    </span>
-  </div>
+    Chordates
+  </span>
   <div
-    class="ouiBreadcrumbWrapper ouiBreadcrumbWrapper--truncate"
+    class="ouiBreadcrumbSeparator"
+  />
+  <span
+    aria-current="false"
+    class="ouiBreadcrumb ouiBreadcrumb--truncate"
   >
-    <span
-      aria-current="false"
-      class="ouiBreadcrumb ouiBreadcrumb--truncate"
-    >
-      Nebulosa subspecies is also a real mouthful, especially for creatures without mouths
-    </span>
-  </div>
+    Nebulosa subspecies is also a real mouthful, especially for creatures without mouths
+  </span>
   <div
-    class="ouiBreadcrumbWrapper"
+    class="ouiBreadcrumbSeparator"
+  />
+  <span
+    aria-current="false"
+    class="ouiBreadcrumb"
   >
-    <span
-      aria-current="false"
-      class="ouiBreadcrumb"
-    >
-      Tetrapods
-    </span>
-  </div>
+    Tetrapods
+  </span>
   <div
-    class="ouiBreadcrumbWrapper"
+    class="ouiBreadcrumbSeparator"
+  />
+  <button
+    class="ouiLink ouiLink--subdued ouiBreadcrumb"
+    type="button"
   >
-    <button
-      class="ouiLink ouiLink--subdued ouiBreadcrumb"
-      type="button"
-    >
-      Reptiles
-    </button>
-  </div>
+    Reptiles
+  </button>
   <div
-    class="ouiBreadcrumbWrapper ouiBreadcrumbWrapper--truncate"
+    class="ouiBreadcrumbSeparator"
+  />
+  <a
+    class="ouiLink ouiLink--subdued ouiBreadcrumb ouiBreadcrumb--truncate"
+    href="#"
+    rel="noreferrer"
   >
-    <a
-      class="ouiLink ouiLink--subdued ouiBreadcrumb ouiBreadcrumb--truncate"
-      href="#"
-      rel="noreferrer"
-    >
-      Boa constrictor
-    </a>
-  </div>
+    Boa constrictor
+  </a>
   <div
-    class="ouiBreadcrumbWrapper ouiBreadcrumbWrapper--last"
+    class="ouiBreadcrumbSeparator"
+  />
+  <span
+    aria-current="page"
+    class="ouiBreadcrumb ouiBreadcrumb--last"
   >
-    <span
-      aria-current="page"
-      class="ouiBreadcrumb ouiBreadcrumb--last"
-    >
-      Edit
-    </span>
-  </div>
+    Edit
+  </span>
 </nav>
 `;
 
@@ -190,38 +162,33 @@ exports[`OuiBreadcrumbs props max renders 1 item 1`] = `
   class="ouiBreadcrumbs ouiBreadcrumbs--truncate"
 >
   <div
-    class="ouiBreadcrumbWrapper ouiBreadcrumbWrapper--collapsed"
+    class="ouiPopover ouiPopover--anchorDownCenter ouiBreadcrumb ouiBreadcrumb--collapsed"
   >
     <div
-      class="ouiPopover ouiPopover--anchorDownCenter ouiBreadcrumb ouiBreadcrumb--collapsed"
+      class="ouiPopover__anchor"
     >
-      <div
-        class="ouiPopover__anchor"
+      <button
+        aria-label="Show collapsed breadcrumbs"
+        class="ouiLink ouiLink--subdued ouiBreadcrumb__collapsedLink"
+        title="Show collapsed breadcrumbs"
+        type="button"
       >
-        <button
-          aria-label="Show collapsed breadcrumbs"
-          class="ouiLink ouiLink--subdued ouiBreadcrumb__collapsedLink"
-          title="Show collapsed breadcrumbs"
-          type="button"
-        >
-          … 
-          <span
-            data-ouiicon-type="arrowDown"
-          />
-        </button>
-      </div>
+        … 
+        <span
+          data-ouiicon-type="arrowDown"
+        />
+      </button>
     </div>
   </div>
   <div
-    class="ouiBreadcrumbWrapper ouiBreadcrumbWrapper--last"
+    class="ouiBreadcrumbSeparator"
+  />
+  <span
+    aria-current="page"
+    class="ouiBreadcrumb ouiBreadcrumb--last"
   >
-    <span
-      aria-current="page"
-      class="ouiBreadcrumb ouiBreadcrumb--last"
-    >
-      Edit
-    </span>
-  </div>
+    Edit
+  </span>
 </nav>
 `;
 
@@ -230,93 +197,78 @@ exports[`OuiBreadcrumbs props max renders all items with null 1`] = `
   aria-label="breadcrumb"
   class="ouiBreadcrumbs ouiBreadcrumbs--truncate"
 >
-  <div
-    class="ouiBreadcrumbWall"
+  <a
+    class="ouiLink ouiLink--subdued ouiBreadcrumb customClass"
+    data-test-subj="breadcrumbsAnimals"
+    href="#"
+    rel="noreferrer"
   >
-    <div
-      class="ouiBreadcrumbWrapper ouiBreadcrumbWrapper--first"
-    >
-      <a
-        class="ouiLink ouiLink--subdued ouiBreadcrumb customClass"
-        data-test-subj="breadcrumbsAnimals"
-        href="#"
-        rel="noreferrer"
-      >
-        Animals
-      </a>
-    </div>
-  </div>
+    Animals
+  </a>
   <div
-    class="ouiBreadcrumbWrapper"
+    class="ouiBreadcrumbSeparator"
+  />
+  <span
+    aria-current="false"
+    class="ouiBreadcrumb"
   >
-    <span
-      aria-current="false"
-      class="ouiBreadcrumb"
-    >
-      Metazoans
-    </span>
-  </div>
+    Metazoans
+  </span>
   <div
-    class="ouiBreadcrumbWrapper"
+    class="ouiBreadcrumbSeparator"
+  />
+  <span
+    aria-current="false"
+    class="ouiBreadcrumb"
   >
-    <span
-      aria-current="false"
-      class="ouiBreadcrumb"
-    >
-      Chordates
-    </span>
-  </div>
+    Chordates
+  </span>
   <div
-    class="ouiBreadcrumbWrapper ouiBreadcrumbWrapper--truncate"
+    class="ouiBreadcrumbSeparator"
+  />
+  <span
+    aria-current="false"
+    class="ouiBreadcrumb ouiBreadcrumb--truncate"
   >
-    <span
-      aria-current="false"
-      class="ouiBreadcrumb ouiBreadcrumb--truncate"
-    >
-      Nebulosa subspecies is also a real mouthful, especially for creatures without mouths
-    </span>
-  </div>
+    Nebulosa subspecies is also a real mouthful, especially for creatures without mouths
+  </span>
   <div
-    class="ouiBreadcrumbWrapper"
+    class="ouiBreadcrumbSeparator"
+  />
+  <span
+    aria-current="false"
+    class="ouiBreadcrumb"
   >
-    <span
-      aria-current="false"
-      class="ouiBreadcrumb"
-    >
-      Tetrapods
-    </span>
-  </div>
+    Tetrapods
+  </span>
   <div
-    class="ouiBreadcrumbWrapper"
+    class="ouiBreadcrumbSeparator"
+  />
+  <button
+    class="ouiLink ouiLink--subdued ouiBreadcrumb"
+    type="button"
   >
-    <button
-      class="ouiLink ouiLink--subdued ouiBreadcrumb"
-      type="button"
-    >
-      Reptiles
-    </button>
-  </div>
+    Reptiles
+  </button>
   <div
-    class="ouiBreadcrumbWrapper ouiBreadcrumbWrapper--truncate"
+    class="ouiBreadcrumbSeparator"
+  />
+  <a
+    class="ouiLink ouiLink--subdued ouiBreadcrumb ouiBreadcrumb--truncate"
+    href="#"
+    rel="noreferrer"
   >
-    <a
-      class="ouiLink ouiLink--subdued ouiBreadcrumb ouiBreadcrumb--truncate"
-      href="#"
-      rel="noreferrer"
-    >
-      Boa constrictor
-    </a>
-  </div>
+    Boa constrictor
+  </a>
   <div
-    class="ouiBreadcrumbWrapper ouiBreadcrumbWrapper--last"
+    class="ouiBreadcrumbSeparator"
+  />
+  <span
+    aria-current="page"
+    class="ouiBreadcrumb ouiBreadcrumb--last"
   >
-    <span
-      aria-current="page"
-      class="ouiBreadcrumb ouiBreadcrumb--last"
-    >
-      Edit
-    </span>
-  </div>
+    Edit
+  </span>
 </nav>
 `;
 
@@ -325,86 +277,73 @@ exports[`OuiBreadcrumbs props responsive is rendered 1`] = `
   aria-label="breadcrumb"
   class="ouiBreadcrumbs ouiBreadcrumbs--truncate"
 >
+  <a
+    class="ouiLink ouiLink--subdued ouiBreadcrumb customClass"
+    data-test-subj="breadcrumbsAnimals"
+    href="#"
+    rel="noreferrer"
+  >
+    Animals
+  </a>
   <div
-    class="ouiBreadcrumbWall"
+    class="ouiBreadcrumbSeparator"
+  />
+  <span
+    aria-current="false"
+    class="ouiBreadcrumb"
+  >
+    Metazoans
+  </span>
+  <div
+    class="ouiBreadcrumbSeparator"
+  />
+  <div
+    class="ouiPopover ouiPopover--anchorDownCenter ouiBreadcrumb ouiBreadcrumb--collapsed"
   >
     <div
-      class="ouiBreadcrumbWrapper ouiBreadcrumbWrapper--first"
+      class="ouiPopover__anchor"
     >
-      <a
-        class="ouiLink ouiLink--subdued ouiBreadcrumb customClass"
-        data-test-subj="breadcrumbsAnimals"
-        href="#"
-        rel="noreferrer"
+      <button
+        aria-label="Show collapsed breadcrumbs"
+        class="ouiLink ouiLink--subdued ouiBreadcrumb__collapsedLink"
+        title="Show collapsed breadcrumbs"
+        type="button"
       >
-        Animals
-      </a>
+        … 
+        <span
+          data-ouiicon-type="arrowDown"
+        />
+      </button>
     </div>
   </div>
   <div
-    class="ouiBreadcrumbWrapper"
+    class="ouiBreadcrumbSeparator"
+  />
+  <button
+    class="ouiLink ouiLink--subdued ouiBreadcrumb"
+    type="button"
   >
-    <span
-      aria-current="false"
-      class="ouiBreadcrumb"
-    >
-      Metazoans
-    </span>
-  </div>
+    Reptiles
+  </button>
   <div
-    class="ouiBreadcrumbWrapper ouiBreadcrumbWrapper--collapsed"
+    class="ouiBreadcrumbSeparator"
+  />
+  <a
+    class="ouiLink ouiLink--subdued ouiBreadcrumb ouiBreadcrumb--truncate"
+    href="#"
+    rel="noreferrer"
   >
-    <div
-      class="ouiPopover ouiPopover--anchorDownCenter ouiBreadcrumb ouiBreadcrumb--collapsed"
-    >
-      <div
-        class="ouiPopover__anchor"
-      >
-        <button
-          aria-label="Show collapsed breadcrumbs"
-          class="ouiLink ouiLink--subdued ouiBreadcrumb__collapsedLink"
-          title="Show collapsed breadcrumbs"
-          type="button"
-        >
-          … 
-          <span
-            data-ouiicon-type="arrowDown"
-          />
-        </button>
-      </div>
-    </div>
-  </div>
+    Boa constrictor
+  </a>
   <div
-    class="ouiBreadcrumbWrapper"
+    class="ouiBreadcrumbSeparator"
+  />
+  <span
+    aria-current="page"
+    class="ouiBreadcrumb ouiBreadcrumb--last"
   >
-    <button
-      class="ouiLink ouiLink--subdued ouiBreadcrumb"
-      type="button"
-    >
-      Reptiles
-    </button>
-  </div>
-  <div
-    class="ouiBreadcrumbWrapper ouiBreadcrumbWrapper--truncate"
-  >
-    <a
-      class="ouiLink ouiLink--subdued ouiBreadcrumb ouiBreadcrumb--truncate"
-      href="#"
-      rel="noreferrer"
-    >
-      Boa constrictor
-    </a>
-  </div>
-  <div
-    class="ouiBreadcrumbWrapper ouiBreadcrumbWrapper--last"
-  >
-    <span
-      aria-current="page"
-      class="ouiBreadcrumb ouiBreadcrumb--last"
-    >
-      Edit
-    </span>
-  </div>
+    Edit
+  </span>
 </nav>
 `;
 
@@ -413,86 +352,73 @@ exports[`OuiBreadcrumbs props responsive is rendered as false 1`] = `
   aria-label="breadcrumb"
   class="ouiBreadcrumbs ouiBreadcrumbs--truncate"
 >
+  <a
+    class="ouiLink ouiLink--subdued ouiBreadcrumb customClass"
+    data-test-subj="breadcrumbsAnimals"
+    href="#"
+    rel="noreferrer"
+  >
+    Animals
+  </a>
   <div
-    class="ouiBreadcrumbWall"
+    class="ouiBreadcrumbSeparator"
+  />
+  <span
+    aria-current="false"
+    class="ouiBreadcrumb"
+  >
+    Metazoans
+  </span>
+  <div
+    class="ouiBreadcrumbSeparator"
+  />
+  <div
+    class="ouiPopover ouiPopover--anchorDownCenter ouiBreadcrumb ouiBreadcrumb--collapsed"
   >
     <div
-      class="ouiBreadcrumbWrapper ouiBreadcrumbWrapper--first"
+      class="ouiPopover__anchor"
     >
-      <a
-        class="ouiLink ouiLink--subdued ouiBreadcrumb customClass"
-        data-test-subj="breadcrumbsAnimals"
-        href="#"
-        rel="noreferrer"
+      <button
+        aria-label="Show collapsed breadcrumbs"
+        class="ouiLink ouiLink--subdued ouiBreadcrumb__collapsedLink"
+        title="Show collapsed breadcrumbs"
+        type="button"
       >
-        Animals
-      </a>
+        … 
+        <span
+          data-ouiicon-type="arrowDown"
+        />
+      </button>
     </div>
   </div>
   <div
-    class="ouiBreadcrumbWrapper"
+    class="ouiBreadcrumbSeparator"
+  />
+  <button
+    class="ouiLink ouiLink--subdued ouiBreadcrumb"
+    type="button"
   >
-    <span
-      aria-current="false"
-      class="ouiBreadcrumb"
-    >
-      Metazoans
-    </span>
-  </div>
+    Reptiles
+  </button>
   <div
-    class="ouiBreadcrumbWrapper ouiBreadcrumbWrapper--collapsed"
+    class="ouiBreadcrumbSeparator"
+  />
+  <a
+    class="ouiLink ouiLink--subdued ouiBreadcrumb ouiBreadcrumb--truncate"
+    href="#"
+    rel="noreferrer"
   >
-    <div
-      class="ouiPopover ouiPopover--anchorDownCenter ouiBreadcrumb ouiBreadcrumb--collapsed"
-    >
-      <div
-        class="ouiPopover__anchor"
-      >
-        <button
-          aria-label="Show collapsed breadcrumbs"
-          class="ouiLink ouiLink--subdued ouiBreadcrumb__collapsedLink"
-          title="Show collapsed breadcrumbs"
-          type="button"
-        >
-          … 
-          <span
-            data-ouiicon-type="arrowDown"
-          />
-        </button>
-      </div>
-    </div>
-  </div>
+    Boa constrictor
+  </a>
   <div
-    class="ouiBreadcrumbWrapper"
+    class="ouiBreadcrumbSeparator"
+  />
+  <span
+    aria-current="page"
+    class="ouiBreadcrumb ouiBreadcrumb--last"
   >
-    <button
-      class="ouiLink ouiLink--subdued ouiBreadcrumb"
-      type="button"
-    >
-      Reptiles
-    </button>
-  </div>
-  <div
-    class="ouiBreadcrumbWrapper ouiBreadcrumbWrapper--truncate"
-  >
-    <a
-      class="ouiLink ouiLink--subdued ouiBreadcrumb ouiBreadcrumb--truncate"
-      href="#"
-      rel="noreferrer"
-    >
-      Boa constrictor
-    </a>
-  </div>
-  <div
-    class="ouiBreadcrumbWrapper ouiBreadcrumbWrapper--last"
-  >
-    <span
-      aria-current="page"
-      class="ouiBreadcrumb ouiBreadcrumb--last"
-    >
-      Edit
-    </span>
-  </div>
+    Edit
+  </span>
 </nav>
 `;
 
@@ -502,38 +428,33 @@ exports[`OuiBreadcrumbs props responsive is rendered with custom breakpoints 1`]
   class="ouiBreadcrumbs ouiBreadcrumbs--truncate"
 >
   <div
-    class="ouiBreadcrumbWrapper ouiBreadcrumbWrapper--collapsed"
+    class="ouiPopover ouiPopover--anchorDownCenter ouiBreadcrumb ouiBreadcrumb--collapsed"
   >
     <div
-      class="ouiPopover ouiPopover--anchorDownCenter ouiBreadcrumb ouiBreadcrumb--collapsed"
+      class="ouiPopover__anchor"
     >
-      <div
-        class="ouiPopover__anchor"
+      <button
+        aria-label="Show collapsed breadcrumbs"
+        class="ouiLink ouiLink--subdued ouiBreadcrumb__collapsedLink"
+        title="Show collapsed breadcrumbs"
+        type="button"
       >
-        <button
-          aria-label="Show collapsed breadcrumbs"
-          class="ouiLink ouiLink--subdued ouiBreadcrumb__collapsedLink"
-          title="Show collapsed breadcrumbs"
-          type="button"
-        >
-          … 
-          <span
-            data-ouiicon-type="arrowDown"
-          />
-        </button>
-      </div>
+        … 
+        <span
+          data-ouiicon-type="arrowDown"
+        />
+      </button>
     </div>
   </div>
   <div
-    class="ouiBreadcrumbWrapper ouiBreadcrumbWrapper--last"
+    class="ouiBreadcrumbSeparator"
+  />
+  <span
+    aria-current="page"
+    class="ouiBreadcrumb ouiBreadcrumb--last"
   >
-    <span
-      aria-current="page"
-      class="ouiBreadcrumb ouiBreadcrumb--last"
-    >
-      Edit
-    </span>
-  </div>
+    Edit
+  </span>
 </nav>
 `;
 
@@ -542,85 +463,72 @@ exports[`OuiBreadcrumbs props truncate as false is rendered 1`] = `
   aria-label="breadcrumb"
   class="ouiBreadcrumbs"
 >
+  <a
+    class="ouiLink ouiLink--subdued ouiBreadcrumb customClass"
+    data-test-subj="breadcrumbsAnimals"
+    href="#"
+    rel="noreferrer"
+  >
+    Animals
+  </a>
   <div
-    class="ouiBreadcrumbWall"
+    class="ouiBreadcrumbSeparator"
+  />
+  <span
+    aria-current="false"
+    class="ouiBreadcrumb"
+  >
+    Metazoans
+  </span>
+  <div
+    class="ouiBreadcrumbSeparator"
+  />
+  <div
+    class="ouiPopover ouiPopover--anchorDownCenter ouiBreadcrumb ouiBreadcrumb--collapsed"
   >
     <div
-      class="ouiBreadcrumbWrapper ouiBreadcrumbWrapper--first"
+      class="ouiPopover__anchor"
     >
-      <a
-        class="ouiLink ouiLink--subdued ouiBreadcrumb customClass"
-        data-test-subj="breadcrumbsAnimals"
-        href="#"
-        rel="noreferrer"
+      <button
+        aria-label="Show collapsed breadcrumbs"
+        class="ouiLink ouiLink--subdued ouiBreadcrumb__collapsedLink"
+        title="Show collapsed breadcrumbs"
+        type="button"
       >
-        Animals
-      </a>
+        … 
+        <span
+          data-ouiicon-type="arrowDown"
+        />
+      </button>
     </div>
   </div>
   <div
-    class="ouiBreadcrumbWrapper"
+    class="ouiBreadcrumbSeparator"
+  />
+  <button
+    class="ouiLink ouiLink--subdued ouiBreadcrumb"
+    type="button"
   >
-    <span
-      aria-current="false"
-      class="ouiBreadcrumb"
-    >
-      Metazoans
-    </span>
-  </div>
+    Reptiles
+  </button>
   <div
-    class="ouiBreadcrumbWrapper ouiBreadcrumbWrapper--collapsed"
+    class="ouiBreadcrumbSeparator"
+  />
+  <a
+    class="ouiLink ouiLink--subdued ouiBreadcrumb ouiBreadcrumb--truncate"
+    href="#"
+    rel="noreferrer"
   >
-    <div
-      class="ouiPopover ouiPopover--anchorDownCenter ouiBreadcrumb ouiBreadcrumb--collapsed"
-    >
-      <div
-        class="ouiPopover__anchor"
-      >
-        <button
-          aria-label="Show collapsed breadcrumbs"
-          class="ouiLink ouiLink--subdued ouiBreadcrumb__collapsedLink"
-          title="Show collapsed breadcrumbs"
-          type="button"
-        >
-          … 
-          <span
-            data-ouiicon-type="arrowDown"
-          />
-        </button>
-      </div>
-    </div>
-  </div>
+    Boa constrictor
+  </a>
   <div
-    class="ouiBreadcrumbWrapper"
+    class="ouiBreadcrumbSeparator"
+  />
+  <span
+    aria-current="page"
+    class="ouiBreadcrumb ouiBreadcrumb--last"
   >
-    <button
-      class="ouiLink ouiLink--subdued ouiBreadcrumb"
-      type="button"
-    >
-      Reptiles
-    </button>
-  </div>
-  <div
-    class="ouiBreadcrumbWrapper ouiBreadcrumbWrapper--truncate"
-  >
-    <a
-      class="ouiLink ouiLink--subdued ouiBreadcrumb ouiBreadcrumb--truncate"
-      href="#"
-      rel="noreferrer"
-    >
-      Boa constrictor
-    </a>
-  </div>
-  <div
-    class="ouiBreadcrumbWrapper ouiBreadcrumbWrapper--last"
-  >
-    <span
-      aria-current="page"
-      class="ouiBreadcrumb ouiBreadcrumb--last"
-    >
-      Edit
-    </span>
-  </div>
+    Edit
+  </span>
 </nav>
 `;

--- a/src/components/breadcrumbs/_breadcrumbs.scss
+++ b/src/components/breadcrumbs/_breadcrumbs.scss
@@ -25,14 +25,11 @@
 
 .ouiBreadcrumb {
   display: inline-block;
-  transform: skewX(20deg);
+  margin-bottom: $ouiSizeXS; /* 1 */
 
   &:not(.ouiBreadcrumb--last) {
+    margin-right: $ouiBreadcrumbSpacing;
     color: $ouiTextSubduedColor;
-
-    &:hover {
-      color: $ouiBreadCrumbHoverColor !important; // sass-lint:disable-line no-important
-    }
   }
 }
 
@@ -42,12 +39,16 @@
 
 .ouiBreadcrumb--collapsed {
   flex-shrink: 0;
-  color: $ouiBreadcrumbCollapsedLink;
-  vertical-align: top !important; // sass-lint:disable-line no-important
 }
 
-.ouiBreadcrumb__collapsedLink:hover {
-  color: $ouiBreadCrumbHoverColor !important; // sass-lint:disable-line no-important
+.ouiBreadcrumbSeparator {
+  flex-shrink: 0;
+  display: inline-block;
+  margin-right: $ouiBreadcrumbSpacing;
+  width: 1px;
+  height: $ouiSize;
+  transform: translateY(-1px) rotate(15deg);
+  background: $ouiColorLightShade;
 }
 
 .ouiBreadcrumbs__inPopover .ouiBreadcrumb--last {
@@ -60,18 +61,11 @@
   flex-wrap: nowrap;
 
   .ouiBreadcrumb:not(.ouiBreadcrumb--collapsed) {
-    max-width: 100%;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    vertical-align: top; // overflow hidden causes misalignment of links and slashes, this fixes that
-  }
-
-  .ouiBreadcrumbWrapper:not(.ouiBreadcrumbWrapper--collapsed) {
     max-width: $ouiBreadcrumbTruncateWidth;
     overflow: hidden;
     text-overflow: ellipsis;
 
-    &.ouiBreadcrumbWrapper--last {
+    &.ouiBreadcrumb--last {
       max-width: none;
     }
   }
@@ -79,37 +73,7 @@
 
 .ouiBreadcrumb--truncate {
   @include ouiTextTruncate;
-  max-width: 100%;
+  max-width: $ouiBreadcrumbTruncateWidth;
   text-align: center;
   vertical-align: top; // overflow hidden causes misalignment of links and slashes, this fixes that
-}
-
-.ouiBreadcrumbWrapper--truncate {
-  max-width: $ouiBreadcrumbTruncateWidth;
-}
-
-.ouiBreadcrumbWrapper {
-  background-color: $ouiBreadcrumbGrayBackground;
-  transform: skewX(-20deg);
-  border-radius: $ouiSizeXS;
-  padding: $ouiSizeXS - 2.5 $ouiSizeL - $ouiSizeXS;
-
-  &:not(.ouiBreadcrumbWrapper--first) {
-    margin-bottom: $ouiSizeXS; /* 1 */
-  }
-
-  &:not(.ouiBreadcrumbWrapper--last) {
-    margin-right: $ouiBreadcrumbSpacing;
-  }
-}
-
-.ouiBreadcrumbWall {
-  background-image: linear-gradient(to right, $ouiBreadcrumbGrayBackground 0 $ouiSizeM, transparent $ouiSizeM);
-  border-radius: $ouiSizeXS;
-  overflow: hidden;
-  margin-bottom: $ouiSizeXS; /* 1 */
-}
-
-.ouiBreadcrumbWrapper--last {
-  background-color: $ouiBreadcrumbBlueBackground;
 }

--- a/src/components/breadcrumbs/_variables.scss
+++ b/src/components/breadcrumbs/_variables.scss
@@ -12,17 +12,8 @@
 $ouiBreadcrumbSpacing: $ouiSizeS !default;
 $ouiBreadcrumbTruncateWidth: $ouiSize * 10 !default;
 
-$ouiBreadcrumbBlueBackground: #B9D9EB !default;
-$ouiBreadcrumbGrayBackground: #D9E1E2 !default;
-$ouiBreadcrumbCollapsedLink: #002A3A !default;
-$ouiBreadCrumbHoverColor: #535861 !default;
 
 /* OUI -> EUI Aliases */
 $euiBreadcrumbSpacing: $ouiBreadcrumbSpacing;
 $euiBreadcrumbTruncateWidth: $ouiBreadcrumbTruncateWidth;
-
-$euiBreadcrumbBlueBackground: $ouiBreadcrumbBlueBackground;
-$euiBreadcrumbGrayBackground: $ouiBreadcrumbGrayBackground;
-$euiBreadcrumbCollapsedLink: $ouiBreadcrumbCollapsedLink;
-$euiBreadCrumbHoverColor: $ouiBreadCrumbHoverColor;
 /* End of Aliases */

--- a/src/components/breadcrumbs/breadcrumbs.tsx
+++ b/src/components/breadcrumbs/breadcrumbs.tsx
@@ -162,21 +162,20 @@ const limitBreadcrumbs = (
 
     return (
       <Fragment>
-        <div className="ouiBreadcrumbWrapper ouiBreadcrumbWrapper--collapsed">
-          <OuiPopover
-            className="ouiBreadcrumb ouiBreadcrumb--collapsed"
-            button={ellipsisButton}
-            isOpen={isPopoverOpen}
-            closePopover={() => setIsPopoverOpen(false)}>
-            <OuiBreadcrumbs
-              className="ouiBreadcrumbs__inPopover"
-              breadcrumbs={overflowBreadcrumbs}
-              responsive={false}
-              truncate={false}
-              max={0}
-            />
-          </OuiPopover>
-        </div>
+        <OuiPopover
+          className="ouiBreadcrumb ouiBreadcrumb--collapsed"
+          button={ellipsisButton}
+          isOpen={isPopoverOpen}
+          closePopover={() => setIsPopoverOpen(false)}>
+          <OuiBreadcrumbs
+            className="ouiBreadcrumbs__inPopover"
+            breadcrumbs={overflowBreadcrumbs}
+            responsive={false}
+            truncate={false}
+            max={0}
+          />
+        </OuiPopover>
+        <OuiBreadcrumbSeparator />
       </Fragment>
     );
   };
@@ -187,6 +186,8 @@ const limitBreadcrumbs = (
 
   return [...breadcrumbsAtStart, ...breadcrumbsAtEnd];
 };
+
+const OuiBreadcrumbSeparator = () => <div className="ouiBreadcrumbSeparator" />;
 
 export const OuiBreadcrumbs: FunctionComponent<OuiBreadcrumbsProps> = ({
   breadcrumbs,
@@ -227,14 +228,7 @@ export const OuiBreadcrumbs: FunctionComponent<OuiBreadcrumbsProps> = ({
       ...breadcrumbRest
     } = breadcrumb;
 
-    const isFirstBreadcrumb = index === 0;
     const isLastBreadcrumb = index === breadcrumbs.length - 1;
-
-    const breadcrumbWrapperClasses = classNames('ouiBreadcrumbWrapper', {
-      'ouiBreadcrumbWrapper--first': isFirstBreadcrumb,
-      'ouiBreadcrumbWrapper--last': isLastBreadcrumb,
-      'ouiBreadcrumbWrapper--truncate': truncate,
-    });
 
     const breadcrumbClasses = classNames('ouiBreadcrumb', breadcrumbClassName, {
       'ouiBreadcrumb--last': isLastBreadcrumb,
@@ -277,15 +271,18 @@ export const OuiBreadcrumbs: FunctionComponent<OuiBreadcrumbsProps> = ({
       );
     }
 
-    let wrapper = <div className={breadcrumbWrapperClasses}>{link}</div>;
+    let separator;
 
-    if (isFirstBreadcrumb) {
-      const breadcrumbWallClasses = classNames('ouiBreadcrumbWall');
-
-      wrapper = <div className={breadcrumbWallClasses}>{wrapper}</div>;
+    if (!isLastBreadcrumb) {
+      separator = <OuiBreadcrumbSeparator />;
     }
 
-    return <Fragment key={index}>{wrapper}</Fragment>;
+    return (
+      <Fragment key={index}>
+        {link}
+        {separator}
+      </Fragment>
+    );
   });
 
   // Use the default object if they simply passed `true` for responsive

--- a/src/components/control_bar/__snapshots__/control_bar.test.tsx.snap
+++ b/src/components/control_bar/__snapshots__/control_bar.test.tsx.snap
@@ -19,32 +19,23 @@ exports[`OuiControlBar is rendered 1`] = `
       aria-label="breadcrumb"
       class="ouiBreadcrumbs ouiControlBar__breadcrumbs ouiBreadcrumbs--truncate"
     >
-      <div
-        class="ouiBreadcrumbWall"
+      <span
+        aria-current="false"
+        class="ouiBreadcrumb"
+        title="src"
       >
-        <div
-          class="ouiBreadcrumbWrapper ouiBreadcrumbWrapper--first"
-        >
-          <span
-            aria-current="false"
-            class="ouiBreadcrumb"
-            title="src"
-          >
-            src
-          </span>
-        </div>
-      </div>
+        src
+      </span>
       <div
-        class="ouiBreadcrumbWrapper ouiBreadcrumbWrapper--last"
+        class="ouiBreadcrumbSeparator"
+      />
+      <span
+        aria-current="page"
+        class="ouiBreadcrumb ouiBreadcrumb--last"
+        title="components"
       >
-        <span
-          aria-current="page"
-          class="ouiBreadcrumb ouiBreadcrumb--last"
-          title="components"
-        >
-          components
-        </span>
-      </div>
+        components
+      </span>
     </nav>
     <button
       class="ouiButton ouiButton--ghost ouiButton--small ouiControlBar__button"
@@ -165,32 +156,23 @@ exports[`OuiControlBar props leftOffset is rendered 1`] = `
                 aria-label="breadcrumb"
                 class="ouiBreadcrumbs ouiControlBar__breadcrumbs ouiBreadcrumbs--truncate"
               >
-                <div
-                  class="ouiBreadcrumbWall"
+                <span
+                  aria-current="false"
+                  class="ouiBreadcrumb"
+                  title="src"
                 >
-                  <div
-                    class="ouiBreadcrumbWrapper ouiBreadcrumbWrapper--first"
-                  >
-                    <span
-                      aria-current="false"
-                      class="ouiBreadcrumb"
-                      title="src"
-                    >
-                      src
-                    </span>
-                  </div>
-                </div>
+                  src
+                </span>
                 <div
-                  class="ouiBreadcrumbWrapper ouiBreadcrumbWrapper--last"
+                  class="ouiBreadcrumbSeparator"
+                />
+                <span
+                  aria-current="page"
+                  class="ouiBreadcrumb ouiBreadcrumb--last"
+                  title="components"
                 >
-                  <span
-                    aria-current="page"
-                    class="ouiBreadcrumb ouiBreadcrumb--last"
-                    title="components"
-                  >
-                    components
-                  </span>
-                </div>
+                  components
+                </span>
               </nav>
               <button
                 class="ouiButton ouiButton--ghost ouiButton--small ouiControlBar__button"
@@ -284,36 +266,29 @@ exports[`OuiControlBar props leftOffset is rendered 1`] = `
                 aria-label="breadcrumb"
                 className="ouiBreadcrumbs ouiControlBar__breadcrumbs ouiBreadcrumbs--truncate"
               >
-                <div
-                  className="ouiBreadcrumbWall"
-                >
-                  <div
-                    className="ouiBreadcrumbWrapper ouiBreadcrumbWrapper--first"
+                <OuiInnerText>
+                  <span
+                    aria-current="false"
+                    className="ouiBreadcrumb"
+                    title="src"
                   >
-                    <OuiInnerText>
-                      <span
-                        aria-current="false"
-                        className="ouiBreadcrumb"
-                        title="src"
-                      >
-                        src
-                      </span>
-                    </OuiInnerText>
-                  </div>
-                </div>
-                <div
-                  className="ouiBreadcrumbWrapper ouiBreadcrumbWrapper--last"
-                >
-                  <OuiInnerText>
-                    <span
-                      aria-current="page"
-                      className="ouiBreadcrumb ouiBreadcrumb--last"
-                      title="components"
-                    >
-                      components
-                    </span>
-                  </OuiInnerText>
-                </div>
+                    src
+                  </span>
+                </OuiInnerText>
+                <OuiBreadcrumbSeparator>
+                  <div
+                    className="ouiBreadcrumbSeparator"
+                  />
+                </OuiBreadcrumbSeparator>
+                <OuiInnerText>
+                  <span
+                    aria-current="page"
+                    className="ouiBreadcrumb ouiBreadcrumb--last"
+                    title="components"
+                  >
+                    components
+                  </span>
+                </OuiInnerText>
               </nav>
             </OuiBreadcrumbs>
             <OuiButton
@@ -505,32 +480,23 @@ exports[`OuiControlBar props maxHeight is rendered 1`] = `
                 aria-label="breadcrumb"
                 class="ouiBreadcrumbs ouiControlBar__breadcrumbs ouiBreadcrumbs--truncate"
               >
-                <div
-                  class="ouiBreadcrumbWall"
+                <span
+                  aria-current="false"
+                  class="ouiBreadcrumb"
+                  title="src"
                 >
-                  <div
-                    class="ouiBreadcrumbWrapper ouiBreadcrumbWrapper--first"
-                  >
-                    <span
-                      aria-current="false"
-                      class="ouiBreadcrumb"
-                      title="src"
-                    >
-                      src
-                    </span>
-                  </div>
-                </div>
+                  src
+                </span>
                 <div
-                  class="ouiBreadcrumbWrapper ouiBreadcrumbWrapper--last"
+                  class="ouiBreadcrumbSeparator"
+                />
+                <span
+                  aria-current="page"
+                  class="ouiBreadcrumb ouiBreadcrumb--last"
+                  title="components"
                 >
-                  <span
-                    aria-current="page"
-                    class="ouiBreadcrumb ouiBreadcrumb--last"
-                    title="components"
-                  >
-                    components
-                  </span>
-                </div>
+                  components
+                </span>
               </nav>
               <button
                 class="ouiButton ouiButton--ghost ouiButton--small ouiControlBar__button"
@@ -624,36 +590,29 @@ exports[`OuiControlBar props maxHeight is rendered 1`] = `
                 aria-label="breadcrumb"
                 className="ouiBreadcrumbs ouiControlBar__breadcrumbs ouiBreadcrumbs--truncate"
               >
-                <div
-                  className="ouiBreadcrumbWall"
-                >
-                  <div
-                    className="ouiBreadcrumbWrapper ouiBreadcrumbWrapper--first"
+                <OuiInnerText>
+                  <span
+                    aria-current="false"
+                    className="ouiBreadcrumb"
+                    title="src"
                   >
-                    <OuiInnerText>
-                      <span
-                        aria-current="false"
-                        className="ouiBreadcrumb"
-                        title="src"
-                      >
-                        src
-                      </span>
-                    </OuiInnerText>
-                  </div>
-                </div>
-                <div
-                  className="ouiBreadcrumbWrapper ouiBreadcrumbWrapper--last"
-                >
-                  <OuiInnerText>
-                    <span
-                      aria-current="page"
-                      className="ouiBreadcrumb ouiBreadcrumb--last"
-                      title="components"
-                    >
-                      components
-                    </span>
-                  </OuiInnerText>
-                </div>
+                    src
+                  </span>
+                </OuiInnerText>
+                <OuiBreadcrumbSeparator>
+                  <div
+                    className="ouiBreadcrumbSeparator"
+                  />
+                </OuiBreadcrumbSeparator>
+                <OuiInnerText>
+                  <span
+                    aria-current="page"
+                    className="ouiBreadcrumb ouiBreadcrumb--last"
+                    title="components"
+                  >
+                    components
+                  </span>
+                </OuiInnerText>
               </nav>
             </OuiBreadcrumbs>
             <OuiButton
@@ -844,32 +803,23 @@ exports[`OuiControlBar props mobile is rendered 1`] = `
                 aria-label="breadcrumb"
                 class="ouiBreadcrumbs ouiControlBar__breadcrumbs ouiBreadcrumbs--truncate"
               >
-                <div
-                  class="ouiBreadcrumbWall"
+                <span
+                  aria-current="false"
+                  class="ouiBreadcrumb"
+                  title="src"
                 >
-                  <div
-                    class="ouiBreadcrumbWrapper ouiBreadcrumbWrapper--first"
-                  >
-                    <span
-                      aria-current="false"
-                      class="ouiBreadcrumb"
-                      title="src"
-                    >
-                      src
-                    </span>
-                  </div>
-                </div>
+                  src
+                </span>
                 <div
-                  class="ouiBreadcrumbWrapper ouiBreadcrumbWrapper--last"
+                  class="ouiBreadcrumbSeparator"
+                />
+                <span
+                  aria-current="page"
+                  class="ouiBreadcrumb ouiBreadcrumb--last"
+                  title="components"
                 >
-                  <span
-                    aria-current="page"
-                    class="ouiBreadcrumb ouiBreadcrumb--last"
-                    title="components"
-                  >
-                    components
-                  </span>
-                </div>
+                  components
+                </span>
               </nav>
               <button
                 class="ouiButton ouiButton--ghost ouiButton--small ouiControlBar__button"
@@ -963,36 +913,29 @@ exports[`OuiControlBar props mobile is rendered 1`] = `
                 aria-label="breadcrumb"
                 className="ouiBreadcrumbs ouiControlBar__breadcrumbs ouiBreadcrumbs--truncate"
               >
-                <div
-                  className="ouiBreadcrumbWall"
-                >
-                  <div
-                    className="ouiBreadcrumbWrapper ouiBreadcrumbWrapper--first"
+                <OuiInnerText>
+                  <span
+                    aria-current="false"
+                    className="ouiBreadcrumb"
+                    title="src"
                   >
-                    <OuiInnerText>
-                      <span
-                        aria-current="false"
-                        className="ouiBreadcrumb"
-                        title="src"
-                      >
-                        src
-                      </span>
-                    </OuiInnerText>
-                  </div>
-                </div>
-                <div
-                  className="ouiBreadcrumbWrapper ouiBreadcrumbWrapper--last"
-                >
-                  <OuiInnerText>
-                    <span
-                      aria-current="page"
-                      className="ouiBreadcrumb ouiBreadcrumb--last"
-                      title="components"
-                    >
-                      components
-                    </span>
-                  </OuiInnerText>
-                </div>
+                    src
+                  </span>
+                </OuiInnerText>
+                <OuiBreadcrumbSeparator>
+                  <div
+                    className="ouiBreadcrumbSeparator"
+                  />
+                </OuiBreadcrumbSeparator>
+                <OuiInnerText>
+                  <span
+                    aria-current="page"
+                    className="ouiBreadcrumb ouiBreadcrumb--last"
+                    title="components"
+                  >
+                    components
+                  </span>
+                </OuiInnerText>
               </nav>
             </OuiBreadcrumbs>
             <OuiButton
@@ -1206,36 +1149,29 @@ exports[`OuiControlBar props position is rendered 1`] = `
             aria-label="breadcrumb"
             className="ouiBreadcrumbs ouiControlBar__breadcrumbs ouiBreadcrumbs--truncate"
           >
-            <div
-              className="ouiBreadcrumbWall"
-            >
-              <div
-                className="ouiBreadcrumbWrapper ouiBreadcrumbWrapper--first"
+            <OuiInnerText>
+              <span
+                aria-current="false"
+                className="ouiBreadcrumb"
+                title="src"
               >
-                <OuiInnerText>
-                  <span
-                    aria-current="false"
-                    className="ouiBreadcrumb"
-                    title="src"
-                  >
-                    src
-                  </span>
-                </OuiInnerText>
-              </div>
-            </div>
-            <div
-              className="ouiBreadcrumbWrapper ouiBreadcrumbWrapper--last"
-            >
-              <OuiInnerText>
-                <span
-                  aria-current="page"
-                  className="ouiBreadcrumb ouiBreadcrumb--last"
-                  title="components"
-                >
-                  components
-                </span>
-              </OuiInnerText>
-            </div>
+                src
+              </span>
+            </OuiInnerText>
+            <OuiBreadcrumbSeparator>
+              <div
+                className="ouiBreadcrumbSeparator"
+              />
+            </OuiBreadcrumbSeparator>
+            <OuiInnerText>
+              <span
+                aria-current="page"
+                className="ouiBreadcrumb ouiBreadcrumb--last"
+                title="components"
+              >
+                components
+              </span>
+            </OuiInnerText>
           </nav>
         </OuiBreadcrumbs>
         <OuiButton
@@ -1411,32 +1347,23 @@ exports[`OuiControlBar props rightOffset is rendered 1`] = `
                 aria-label="breadcrumb"
                 class="ouiBreadcrumbs ouiControlBar__breadcrumbs ouiBreadcrumbs--truncate"
               >
-                <div
-                  class="ouiBreadcrumbWall"
+                <span
+                  aria-current="false"
+                  class="ouiBreadcrumb"
+                  title="src"
                 >
-                  <div
-                    class="ouiBreadcrumbWrapper ouiBreadcrumbWrapper--first"
-                  >
-                    <span
-                      aria-current="false"
-                      class="ouiBreadcrumb"
-                      title="src"
-                    >
-                      src
-                    </span>
-                  </div>
-                </div>
+                  src
+                </span>
                 <div
-                  class="ouiBreadcrumbWrapper ouiBreadcrumbWrapper--last"
+                  class="ouiBreadcrumbSeparator"
+                />
+                <span
+                  aria-current="page"
+                  class="ouiBreadcrumb ouiBreadcrumb--last"
+                  title="components"
                 >
-                  <span
-                    aria-current="page"
-                    class="ouiBreadcrumb ouiBreadcrumb--last"
-                    title="components"
-                  >
-                    components
-                  </span>
-                </div>
+                  components
+                </span>
               </nav>
               <button
                 class="ouiButton ouiButton--ghost ouiButton--small ouiControlBar__button"
@@ -1530,36 +1457,29 @@ exports[`OuiControlBar props rightOffset is rendered 1`] = `
                 aria-label="breadcrumb"
                 className="ouiBreadcrumbs ouiControlBar__breadcrumbs ouiBreadcrumbs--truncate"
               >
-                <div
-                  className="ouiBreadcrumbWall"
-                >
-                  <div
-                    className="ouiBreadcrumbWrapper ouiBreadcrumbWrapper--first"
+                <OuiInnerText>
+                  <span
+                    aria-current="false"
+                    className="ouiBreadcrumb"
+                    title="src"
                   >
-                    <OuiInnerText>
-                      <span
-                        aria-current="false"
-                        className="ouiBreadcrumb"
-                        title="src"
-                      >
-                        src
-                      </span>
-                    </OuiInnerText>
-                  </div>
-                </div>
-                <div
-                  className="ouiBreadcrumbWrapper ouiBreadcrumbWrapper--last"
-                >
-                  <OuiInnerText>
-                    <span
-                      aria-current="page"
-                      className="ouiBreadcrumb ouiBreadcrumb--last"
-                      title="components"
-                    >
-                      components
-                    </span>
-                  </OuiInnerText>
-                </div>
+                    src
+                  </span>
+                </OuiInnerText>
+                <OuiBreadcrumbSeparator>
+                  <div
+                    className="ouiBreadcrumbSeparator"
+                  />
+                </OuiBreadcrumbSeparator>
+                <OuiInnerText>
+                  <span
+                    aria-current="page"
+                    className="ouiBreadcrumb ouiBreadcrumb--last"
+                    title="components"
+                  >
+                    components
+                  </span>
+                </OuiInnerText>
               </nav>
             </OuiBreadcrumbs>
             <OuiButton
@@ -1750,32 +1670,23 @@ exports[`OuiControlBar props showContent is rendered 1`] = `
                 aria-label="breadcrumb"
                 class="ouiBreadcrumbs ouiControlBar__breadcrumbs ouiBreadcrumbs--truncate"
               >
-                <div
-                  class="ouiBreadcrumbWall"
+                <span
+                  aria-current="false"
+                  class="ouiBreadcrumb"
+                  title="src"
                 >
-                  <div
-                    class="ouiBreadcrumbWrapper ouiBreadcrumbWrapper--first"
-                  >
-                    <span
-                      aria-current="false"
-                      class="ouiBreadcrumb"
-                      title="src"
-                    >
-                      src
-                    </span>
-                  </div>
-                </div>
+                  src
+                </span>
                 <div
-                  class="ouiBreadcrumbWrapper ouiBreadcrumbWrapper--last"
+                  class="ouiBreadcrumbSeparator"
+                />
+                <span
+                  aria-current="page"
+                  class="ouiBreadcrumb ouiBreadcrumb--last"
+                  title="components"
                 >
-                  <span
-                    aria-current="page"
-                    class="ouiBreadcrumb ouiBreadcrumb--last"
-                    title="components"
-                  >
-                    components
-                  </span>
-                </div>
+                  components
+                </span>
               </nav>
               <button
                 class="ouiButton ouiButton--ghost ouiButton--small ouiControlBar__button"
@@ -1874,36 +1785,29 @@ exports[`OuiControlBar props showContent is rendered 1`] = `
                 aria-label="breadcrumb"
                 className="ouiBreadcrumbs ouiControlBar__breadcrumbs ouiBreadcrumbs--truncate"
               >
-                <div
-                  className="ouiBreadcrumbWall"
-                >
-                  <div
-                    className="ouiBreadcrumbWrapper ouiBreadcrumbWrapper--first"
+                <OuiInnerText>
+                  <span
+                    aria-current="false"
+                    className="ouiBreadcrumb"
+                    title="src"
                   >
-                    <OuiInnerText>
-                      <span
-                        aria-current="false"
-                        className="ouiBreadcrumb"
-                        title="src"
-                      >
-                        src
-                      </span>
-                    </OuiInnerText>
-                  </div>
-                </div>
-                <div
-                  className="ouiBreadcrumbWrapper ouiBreadcrumbWrapper--last"
-                >
-                  <OuiInnerText>
-                    <span
-                      aria-current="page"
-                      className="ouiBreadcrumb ouiBreadcrumb--last"
-                      title="components"
-                    >
-                      components
-                    </span>
-                  </OuiInnerText>
-                </div>
+                    src
+                  </span>
+                </OuiInnerText>
+                <OuiBreadcrumbSeparator>
+                  <div
+                    className="ouiBreadcrumbSeparator"
+                  />
+                </OuiBreadcrumbSeparator>
+                <OuiInnerText>
+                  <span
+                    aria-current="page"
+                    className="ouiBreadcrumb ouiBreadcrumb--last"
+                    title="components"
+                  >
+                    components
+                  </span>
+                </OuiInnerText>
               </nav>
             </OuiBreadcrumbs>
             <OuiButton
@@ -2099,32 +2003,23 @@ exports[`OuiControlBar props size is rendered 1`] = `
                 aria-label="breadcrumb"
                 class="ouiBreadcrumbs ouiControlBar__breadcrumbs ouiBreadcrumbs--truncate"
               >
-                <div
-                  class="ouiBreadcrumbWall"
+                <span
+                  aria-current="false"
+                  class="ouiBreadcrumb"
+                  title="src"
                 >
-                  <div
-                    class="ouiBreadcrumbWrapper ouiBreadcrumbWrapper--first"
-                  >
-                    <span
-                      aria-current="false"
-                      class="ouiBreadcrumb"
-                      title="src"
-                    >
-                      src
-                    </span>
-                  </div>
-                </div>
+                  src
+                </span>
                 <div
-                  class="ouiBreadcrumbWrapper ouiBreadcrumbWrapper--last"
+                  class="ouiBreadcrumbSeparator"
+                />
+                <span
+                  aria-current="page"
+                  class="ouiBreadcrumb ouiBreadcrumb--last"
+                  title="components"
                 >
-                  <span
-                    aria-current="page"
-                    class="ouiBreadcrumb ouiBreadcrumb--last"
-                    title="components"
-                  >
-                    components
-                  </span>
-                </div>
+                  components
+                </span>
               </nav>
               <button
                 class="ouiButton ouiButton--ghost ouiButton--small ouiControlBar__button"
@@ -2218,36 +2113,29 @@ exports[`OuiControlBar props size is rendered 1`] = `
                 aria-label="breadcrumb"
                 className="ouiBreadcrumbs ouiControlBar__breadcrumbs ouiBreadcrumbs--truncate"
               >
-                <div
-                  className="ouiBreadcrumbWall"
-                >
-                  <div
-                    className="ouiBreadcrumbWrapper ouiBreadcrumbWrapper--first"
+                <OuiInnerText>
+                  <span
+                    aria-current="false"
+                    className="ouiBreadcrumb"
+                    title="src"
                   >
-                    <OuiInnerText>
-                      <span
-                        aria-current="false"
-                        className="ouiBreadcrumb"
-                        title="src"
-                      >
-                        src
-                      </span>
-                    </OuiInnerText>
-                  </div>
-                </div>
-                <div
-                  className="ouiBreadcrumbWrapper ouiBreadcrumbWrapper--last"
-                >
-                  <OuiInnerText>
-                    <span
-                      aria-current="page"
-                      className="ouiBreadcrumb ouiBreadcrumb--last"
-                      title="components"
-                    >
-                      components
-                    </span>
-                  </OuiInnerText>
-                </div>
+                    src
+                  </span>
+                </OuiInnerText>
+                <OuiBreadcrumbSeparator>
+                  <div
+                    className="ouiBreadcrumbSeparator"
+                  />
+                </OuiBreadcrumbSeparator>
+                <OuiInnerText>
+                  <span
+                    aria-current="page"
+                    className="ouiBreadcrumb ouiBreadcrumb--last"
+                    title="components"
+                  >
+                    components
+                  </span>
+                </OuiInnerText>
               </nav>
             </OuiBreadcrumbs>
             <OuiButton

--- a/src/components/header/__snapshots__/header.test.tsx.snap
+++ b/src/components/header/__snapshots__/header.test.tsx.snap
@@ -42,20 +42,12 @@ exports[`OuiHeader sections render breadcrumbs and props 1`] = `
     aria-label="breadcrumb"
     class="ouiBreadcrumbs ouiHeaderBreadcrumbs ouiBreadcrumbs--truncate"
   >
-    <div
-      class="ouiBreadcrumbWall"
+    <span
+      aria-current="page"
+      class="ouiBreadcrumb ouiBreadcrumb--last"
     >
-      <div
-        class="ouiBreadcrumbWrapper ouiBreadcrumbWrapper--first ouiBreadcrumbWrapper--last"
-      >
-        <span
-          aria-current="page"
-          class="ouiBreadcrumb ouiBreadcrumb--last"
-        >
-          Breadcrumb
-        </span>
-      </div>
-    </div>
+      Breadcrumb
+    </span>
   </nav>
 </div>
 `;

--- a/src/components/header/header_breadcrumbs/__snapshots__/header_breadcrumbs.test.tsx.snap
+++ b/src/components/header/header_breadcrumbs/__snapshots__/header_breadcrumbs.test.tsx.snap
@@ -6,52 +6,41 @@ exports[`OuiHeaderBreadcrumbs is rendered 1`] = `
   class="ouiBreadcrumbs ouiHeaderBreadcrumbs testClass1 testClass2 ouiBreadcrumbs--truncate"
   data-test-subj="test subject string"
 >
-  <div
-    class="ouiBreadcrumbWall"
+  <a
+    class="ouiLink ouiLink--subdued ouiBreadcrumb customClass"
+    data-test-subj="breadcrumbsAnimals"
+    href="#"
+    rel="noreferrer"
   >
-    <div
-      class="ouiBreadcrumbWrapper ouiBreadcrumbWrapper--first"
-    >
-      <a
-        class="ouiLink ouiLink--subdued ouiBreadcrumb customClass"
-        data-test-subj="breadcrumbsAnimals"
-        href="#"
-        rel="noreferrer"
-      >
-        Animals
-      </a>
-    </div>
-  </div>
+    Animals
+  </a>
   <div
-    class="ouiBreadcrumbWrapper"
+    class="ouiBreadcrumbSeparator"
+  />
+  <button
+    class="ouiLink ouiLink--subdued ouiBreadcrumb"
+    type="button"
   >
-    <button
-      class="ouiLink ouiLink--subdued ouiBreadcrumb"
-      type="button"
-    >
-      Reptiles
-    </button>
-  </div>
+    Reptiles
+  </button>
   <div
-    class="ouiBreadcrumbWrapper"
+    class="ouiBreadcrumbSeparator"
+  />
+  <a
+    class="ouiLink ouiLink--subdued ouiBreadcrumb"
+    href="#"
+    rel="noreferrer"
   >
-    <a
-      class="ouiLink ouiLink--subdued ouiBreadcrumb"
-      href="#"
-      rel="noreferrer"
-    >
-      Boa constrictor
-    </a>
-  </div>
+    Boa constrictor
+  </a>
   <div
-    class="ouiBreadcrumbWrapper ouiBreadcrumbWrapper--last"
+    class="ouiBreadcrumbSeparator"
+  />
+  <span
+    aria-current="page"
+    class="ouiBreadcrumb ouiBreadcrumb--last"
   >
-    <span
-      aria-current="page"
-      class="ouiBreadcrumb ouiBreadcrumb--last"
-    >
-      Edit
-    </span>
-  </div>
+    Edit
+  </span>
 </nav>
 `;

--- a/src/themes/oui/oui_colors_dark.scss
+++ b/src/themes/oui/oui_colors_dark.scss
@@ -62,12 +62,6 @@ $ouiColorChartBand: tint($ouiColorLightestShade, 2.5%);
 $ouiShadowColor: #000;
 $ouiShadowColorLarge: #000;
 
-// Breadcrumbs
-$ouiBreadcrumbBlueBackground: #163F66;
-$ouiBreadcrumbGrayBackground: #4C636F;
-$ouiBreadcrumbCollapsedLink: #FFF;
-$ouiBreadCrumbHoverColor: #B0B8BB;
-
 
 /* OUI -> EUI Aliases */
 $euiColorGhost: $ouiColorGhost;
@@ -103,8 +97,4 @@ $euiColorChartLines: $ouiColorChartLines;
 $euiColorChartBand: $ouiColorChartBand;
 $euiShadowColor: $ouiShadowColor;
 $euiShadowColorLarge: $ouiShadowColorLarge;
-$euiBreadcrumbBlueBackground: $ouiBreadcrumbBlueBackground;
-$euiBreadcrumbGrayBackground: $ouiBreadcrumbGrayBackground;
-$euiBreadcrumbCollapsedLink: $ouiBreadcrumbCollapsedLink;
-$euiBreadCrumbHoverColor: $ouiBreadCrumbHoverColor;
 /* End of Aliases */


### PR DESCRIPTION
This reverts commit 70c12b02551ff0505efd64fb754e8b390e92c980.

### Description
This PR is ready to go in case we need to revert breadcrumbs for 1.2. If we can get a fix for #771 in for 1.2, this PR will be closed. If not, we'll merge this PR and schedule breadcrumbs for next release.

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [x] All tests pass
  - [x] `yarn lint`
  - [x] `yarn test-unit`
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/oui/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
