### PR TITLE
Fix breadcrumb styling with a single breadcrumb

### DIFF
--- a/src/components/breadcrumbs/_breadcrumbs.scss
+++ b/src/components/breadcrumbs/_breadcrumbs.scss
@@ -98,7 +98,8 @@
     margin-bottom: $ouiSizeXS; /* 1 */
   }
 
-  &:not(.ouiBreadcrumbWrapper--last) {
+  &:not(.ouiBreadcrumbWrapper--last),
+  &.ouiBreadcrumbWrapper--first.ouiBreadcrumbWrapper--last {
     margin-right: $ouiBreadcrumbSpacing;
   }
 }
@@ -108,6 +109,10 @@
   border-radius: $ouiSizeXS;
   overflow: hidden;
   margin-bottom: $ouiSizeXS; /* 1 */
+}
+
+.ouiBreadcrumbWall--single {
+  background-image: linear-gradient(to right, $ouiBreadcrumbBlueBackground 0 $ouiSizeM, transparent $ouiSizeM);
 }
 
 .ouiBreadcrumbWrapper--last {

--- a/src/components/breadcrumbs/breadcrumbs.tsx
+++ b/src/components/breadcrumbs/breadcrumbs.tsx
@@ -280,7 +280,9 @@ export const OuiBreadcrumbs: FunctionComponent<OuiBreadcrumbsProps> = ({
     let wrapper = <div className={breadcrumbWrapperClasses}>{link}</div>;
 
     if (isFirstBreadcrumb) {
-      const breadcrumbWallClasses = classNames('ouiBreadcrumbWall');
+      const breadcrumbWallClasses = classNames('ouiBreadcrumbWall', {
+        'ouiBreadcrumbWall--single': isLastBreadcrumb,
+      });
 
       wrapper = <div className={breadcrumbWallClasses}>{wrapper}</div>;
     }

--- a/src/components/header/__snapshots__/header.test.tsx.snap
+++ b/src/components/header/__snapshots__/header.test.tsx.snap
@@ -43,7 +43,7 @@ exports[`OuiHeader sections render breadcrumbs and props 1`] = `
     class="ouiBreadcrumbs ouiHeaderBreadcrumbs ouiBreadcrumbs--truncate"
   >
     <div
-      class="ouiBreadcrumbWall"
+      class="ouiBreadcrumbWall ouiBreadcrumbWall--single"
     >
       <div
         class="ouiBreadcrumbWrapper ouiBreadcrumbWrapper--first ouiBreadcrumbWrapper--last"


### PR DESCRIPTION
### Description
Fixes breadcrumb styling when there is only a single breadcrumb.

Before:

![Screenshot (36)](https://github.com/opensearch-project/oui/assets/6763209/17c3aacc-5370-4b0d-9fa9-1d89e07f58cc)

After:

![Screenshot (42)](https://github.com/opensearch-project/oui/assets/6763209/97fc61f2-e7b8-4344-9042-1deb81e4805b)

### Issues Resolved
Fixes #771 
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [x] All tests pass
  - [x] `yarn lint`
  - [x] `yarn test-unit`
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/oui/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
