### PR TITLE
[CCI] Update the default branch

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -14,7 +14,7 @@ Yes, but be aware of the [license](LICENSE) as always. The roadmap and prioritie
 
 We use [semver](https://semver.org/) for versioning and use that to denote breaking changes in OUI upgrades. We consider API changes in our prop names or existing component functionality to be a reason for a breaking change, but do not consider renaming of CSS selectors, mixins, or other style changes to be breaking.
 
-Traditionally releases are made weekly against whatever is in master and you can upgrade from NPM as you see fit.
+Traditionally releases are made weekly against whatever is in main and you can upgrade from NPM as you see fit.
 
 ## How do you handle Typescript, Sass and theming?
 

--- a/scripts/deploy/deploy_docs
+++ b/scripts/deploy/deploy_docs
@@ -41,7 +41,7 @@ set +x
 # Expected env variables:
 # * GPROJECT - GCE project name, e.g. elastic-bekitzur
 # * GCE_ACCOUNT - credentials for the google service account (JSON blob)
-# * GIT_BRANCH - current Git branch or tag (e.g. "refs/heads/master", "v18.2.1")
+# * GIT_BRANCH - current Git branch or tag (e.g. "refs/heads/main", "v18.2.1")
 
 if [[ -z "${GPROJECT}" ]]; then
     echo "GPROJECT is not set, e.g. 'GPROJECT=elastic-bekitzur'"
@@ -52,7 +52,7 @@ if [[ -z "${GCE_ACCOUNT}" ]]; then
   exit 1
 fi
 if [[ -z "${GIT_BRANCH}" ]]; then
-  echo "GIT_BRANCH is not set, e.g. 'GIT_BRANCH=refs/heads/master'"
+  echo "GIT_BRANCH is not set, e.g. 'GIT_BRANCH=refs/heads/main'"
   exit 1
 fi
 

--- a/scripts/update-changelog-version.js
+++ b/scripts/update-changelog-version.js
@@ -21,17 +21,20 @@ const { version } = require(pathToPackage);
 const pathToChangelog = path.resolve(cwd, 'CHANGELOG.md');
 let changelogContents = fs.readFileSync(pathToChangelog).toString();
 
-const masterHeading = '## [`master`](https://github.com/opensearch-project/oui/tree/master)';
-// sanity check, changelog should start with master heading
-if (changelogContents.indexOf(masterHeading) !== 0) {
-  console.error(`Cannot update CHANGELOG.md: does not start with expected heading "${masterHeading}"`);
+const mainHeading =
+  '## [`main`](https://github.com/opensearch-project/oui/tree/main)';
+// sanity check, changelog should start with main heading
+if (changelogContents.indexOf(mainHeading) !== 0) {
+  console.error(
+    `Cannot update CHANGELOG.md: does not start with expected heading "${mainHeading}"`
+  );
   process.exit(1);
 }
 
-// Insert the changelog template after the master header
+// Insert the changelog template after the main header
 changelogContents = changelogContents.replace(
-  masterHeading,
-  `${masterHeading}
+  mainHeading,
+  `${mainHeading}
 
 No public interface changes since \`${version}\`.
 

--- a/src-docs/src/views/datagrid/datagrid_example.js
+++ b/src-docs/src/views/datagrid/datagrid_example.js
@@ -427,7 +427,7 @@ export const DataGridExample = {
               explanation on the lower level object types. The majority of the
               types are defined in the{' '}
               <a
-                href="https://github.com/elastic/eui/tree/master/src/components/datagrid/data_grid_types.ts"
+                href="https://github.com/opensearch-project/oui/blob/main/src/components/datagrid/data_grid_types.ts"
                 target="_blank">
                 /datagrid/data_grid_types.ts
               </a>{' '}

--- a/src-docs/src/views/guidelines/sass.js
+++ b/src-docs/src/views/guidelines/sass.js
@@ -611,11 +611,11 @@ export const SassGuidelines = ({ selectedTheme }) => {
       <OuiText grow={false}>
         <p>
           View the{' '}
-          <OuiLink href="https://github.com/opensearch-project/oui/blob/master/src/global_styling/variables/_typography.scss">
+          <OuiLink href="https://github.com/opensearch-project/oui/blob/main/src/global_styling/variables/_typography.scss">
             variable
           </OuiLink>{' '}
           and{' '}
-          <OuiLink href="https://github.com/opensearch-project/oui/blob/master/src/global_styling/mixins/_typography.scss">
+          <OuiLink href="https://github.com/opensearch-project/oui/blob/main/src/global_styling/mixins/_typography.scss">
             mixins
           </OuiLink>{' '}
           Sass code for typography. For most of your components we recommend
@@ -753,7 +753,7 @@ export const SassGuidelines = ({ selectedTheme }) => {
 
           <OuiText>
             <p>
-              <OuiLink href="https://github.com/opensearch-project/oui/blob/master/src/global_styling/mixins/_shadow.scss">
+              <OuiLink href="https://github.com/opensearch-project/oui/blob/main/src/global_styling/mixins/_shadow.scss">
                 View the Sass code for shadow mixins
               </OuiLink>
               .
@@ -888,7 +888,7 @@ export const SassGuidelines = ({ selectedTheme }) => {
             <p>
               If you need to further customize the position or side of the
               overflow shadow use the <OuiCode>ouiOverflowShadow</OuiCode>{' '}
-              <OuiLink href="https://github.com/opensearch-project/oui/blob/master/src/global_styling/mixins/_shadow.scss">
+              <OuiLink href="https://github.com/opensearch-project/oui/blob/main/src/global_styling/mixins/_shadow.scss">
                 mixin
               </OuiLink>
               .
@@ -903,7 +903,7 @@ export const SassGuidelines = ({ selectedTheme }) => {
 
       <OuiText>
         <p>
-          <OuiLink href="https://github.com/opensearch-project/oui/blob/master/src/global_styling/mixins/_responsive.scss">
+          <OuiLink href="https://github.com/opensearch-project/oui/blob/main/src/global_styling/mixins/_responsive.scss">
             View the Sass code for media queries
           </OuiLink>
           .
@@ -983,7 +983,7 @@ export const SassGuidelines = ({ selectedTheme }) => {
       <GuideRuleTitle>Animation</GuideRuleTitle>
       <OuiText grow={false}>
         <p>
-          <OuiLink href="https://github.com/opensearch-project/oui/blob/master/src/global_styling/variables/_animations.scss">
+          <OuiLink href="https://github.com/opensearch-project/oui/blob/main/src/global_styling/variables/_animations.scss">
             View the Sass code for animation
           </OuiLink>
           .

--- a/src-docs/src/views/home/home_view.js
+++ b/src-docs/src/views/home/home_view.js
@@ -66,7 +66,7 @@ export const HomeView = () => (
               </p>
               <OuiFlexGroup gutterSize="xl" wrap responsive={false}>
                 <OuiFlexItem grow={false}>
-                  <OuiLink href="https://github.com/opensearch-project/oui/blob/master/wiki/consuming.md">
+                  <OuiLink href="https://github.com/opensearch-project/oui/blob/main/wiki/consuming.md">
                     <strong>Getting started</strong>
                   </OuiLink>
                 </OuiFlexItem>
@@ -76,7 +76,7 @@ export const HomeView = () => (
                   </Link>
                 </OuiFlexItem>
                 <OuiFlexItem grow={false}>
-                  <OuiLink href="https://github.com/opensearch-project/oui/blob/master/CONTRIBUTING.md">
+                  <OuiLink href="https://github.com/opensearch-project/oui/blob/main/CONTRIBUTING.md">
                     <strong>Contributing</strong>
                   </OuiLink>
                 </OuiFlexItem>
@@ -212,7 +212,7 @@ export const HomeView = () => (
         <OuiText size="xs" textAlign="center" color="subdued">
           <p>
             OUI is licensed under{' '}
-            <OuiLink href="https://github.com/opensearch-project/oui/blob/master/LICENSE">
+            <OuiLink href="https://github.com/opensearch-project/oui/blob/main/LICENSE">
               Apache License 2.0
             </OuiLink>{' '}
             | © OpenSearch contributors, {new Date().getFullYear()}.

--- a/src-docs/src/views/package/changelog.js
+++ b/src-docs/src/views/package/changelog.js
@@ -15,7 +15,7 @@ import { OuiMarkdownFormat } from '../../../../src';
 import { GuidePage } from '../../components/guide_page';
 
 const changelogSource = require('!!raw-loader!../../../../CHANGELOG.md').default.replace(
-  /## \[`master`\].+?##/s, // remove the `master` heading & contents
+  /## \[`main`\].+?##/s, // remove the `main` heading & contents
   '##'
 );
 

--- a/src-docs/src/views/package/i18n_tokens.js
+++ b/src-docs/src/views/package/i18n_tokens.js
@@ -36,7 +36,7 @@ const columns = [
           <OuiLink
             target="_blank"
             color="subdued"
-            href={`https://github.com/opensearch-project/oui/blob/master/${filepath}#L${loc.start.line}`}>
+            href={`https://github.com/opensearch-project/oui/blob/main/${filepath}#L${loc.start.line}`}>
             {filepath}:{loc.start.line}:{loc.start.column}
           </OuiLink>
         </div>

--- a/src-docs/src/views/tool_tip/tool_tip_example.js
+++ b/src-docs/src/views/tool_tip/tool_tip_example.js
@@ -88,7 +88,7 @@ export const ToolTipExample = {
             pass in a custom component, then you&rsquo;ll need to make sure
             these props are applied to the root element rendered by your
             component. The best way to do that is to follow{' '}
-            <a href="https://github.com/opensearch-project/oui/blob/master/wiki/component-design.md#pass-through-props">
+            <a href="https://github.com/opensearch-project/oui/blob/main/wiki/component-design.md#pass-through-props">
               OUI&rsquo;s guidelines on pass-through props
             </a>
             .

--- a/wiki/documentation-guidelines.md
+++ b/wiki/documentation-guidelines.md
@@ -51,7 +51,7 @@ import {
 
 // ...
 
-<OuiLink href="https://github.com/opensearch-project/oui/blob/master/src/global_styling/mixins/_shadow.scss">View the Sass code for shadow mixins</OuiLink>.
+<OuiLink href="https://github.com/opensearch-project/oui/blob/main/src/global_styling/mixins/_shadow.scss">View the Sass code for shadow mixins</OuiLink>.
 ```
 
 ## Adding snippets
@@ -134,7 +134,7 @@ Most documentation pages include a [playground section](https://oui.opensearch.o
 
 ### Toggles for required props
 
-Props marked required for a component typically do not have default values and therefore need to be set for the playground to work well. For example, the `children` prop, which can be set in the component's [`playground.js` file](https://github.com/opensearch-project/oui/blob/master/src-docs/src/views/accordion/playground.js):
+Props marked required for a component typically do not have default values and therefore need to be set for the playground to work well. For example, the `children` prop, which can be set in the component's [`playground.js` file](https://github.com/opensearch-project/oui/blob/main/src-docs/src/views/accordion/playground.js):
 
 ```js
 propsToUse.children = {
@@ -213,7 +213,7 @@ import { ExampleContext } from '../../services';
 
 Any updates to the `src/` folder require an entry in the [CHANGELOG.md](../CHANGELOG.md) file. Documentation-only changes do not. Here are our guidelines for updating the file:
 
-* Append your changes to the `master` sub-heading of `CHANGELOG.md`.
+* Append your changes to the `main` sub-heading of `CHANGELOG.md`.
 * Add a list item for each significant change in the PR: bugs that were fixed, new features, new components, or changes to the public API
 * In the list item, always link to any relevant pull requests
 * Add a summary of what has changed, making sure it's informative to consumers who might be unaware of implementation details


### PR DESCRIPTION
### Description
The current default branch is `main`. I have updated the places that still refer to `master`.

Before:
<img width="1728" alt="Screenshot 2023-05-29 at 18 41 07" src="https://github.com/opensearch-project/oui/assets/40265277/c2f721b0-3824-48e1-ad6b-cd4cd6f0082a">

After:
<img width="1728" alt="Screenshot 2023-05-29 at 18 39 29" src="https://github.com/opensearch-project/oui/assets/40265277/bc110ede-d080-4a8e-92a0-4515d2d6e043">


### Issues Resolved
https://github.com/opensearch-project/oui/issues/797
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [X] All tests pass
  - [X] `yarn lint`
  - [X] `yarn test-unit`
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/oui/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
