### PR TITLE
Disable emoticon in markdown renderer by default

### DIFF
--- a/src/components/markdown_editor/plugins/markdown_default_plugins.tsx
+++ b/src/components/markdown_editor/plugins/markdown_default_plugins.tsx
@@ -63,7 +63,7 @@ import { OuiCodeBlock, OuiCode } from '../../code';
 export const getDefaultOuiMarkdownParsingPlugins = (): PluggableList => [
   [markdown, {}],
   [highlight, {}],
-  [emoji, { emoticon: true }],
+  [emoji, { emoticon: false }],
   [MarkdownTooltip.parser, {}],
   [MarkdownCheckbox.parser, {}],
   [markdownLinkValidator, {}],


### PR DESCRIPTION
### Description
This PR disables emoticons (`x-p`, `8)`, etc.) by default but still allows emojis through something like `:laughing:`
 
### Issues Resolved
#802 
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [x] All tests pass
  - [ ] `yarn lint`
  - [ ] `yarn test-unit`
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/oui/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
