### PR TITLE
Make font consumption happen using CSS variables

### DIFF
--- a/src/components/suggest/_suggest_item.scss
+++ b/src/components/suggest/_suggest_item.scss
@@ -62,7 +62,7 @@
 
   .ouiSuggestItem__label {
     @include ouiTextTruncate;
-    font-family: $ouiCodeFontFamily;
+    font-family: var(--oui-code-font-family);
     overflow: hidden;
     text-overflow: ellipsis;
     padding: $ouiSizeXS $ouiSizeS;

--- a/src/global_styling/css_variables/_fonts.scss
+++ b/src/global_styling/css_variables/_fonts.scss
@@ -1,0 +1,9 @@
+/*!
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+:root {
+  --oui-font-family: #{$ouiFontFamily};
+  --oui-code-font-family: #{$ouiCodeFontFamily};
+}

--- a/src/global_styling/css_variables/_index.scss
+++ b/src/global_styling/css_variables/_index.scss
@@ -1,0 +1,6 @@
+/*!
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+@import 'fonts';

--- a/src/global_styling/index.scss
+++ b/src/global_styling/index.scss
@@ -23,5 +23,8 @@
 // Utility classes provide one-off selectors for common css problems
 @import 'utility/index';
 
+// CSS variables of SCSS variables
+@import 'css_variables/index';
+
 // The reset file makes use of variables and mixins
 @import 'reset/index';

--- a/src/global_styling/mixins/_typography.scss
+++ b/src/global_styling/mixins/_typography.scss
@@ -15,7 +15,7 @@
 // Our base fonts
 
 @mixin ouiFont {
-  font-family: $ouiFontFamily;
+  font-family: var(--oui-font-family);
   font-weight: $ouiFontWeightRegular;
   letter-spacing: -.005em;
   -webkit-text-size-adjust: 100%;
@@ -24,7 +24,7 @@
 }
 
 @mixin ouiCodeFont {
-  font-family: $ouiCodeFontFamily;
+  font-family: var(--oui-code-font-family);
   letter-spacing: normal;
 }
 

--- a/src/global_styling/reset/_reset.scss
+++ b/src/global_styling/reset/_reset.scss
@@ -41,7 +41,7 @@ time, mark, audio, video {
 }
 
 code, pre, kbd, samp {
-  font-family: $ouiCodeFontFamily;
+  font-family: var(--oui-code-font-family);
 }
 
 h1, h2, h3, h4, h5, h6, p {
@@ -51,7 +51,7 @@ h1, h2, h3, h4, h5, h6, p {
 }
 
 input, textarea, select, button {
-  font-family: $ouiFontFamily;
+  font-family: var(--oui-font-family);
 }
 
 em {

--- a/src/global_styling/variables/_typography.scss
+++ b/src/global_styling/variables/_typography.scss
@@ -37,8 +37,10 @@
 }
 
 // Families
-$ouiFontFamily: 'Inter UI', -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol' !default;
-$ouiCodeFontFamily: 'Roboto Mono', Consolas, Menlo, Courier, monospace !default;
+// sass-lint:disable quotes
+$ouiFontFamily: #{"'Inter UI', -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'"} !default;
+$ouiCodeFontFamily: #{"'Roboto Mono', Consolas, Menlo, Courier, monospace"} !default;
+// sass-lint:enable quotes
 
 // Careful using ligatures. Code editors like ACE will often error because of width calculations
 $ouiFontFeatureSettings: 'calt' 1, 'kern' 1, 'liga' 1 !default;


### PR DESCRIPTION
### Description
Replace usage of `$ouiFontFamily` and `$ouiCodeFontFamily` with `--oui-font-family` and `--oui-code-font-family` CSS variables
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [X] All tests pass
  - [x] `yarn lint`
  - [x] `yarn test-unit`
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/oui/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
