### PR TITLE
[New Theme] Introduce the first installment of the new look and feel

### DIFF
--- a/src/components/text/_text.scss
+++ b/src/components/text/_text.scss
@@ -153,7 +153,6 @@
     text-align: center;
     margin-left: auto;
     margin-right: auto;
-    font-family: Georgia, Times, Times New Roman, serif;
     font-style: italic;
     letter-spacing: normal;
 

--- a/src/theme_dark.scss
+++ b/src/theme_dark.scss
@@ -20,3 +20,12 @@
 
 // Packages
 @import '../packages/index';
+
+/* During creation of the new theme, these rules had to be
+ * removed from the components. To make sure the theme retains
+ * its looks, they are reintroduced here.
+ */
+
+.ouiText blockquote {
+  font-family: Georgia, Times, Times New Roman, serif;
+}

--- a/src/theme_light.scss
+++ b/src/theme_light.scss
@@ -20,3 +20,12 @@
 
 // Packages
 @import '../packages/index';
+
+/* During creation of the new theme, these rules had to be
+ * removed from the components. To make sure the theme retains
+ * its looks, they are reintroduced here.
+ */
+
+.ouiText blockquote {
+  font-family: Georgia, Times, Times New Roman, serif;
+}

--- a/src/themes/oui-cascadia/global_styling/mixins/_button.scss
+++ b/src/themes/oui-cascadia/global_styling/mixins/_button.scss
@@ -51,6 +51,7 @@
 
   text-decoration: none;
   border: solid 1px transparent;
+  font-weight: 600;
 
   // sass-lint:disable mixins-before-declarations
   // focus states should come after all default styles

--- a/src/themes/oui-cascadia/global_styling/mixins/_typography.scss
+++ b/src/themes/oui-cascadia/global_styling/mixins/_typography.scss
@@ -17,7 +17,6 @@
 @mixin ouiFont {
   font-family: var(--oui-font-family);
   font-weight: $ouiFontWeightRegular;
-  letter-spacing: -.005em;
   -webkit-text-size-adjust: 100%;
   -ms-text-size-adjust: 100%;
   font-kerning: normal;

--- a/src/themes/oui-cascadia/global_styling/variables/_colors.scss
+++ b/src/themes/oui-cascadia/global_styling/variables/_colors.scss
@@ -53,7 +53,7 @@ $ouiColorWarningText: makeHighContrastColor($ouiColorWarning) !default;
 $ouiColorDangerText: makeHighContrastColor($ouiColorDanger) !default;
 $ouiColorDisabledText: makeDisabledContrastColor($ouiColorDisabled) !default;
 $ouiColorSuccessText: $ouiColorSecondaryText !default;
-$ouiLinkColor: #006BB4 !default;
+$ouiLinkColor: $ouiColorPrimaryText !default;
 
 // Visualization colors
 

--- a/src/themes/oui-cascadia/global_styling/variables/_colors.scss
+++ b/src/themes/oui-cascadia/global_styling/variables/_colors.scss
@@ -13,11 +13,11 @@
 @import '../functions/index';
 
 // These colors stay the same no matter the theme
-$ouiColorGhost: #FFF !default;
-$ouiColorInk: #000 !default;
+$ouiColorGhost: #FCFEFF !default;
+$ouiColorInk: #0A121A !default;
 
 // Core
-$ouiColorPrimary: #006BB4 !default;
+$ouiColorPrimary: #159D8D !default;
 $ouiColorSecondary: #017D73 !default;
 $ouiColorAccent: #DD0A73 !default;
 
@@ -27,16 +27,16 @@ $ouiColorWarning: #F5A700 !default;
 $ouiColorDanger: #BD271E !default;
 
 // Grays
-$ouiColorEmptyShade: #FFF !default;
-$ouiColorLightestShade: #F5F7FA !default;
-$ouiColorLightShade: #D3DAE6 !default;
-$ouiColorMediumShade: #98A2B3 !default;
-$ouiColorDarkShade: #69707D !default;
-$ouiColorDarkestShade: #343741 !default;
-$ouiColorFullShade: #000 !default;
+$ouiColorEmptyShade: #FCFEFF !default;
+$ouiColorLightestShade: #E3E5E8 !default;
+$ouiColorLightShade: #D6D9DD !default;
+$ouiColorMediumShade: #ADB4BA !default;
+$ouiColorDarkShade: #5A6875 !default;
+$ouiColorDarkestShade: #2A3947 !default;
+$ouiColorFullShade: #0A1219 !default;
 
 // Backgrounds
-$ouiPageBackgroundColor: tint($ouiColorLightestShade, 50%) !default;
+$ouiPageBackgroundColor: #F0F2F4 !default;
 $ouiColorHighlight: #FFFCDD !default;
 
 // Every color below must be based mathematically on the set above and in a particular order.
@@ -53,7 +53,7 @@ $ouiColorWarningText: makeHighContrastColor($ouiColorWarning) !default;
 $ouiColorDangerText: makeHighContrastColor($ouiColorDanger) !default;
 $ouiColorDisabledText: makeDisabledContrastColor($ouiColorDisabled) !default;
 $ouiColorSuccessText: $ouiColorSecondaryText !default;
-$ouiLinkColor: $ouiColorPrimaryText !default;
+$ouiLinkColor: #006BB4 !default;
 
 // Visualization colors
 

--- a/src/themes/oui-cascadia/global_styling/variables/_typography.scss
+++ b/src/themes/oui-cascadia/global_styling/variables/_typography.scss
@@ -76,11 +76,13 @@ $ouiTitles: (
     'font-size': $ouiFontSizeXS,
     'line-height': lineHeightFromBaseline(3),
     'font-weight': $ouiFontWeightBold,
+    'letter-spacing': -.005em,
   ),
   'xxs': (
     'font-size': $ouiFontSizeS,
     'line-height': lineHeightFromBaseline(3),
     'font-weight': $ouiFontWeightBold,
+    'letter-spacing': -.005em,
   ),
   'xs': (
     'font-size': $ouiFontSize,

--- a/src/themes/oui-cascadia/global_styling/variables/_typography.scss
+++ b/src/themes/oui-cascadia/global_styling/variables/_typography.scss
@@ -37,8 +37,8 @@
 }
 
 // sass-lint:disable quotes
-$ouiFontFamily: #{"'Inter UI', -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'"} !default;
-$ouiCodeFontFamily: #{"'Roboto Mono', Consolas, Menlo, Courier, monospace"} !default;
+$ouiFontFamily: #{"'Source Sans 3', -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'"} !default;
+$ouiCodeFontFamily: #{"'Source Code Pro', Consolas, Menlo, Courier, monospace"} !default;
 // sass-lint:enable quotes
 
 // Careful using ligatures. Code editors like ACE will often error because of width calculations

--- a/src/themes/oui-cascadia/oui_cascadia_colors_dark.scss
+++ b/src/themes/oui-cascadia/oui_cascadia_colors_dark.scss
@@ -52,7 +52,7 @@ $ouiColorWarningText: makeHighContrastColor($ouiColorWarning);
 $ouiColorDangerText: makeHighContrastColor($ouiColorDanger);
 $ouiColorDisabledText: makeDisabledContrastColor($ouiColorDisabled);
 $ouiColorSuccessText: $ouiColorSecondaryText;
-$ouiLinkColor: #1BA9F5;
+$ouiLinkColor: $ouiColorPrimaryText;
 
 // Charts
 $ouiColorChartLines: $ouiColorLightShade;

--- a/src/themes/oui-cascadia/oui_cascadia_colors_dark.scss
+++ b/src/themes/oui-cascadia/oui_cascadia_colors_dark.scss
@@ -12,11 +12,11 @@
 @import 'global_styling/functions/index';
 
 // These colors stay the same no matter the theme
-$ouiColorGhost: #FFF;
-$ouiColorInk: #000;
+$ouiColorGhost: #FCFEFF;
+$ouiColorInk: #0A121A;
 
 // Core
-$ouiColorPrimary: #1BA9F5;
+$ouiColorPrimary: #159D8D;
 $ouiColorSecondary: #7DE2D1;
 $ouiColorAccent: #F990C0;
 
@@ -26,16 +26,16 @@ $ouiColorWarning: #FFCE7A;
 $ouiColorDanger: #F66;
 
 // Grays
-$ouiColorEmptyShade: #1D1E24;
-$ouiColorLightestShade: #25262E;
-$ouiColorLightShade: #343741;
-$ouiColorMediumShade: #535966;
-$ouiColorDarkShade: #98A2B3;
-$ouiColorDarkestShade: #D4DAE5;
-$ouiColorFullShade: #FFF;
+$ouiColorEmptyShade: #0A121A;
+$ouiColorLightestShade: #101B25;
+$ouiColorLightShade: #293847;
+$ouiColorMediumShade: #5B6875;
+$ouiColorDarkShade: #8D98A3;
+$ouiColorDarkestShade: #DFE3E8;
+$ouiColorFullShade: #FCFEFF;
 
 // Backgrounds
-$ouiPageBackgroundColor: shade($ouiColorLightestShade, 45%);
+$ouiPageBackgroundColor: #172430;
 $ouiColorHighlight: #2E2D25;
 
 // Variations from core
@@ -52,7 +52,7 @@ $ouiColorWarningText: makeHighContrastColor($ouiColorWarning);
 $ouiColorDangerText: makeHighContrastColor($ouiColorDanger);
 $ouiColorDisabledText: makeDisabledContrastColor($ouiColorDisabled);
 $ouiColorSuccessText: $ouiColorSecondaryText;
-$ouiLinkColor: $ouiColorPrimaryText;
+$ouiLinkColor: #1BA9F5;
 
 // Charts
 $ouiColorChartLines: $ouiColorLightShade;


### PR DESCRIPTION
### Description
Includes:
* Introduce the new color palette
* Revert `$ouiLinkColor` to match `$ouiColorPrimaryText`
* Update fonts to "Source Sans 3" and "Source Code Pro"
* Remove font override from `.ouiText blockquote`
* To maintain the previous look in the `default` theme, the rule was added as an override there
* Set ouiButton font weight to semi-bold
* Remove negative `letter-spacing` from default font
* To prevent changes in `OuiTitle` in the default theme, the variants that inherited their `letter-spacing` were modified to explicitly have the old value.
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [X] All tests pass
  - [x] `yarn lint`
  - [x] `yarn test-unit`
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/oui/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
