### PR TITLE
Remove all doc site usages of 'panelled' prop in OuiPageBody components

### DIFF
--- a/src-docs/src/views/app_view.js
+++ b/src-docs/src/views/app_view.js
@@ -97,7 +97,7 @@ export class AppView extends Component {
             />
           </OuiErrorBoundary>
 
-          <OuiPageBody panelled>
+          <OuiPageBody>
             <OuiContext i18n={i18n}>
               <ThemeContext.Consumer>
                 {(context) => {

--- a/src-docs/src/views/page/page_bottom_bar.js
+++ b/src-docs/src/views/page/page_bottom_bar.js
@@ -29,7 +29,7 @@ export default ({ button = <></>, content, sideNav, bottomBar }) => {
       </OuiPageSideBar>
 
       {/* Double OuiPageBody to accommodate for the bottom bar */}
-      <OuiPageBody panelled paddingSize="none">
+      <OuiPageBody paddingSize="none">
         <OuiPageBody paddingSize="l">
           <OuiPageHeader
             bottomBorder

--- a/src-docs/src/views/page/page_centered_content.js
+++ b/src-docs/src/views/page/page_centered_content.js
@@ -26,7 +26,7 @@ export default ({ button = <></>, content, sideNav }) => (
       {sideNav}
     </OuiPageSideBar>
 
-    <OuiPageBody panelled>
+    <OuiPageBody>
       <OuiPageHeader
         restrictWidth
         pageTitle="Page title"

--- a/src-docs/src/views/page/page_restricting_width.js
+++ b/src-docs/src/views/page/page_restricting_width.js
@@ -27,7 +27,7 @@ export default ({ button = <></>, content, sideNav }) => {
         {sideNav}
       </OuiPageSideBar>
 
-      <OuiPageBody panelled>
+      <OuiPageBody>
         <OuiPageHeader
           restrictWidth={'75%'}
           pageTitle="Page title"


### PR DESCRIPTION
### Description
<!-- Describe what this change achieves -->

`OuiPageBody` has a `panelled` prop, but most OpenSearch Dashboard layouts don't use it, so it makes sense for the OUI documentation website to match that general behavior.

Example of old layout (panelled):

<img width="1663" alt="Screen Shot 2023-06-22 at 11 09 41 AM" src="https://github.com/opensearch-project/oui/assets/1679762/3b924b38-28e4-4580-86d4-6009d2e5e63b">

Updated (not-panelled):

<img width="1671" alt="Screen Shot 2023-06-22 at 11 07 53 AM" src="https://github.com/opensearch-project/oui/assets/1679762/dec126ea-9f25-4e6b-a123-fd4569b6dbf7">


### Issues Resolved
<!-- List any issues this PR will resolve. -->
<!-- Example: Fixes #1234 -->
Fixes https://github.com/opensearch-project/oui/issues/840

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] All tests pass
  - [ ] `yarn lint`
  - [ ] `yarn test-unit`
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/oui/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
