### PR TITLE
Change deps to keep in preinstall script

### DIFF
--- a/scripts/preinstall.js
+++ b/scripts/preinstall.js
@@ -18,8 +18,10 @@ if (!INIT_CWD?.startsWith?.(PWD)) {
    * be empty.
    */
   const depsToKeep = [
+    '@opensearch',
     '@types',
     'csstype',
+    'detect-node',
     'is-buffer',
     'is-plain-obj',
     'mdast-util-definitions',
@@ -60,7 +62,6 @@ if (!INIT_CWD?.startsWith?.(PWD)) {
     'numeral',
     'prismjs',
     'prop-types',
-    'react',
     'react-beautiful-dnd',
     'react-dom',
     'react-input-autosize',


### PR DESCRIPTION
### Description
Adds deps to keep for deps that are needed in a local OUI Dashboards setup. Also removes `@types/react`, as it causes type errors in Dashboards with differently typed versions of React.

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] All tests pass
  - [ ] `yarn lint`
  - [ ] `yarn test-unit`
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/oui/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
