### PR TITLE
Fix `autofill` text color in dark themes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### 📈 Features/Enhancements
 - Rename the aliased theme files ([#863](https://github.com/opensearch-project/oui/pull/863))
+- Fix `autofill` text color in dark themes ([#871](https://github.com/opensearch-project/oui/pull/871))
 
 
 ### 🐛 Bug Fixes

--- a/src/global_styling/mixins/_form.scss
+++ b/src/global_styling/mixins/_form.scss
@@ -262,16 +262,21 @@
 
     // Needs to be set for autofill
     // sass-lint:disable-block no-vendor-prefixes
-    &:-webkit-autofill {
-      -webkit-text-fill-color: lightOrDarkTheme($ouiColorDarkestShade, $ouiColorLightShade);
+    &:-webkit-autofill,
+    &:autofill {
+      /* Many browsers use `!important` in their built-in `:-webkit-autofill` style declarations,
+       * making their colors non-overridable. `-webkit-text-fill-color` is able to overwrite the
+       * appearance of texts and is used here as a workaround.
+       */
+      -webkit-text-fill-color: $ouiColorDarkestShade;
 
       ~ .ouiFormControlLayoutIcons {
-        color: lightOrDarkTheme($ouiColorDarkestShade, $ouiColorLightShade);
+        color: $ouiColorDarkestShade;
       }
 
       /* OUI -> EUI Aliases */
       ~ .euiFormControlLayoutIcons {
-        color: lightOrDarkTheme($ouiColorDarkestShade, $ouiColorLightShade);
+        color: $ouiColorDarkestShade;
       }
       /* End of Aliases */
     }

--- a/src/themes/oui-next/global_styling/mixins/_form.scss
+++ b/src/themes/oui-next/global_styling/mixins/_form.scss
@@ -20,7 +20,6 @@
   $iconSize: $ouiSize;
   $iconPadding: $ouiFormControlPadding;
   $marginBetweenIcons: $ouiFormControlPadding / 2;
-
   @if ($compressed) {
     $iconPadding: $ouiFormControlCompressedPadding;
   }
@@ -268,15 +267,15 @@
        * making their colors non-overridable. `-webkit-text-fill-color` is able to overwrite the
        * appearance of texts and is used here as a workaround.
        */
-      -webkit-text-fill-color: $ouiColorDarkestShade;
+      -webkit-text-fill-color: $ouiTextColor;
 
       ~ .ouiFormControlLayoutIcons {
-        color: $ouiColorDarkestShade;
+        color: $ouiTextColor;
       }
 
       /* OUI -> EUI Aliases */
       ~ .euiFormControlLayoutIcons {
-        color: $ouiColorDarkestShade;
+        color: $ouiTextColor;
       }
       /* End of Aliases */
     }

--- a/src/themes/oui-next/global_styling/mixins/_form.scss
+++ b/src/themes/oui-next/global_styling/mixins/_form.scss
@@ -262,16 +262,21 @@
 
     // Needs to be set for autofill
     // sass-lint:disable-block no-vendor-prefixes
-    &:-webkit-autofill {
-      -webkit-text-fill-color: lightOrDarkTheme($ouiColorDarkestShade, $ouiColorLightShade);
+    &:-webkit-autofill,
+    &:autofill {
+      /* Many browsers use `!important` in their built-in `:-webkit-autofill` style declarations,
+       * making their colors non-overridable. `-webkit-text-fill-color` is able to overwrite the
+       * appearance of texts and is used here as a workaround.
+       */
+      -webkit-text-fill-color: $ouiColorDarkestShade;
 
       ~ .ouiFormControlLayoutIcons {
-        color: lightOrDarkTheme($ouiColorDarkestShade, $ouiColorLightShade);
+        color: $ouiColorDarkestShade;
       }
 
       /* OUI -> EUI Aliases */
       ~ .euiFormControlLayoutIcons {
-        color: lightOrDarkTheme($ouiColorDarkestShade, $ouiColorLightShade);
+        color: $ouiColorDarkestShade;
       }
       /* End of Aliases */
     }


### PR DESCRIPTION
### Description

Input fields that are auto-populated by the browser, like a saved usernames, are too dark to see in the dark mode for both default and Next themes. That is because the "shades" are reversed in dark mode where `$ouiColorLightestShade` is in fact nearly black and `$ouiColorDarkestShade` is nearly while. This change makes use of `$ouiColorDarkestShade` in both light and dark themes.

Before change:

<img height="156" src="https://github.com/opensearch-project/oui/assets/3527403/f09b7089-7e7d-48d6-b935-806c71e407ea">

After change:

<img height="156" src="https://github.com/opensearch-project/oui/assets/3527403/a44920b0-100d-40b5-bd33-aca8789ed9a0">



### Issues Resolved

Fixes #870

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [X] All tests pass
  - [ ] `yarn lint`
  - [ ] `yarn test-unit`
- [X] Update [CHANGELOG.md](./../CHANGELOG.md)
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/oui/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
