### PR TITLE
Add autocut label to changelog verifier skip

### DIFF
--- a/.github/workflows/changelog_verifier.yml
+++ b/.github/workflows/changelog_verifier.yml
@@ -15,4 +15,4 @@ jobs:
 
       - uses: dangoslen/changelog-enforcer@v3
         with:
-          skipLabels: "skip-changelog"
+          skipLabels: "autocut, skip-changelog"


### PR DESCRIPTION
### Description
Add `autocut` label to changelog verifier skip label set. We know whether or not a PR should have a changlog when it's created, but don't want to need to add the `skip-changelog` label to backports if their original PR had it. This just ignores all backport PRs because they should theoretically have already had the check pass.

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [x] All tests pass
  - [x] `yarn lint`
  - [x] `yarn test-unit`
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/oui/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
