### PR TITLE
Doc Site - Add dark prop toggles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@
 
 ### 📝 Documentation
 
+- Add dark prop toggles ([#910](https://github.com/opensearch-project/oui/pull/910))
+
 ### 🛠 Maintenance
 
 - [CVE-2023-26136] Add resolution for tough-cookie to ^4.1.3 ([#889](https://github.com/opensearch-project/oui/pull/889))

--- a/src-docs/src/views/collapsible_nav/collapsible_nav_list.tsx
+++ b/src-docs/src/views/collapsible_nav/collapsible_nav_list.tsx
@@ -9,13 +9,15 @@
  * GitHub history for details.
  */
 
-import React from 'react';
+import React, { useState } from 'react';
 
 import { OuiCollapsibleNavGroup } from '../../../../src/components/collapsible_nav';
 import {
   OuiListGroup,
   OuiListGroupItemProps,
 } from '../../../../src/components/list_group';
+import { OuiSelect } from '../../../../src/components/form';
+import { OuiSpacer } from '../../../../src/components/spacer';
 
 export const OpenSearchDashboardsLinks: OuiListGroupItemProps[] = [
   { label: 'Overview' },
@@ -56,45 +58,75 @@ export const ManagementLinks: OuiListGroupItemProps[] = [
   };
 });
 
-export default () => (
-  <>
-    <OuiCollapsibleNavGroup
-      title="OpenSearch Dashboards"
-      iconType="logoOpenSearch"
-      isCollapsible={true}
-      initialIsOpen={true}>
-      <OuiListGroup
-        listItems={OpenSearchDashboardsLinks}
-        maxWidth="none"
-        color="subdued"
-        gutterSize="none"
-        size="s"
+export default () => {
+  const [background, setBackground] = useState<'dark' | 'light' | 'none'>(
+    'none'
+  );
+  return (
+    <>
+      <OuiSelect
+        prepend="Set background"
+        options={[
+          {
+            value: 'none',
+            text: 'none (default)',
+          },
+          {
+            value: 'dark',
+            text: 'dark',
+          },
+          {
+            value: 'light',
+            text: 'light',
+          },
+        ]}
+        value={background}
+        onChange={(e: { target: { value: any } }) =>
+          setBackground(e.target.value)
+        }
       />
-    </OuiCollapsibleNavGroup>
-    <OuiCollapsibleNavGroup
-      title="OpenSearch Plugins"
-      isCollapsible={true}
-      initialIsOpen={true}>
-      <OuiListGroup
-        listItems={OpenSearchPluginLinks}
-        maxWidth="none"
-        color="subdued"
-        gutterSize="none"
-        size="s"
-      />
-    </OuiCollapsibleNavGroup>
-    <OuiCollapsibleNavGroup
-      title="Management"
-      iconType="gear"
-      isCollapsible={true}
-      initialIsOpen={true}>
-      <OuiListGroup
-        listItems={ManagementLinks}
-        maxWidth="none"
-        color="subdued"
-        gutterSize="none"
-        size="s"
-      />
-    </OuiCollapsibleNavGroup>
-  </>
-);
+      <OuiSpacer />
+      <OuiCollapsibleNavGroup
+        background={background}
+        title="OpenSearch Dashboards"
+        iconType="logoOpenSearch"
+        isCollapsible={true}
+        initialIsOpen={true}>
+        <OuiListGroup
+          listItems={OpenSearchDashboardsLinks}
+          maxWidth="none"
+          color="subdued"
+          gutterSize="none"
+          size="s"
+        />
+      </OuiCollapsibleNavGroup>
+      <OuiCollapsibleNavGroup
+        background={background}
+        title="OpenSearch Plugins"
+        isCollapsible={true}
+        initialIsOpen={true}>
+        <OuiListGroup
+          listItems={OpenSearchPluginLinks}
+          maxWidth="none"
+          color="subdued"
+          gutterSize="none"
+          size="s"
+        />
+      </OuiCollapsibleNavGroup>
+      <OuiCollapsibleNavGroup
+        background={background}
+        title="Management"
+        iconType="gear"
+        isCollapsible={true}
+        initialIsOpen={true}>
+        <OuiListGroup
+          listItems={ManagementLinks}
+          maxWidth="none"
+          color="subdued"
+          gutterSize="none"
+          size="s"
+        />
+      </OuiCollapsibleNavGroup>
+    </>
+  );
+};

--- a/src-docs/src/views/header/header_dark.tsx
+++ b/src-docs/src/views/header/header_dark.tsx
@@ -9,7 +9,7 @@
  * GitHub history for details.
  */
 
-import React from 'react';
+import React, { useState } from 'react';
 
 /**
  * Docs note: Consuming apps should import the theme via the export json file
@@ -26,41 +26,54 @@ import {
 import { OuiBadge } from '../../../../src/components/badge';
 import { OuiIcon } from '../../../../src/components/icon';
 import { OuiAvatar } from '../../../../src/components/avatar';
+import { OuiSwitch } from '../../../../src/components/form';
+import { OuiSpacer } from '../../../../src/components/spacer';
 
-export default ({ theme }: { theme: any }) => (
-  <OuiHeader
-    theme="dark"
-    sections={[
-      {
-        items: [
-          <OuiHeaderLogo>OpenSearch</OuiHeaderLogo>,
-          <OuiHeaderLinks aria-label="App navigation dark theme example">
-            <OuiHeaderLink isActive>Docs</OuiHeaderLink>
-            <OuiHeaderLink>Code</OuiHeaderLink>
-            <OuiHeaderLink iconType="help"> Help</OuiHeaderLink>
-          </OuiHeaderLinks>,
-        ],
-        borders: 'right',
-      },
-      {
-        items: [
-          <OuiBadge
-            color={theme.ouiColorDarkestShade.rgba}
-            iconType="arrowDown"
-            iconSide="right">
-            Production logs
-          </OuiBadge>,
-          <OuiHeaderSectionItemButton
-            aria-label="2 Notifications"
-            notification={'2'}>
-            <OuiIcon type="cheer" size="m" />
-          </OuiHeaderSectionItemButton>,
-          <OuiHeaderSectionItemButton aria-label="Account menu">
-            <OuiAvatar name="John Username" size="s" />
-          </OuiHeaderSectionItemButton>,
-        ],
-        borders: 'none',
-      },
-    ]}
-  />
-);
+export default ({ theme }: { theme: any }) => {
+  const [headerTheme, setHeaderTheme] = useState<'dark' | 'default'>('dark');
+  return (
+    <>
+      <OuiSwitch
+        label={'Change theme to dark'}
+        checked={headerTheme === 'dark'}
+        onChange={(e) => setHeaderTheme(e.target.checked ? 'dark' : 'default')}
+      />
+      <OuiSpacer />
+      <OuiHeader
+        theme={headerTheme}
+        sections={[
+          {
+            items: [
+              <OuiHeaderLogo>OpenSearch</OuiHeaderLogo>,
+              <OuiHeaderLinks aria-label="App navigation dark theme example">
+                <OuiHeaderLink isActive>Docs</OuiHeaderLink>
+                <OuiHeaderLink>Code</OuiHeaderLink>
+                <OuiHeaderLink iconType="help"> Help</OuiHeaderLink>
+              </OuiHeaderLinks>,
+            ],
+            borders: 'right',
+          },
+          {
+            items: [
+              <OuiBadge
+                color={theme.ouiColorDarkestShade.rgba}
+                iconType="arrowDown"
+                iconSide="right">
+                Production logs
+              </OuiBadge>,
+              <OuiHeaderSectionItemButton
+                aria-label="2 Notifications"
+                notification={'2'}>
+                <OuiIcon type="cheer" size="m" />
+              </OuiHeaderSectionItemButton>,
+              <OuiHeaderSectionItemButton aria-label="Account menu">
+                <OuiAvatar name="John Username" size="s" />
+              </OuiHeaderSectionItemButton>,
+            ],
+            borders: 'none',
+          },
+        ]}
+      />
+    </>
+  );
+};


### PR DESCRIPTION
### Description
<!-- Describe what this change achieves -->
For validating new theme colors, it's helpful to be able to quickly test out component props that affect color selection (on top of the application theme).

1. Add `theme` prop toggle to Header
2. Add `background` prop selector to Collapsible Nav


https://github.com/opensearch-project/oui/assets/1679762/5cb32852-165c-40f7-8395-e7c4723b8ec8




### Issues Resolved
<!-- List any issues this PR will resolve. -->
<!-- Example: Fixes #1234 -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] All tests pass
  - [ ] `yarn lint`
  - [ ] `yarn test-unit`
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/oui/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
