### PR TITLE
Fix blurry breadcrumb text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@
 
 ### 🐛 Bug Fixes
 
+- Fix blurry text in breadcrumbs ([#959](https://github.com/opensearch-project/oui/pull/959))
+
 ### 🚞 Infrastructure
 
 - Add release workflows ([#134](https://github.com/opensearch-project/oui/pull/133))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@
 
 ### 🐛 Bug Fixes
 
-- Fix blurry text in breadcrumbs ([#959](https://github.com/opensearch-project/oui/pull/959))
+- Fix blurry text in breadcrumbs by avoiding skewing text ([#959](https://github.com/opensearch-project/oui/pull/959))
 
 ### 🚞 Infrastructure
 

--- a/src/components/breadcrumbs/_breadcrumbs.scss
+++ b/src/components/breadcrumbs/_breadcrumbs.scss
@@ -27,7 +27,8 @@
   display: inline-block;
 
   &:not(.ouiBreadcrumb--last) {
-    color: $ouiBreadcrumbTextColor !important; // sass-lint:disable-line no-important
+    // TODO: remove important: https://github.com/opensearch-project/oui/issues/376
+    color: $ouiBreadcrumbInactiveTextColor !important; // sass-lint:disable-line no-important
 
     &:hover {
       color: $ouiBreadCrumbHoverColor !important; // sass-lint:disable-line no-important
@@ -102,11 +103,11 @@
   }
 
   &:not(.ouiBreadcrumbWrapper--last)::before {
-    background-color: $ouiBreadcrumbGrayBackground;
+    background-color: $ouiBreadcrumbInactiveBackground;
   }
 
   &.ouiBreadcrumbWrapper--last::before {
-    background-color: $ouiBreadcrumbBlueBackground;
+    background-color: $ouiBreadcrumbActiveBackground;
   }
 
   &:not(.ouiBreadcrumbWrapper--first) {
@@ -116,12 +117,12 @@
 }
 
 .ouiBreadcrumbWall {
-  background-image: linear-gradient(to right, $ouiBreadcrumbGrayBackground 0 $ouiSizeM, transparent $ouiSizeM);
+  background-image: linear-gradient(to right, $ouiBreadcrumbInactiveBackground 0 $ouiSizeM, transparent $ouiSizeM);
   border-radius: $ouiSizeXS;
   overflow: hidden;
   margin-bottom: $ouiSizeXS; /* 1 */
 }
 
 .ouiBreadcrumbWall--single {
-  background-image: linear-gradient(to right, $ouiBreadcrumbBlueBackground 0 $ouiSizeM, transparent $ouiSizeM);
+  background-image: linear-gradient(to right, $ouiBreadcrumbActiveBackground 0 $ouiSizeM, transparent $ouiSizeM);
 }

--- a/src/components/breadcrumbs/_breadcrumbs.scss
+++ b/src/components/breadcrumbs/_breadcrumbs.scss
@@ -25,10 +25,9 @@
 
 .ouiBreadcrumb {
   display: inline-block;
-  transform: skewX(20deg);
 
   &:not(.ouiBreadcrumb--last) {
-    color: $ouiTextSubduedColor;
+    color: $ouiBreadcrumbTextColor !important; // sass-lint:disable-line no-important
 
     &:hover {
       color: $ouiBreadCrumbHoverColor !important; // sass-lint:disable-line no-important
@@ -36,23 +35,18 @@
   }
 }
 
-.ouiBreadcrumb--last {
+.ouiBreadcrumbs:not(.ouiBreadcrumbs__inPopover) .ouiBreadcrumb--last {
   font-weight: $ouiFontWeightMedium;
 }
 
 .ouiBreadcrumb--collapsed {
   flex-shrink: 0;
-  color: $ouiBreadcrumbCollapsedLink;
+  color: $ouiBreadcrumbCollapsedLink !important; // sass-lint:disable-line no-important
   vertical-align: top !important; // sass-lint:disable-line no-important
 }
 
 .ouiBreadcrumb__collapsedLink:hover {
   color: $ouiBreadCrumbHoverColor !important; // sass-lint:disable-line no-important
-}
-
-.ouiBreadcrumbs__inPopover .ouiBreadcrumb--last {
-  font-weight: $ouiFontWeightRegular;
-  color: $ouiColorDarkShade !important; // sass-lint:disable-line no-important
 }
 
 .ouiBreadcrumbs--truncate {
@@ -89,18 +83,35 @@
 }
 
 .ouiBreadcrumbWrapper {
-  background-color: $ouiBreadcrumbGrayBackground;
-  transform: skewX(-20deg);
-  border-radius: $ouiSizeXS;
+  position: relative;
+  z-index: 0;
   padding: $ouiSizeXS - 2.5 $ouiSizeL - $ouiSizeXS;
+  padding-right: $ouiSizeL - $ouiSizeXS + $ouiBreadcrumbSpacing / 2;
+
+  &::before {
+    content: '';
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    left: $ouiBreadcrumbSpacing / 2;
+    right: $ouiBreadcrumbSpacing / 2;
+    z-index: -1;
+
+    transform: skewX(-20deg);
+    border-radius: $ouiSizeXS;
+  }
+
+  &:not(.ouiBreadcrumbWrapper--last)::before {
+    background-color: $ouiBreadcrumbGrayBackground;
+  }
+
+  &.ouiBreadcrumbWrapper--last::before {
+    background-color: $ouiBreadcrumbBlueBackground;
+  }
 
   &:not(.ouiBreadcrumbWrapper--first) {
     margin-bottom: $ouiSizeXS; /* 1 */
-  }
-
-  &:not(.ouiBreadcrumbWrapper--last),
-  &.ouiBreadcrumbWrapper--first.ouiBreadcrumbWrapper--last {
-    margin-right: $ouiBreadcrumbSpacing;
+    padding-left: $ouiSizeL - $ouiSizeXS + $ouiBreadcrumbSpacing / 2;
   }
 }
 
@@ -113,8 +124,4 @@
 
 .ouiBreadcrumbWall--single {
   background-image: linear-gradient(to right, $ouiBreadcrumbBlueBackground 0 $ouiSizeM, transparent $ouiSizeM);
-}
-
-.ouiBreadcrumbWrapper--last {
-  background-color: $ouiBreadcrumbBlueBackground;
 }

--- a/src/components/breadcrumbs/_variables.scss
+++ b/src/components/breadcrumbs/_variables.scss
@@ -12,10 +12,11 @@
 $ouiBreadcrumbSpacing: $ouiSizeS !default;
 $ouiBreadcrumbTruncateWidth: $ouiSize * 10 !default;
 
-$ouiBreadcrumbBlueBackground: #B9D9EB !default;
-$ouiBreadcrumbGrayBackground: #D9E1E2 !default;
-$ouiBreadcrumbCollapsedLink: #002A3A !default;
-$ouiBreadCrumbHoverColor: #535861 !default;
+$ouiBreadcrumbBlueBackground: tintOrShade($ouiColorPrimary, 72%, 41%) !default;
+$ouiBreadcrumbGrayBackground: tint($ouiColorLightShade, 14%) !default;
+$ouiBreadcrumbCollapsedLink: shadeOrTint($ouiColorPrimaryText, 61%, 20%) !default;
+$ouiBreadcrumbTextColor: makeHighContrastColor($ouiTextSubduedColor, $ouiBreadcrumbGrayBackground) !default;
+$ouiBreadCrumbHoverColor: shadeOrTint($ouiBreadcrumbTextColor, 16%, 6%) !default;
 
 /* OUI -> EUI Aliases */
 $euiBreadcrumbSpacing: $ouiBreadcrumbSpacing;

--- a/src/components/breadcrumbs/_variables.scss
+++ b/src/components/breadcrumbs/_variables.scss
@@ -12,18 +12,19 @@
 $ouiBreadcrumbSpacing: $ouiSizeS !default;
 $ouiBreadcrumbTruncateWidth: $ouiSize * 10 !default;
 
-$ouiBreadcrumbBlueBackground: tintOrShade($ouiColorPrimary, 72%, 41%) !default;
-$ouiBreadcrumbGrayBackground: tint($ouiColorLightShade, 14%) !default;
+$ouiBreadcrumbActiveBackground: tintOrShade($ouiColorPrimary, 72%, 41%) !default;
+$ouiBreadcrumbInactiveBackground: tint($ouiColorLightShade, 14%) !default;
 $ouiBreadcrumbCollapsedLink: shadeOrTint($ouiColorPrimaryText, 61%, 20%) !default;
-$ouiBreadcrumbTextColor: makeHighContrastColor($ouiTextSubduedColor, $ouiBreadcrumbGrayBackground) !default;
-$ouiBreadCrumbHoverColor: shadeOrTint($ouiBreadcrumbTextColor, 16%, 6%) !default;
+$ouiBreadcrumbInactiveTextColor: makeHighContrastColor($ouiTextSubduedColor, $ouiBreadcrumbInactiveBackground) !default;
+$ouiBreadCrumbHoverColor: shadeOrTint($ouiBreadcrumbInactiveTextColor, 16%, 6%) !default;
 
 /* OUI -> EUI Aliases */
 $euiBreadcrumbSpacing: $ouiBreadcrumbSpacing;
 $euiBreadcrumbTruncateWidth: $ouiBreadcrumbTruncateWidth;
 
-$euiBreadcrumbBlueBackground: $ouiBreadcrumbBlueBackground;
-$euiBreadcrumbGrayBackground: $ouiBreadcrumbGrayBackground;
+$euiBreadcrumbActiveBackground: $ouiBreadcrumbActiveBackground;
+$euiBreadcrumbInactiveBackground: $ouiBreadcrumbInactiveBackground;
 $euiBreadcrumbCollapsedLink: $ouiBreadcrumbCollapsedLink;
+$euiBreadcrumbInactiveTextColor: $ouiBreadcrumbInactiveTextColor;
 $euiBreadCrumbHoverColor: $ouiBreadCrumbHoverColor;
 /* End of Aliases */

--- a/src/themes/oui-next/oui_next_colors_dark.scss
+++ b/src/themes/oui-next/oui_next_colors_dark.scss
@@ -62,12 +62,6 @@ $ouiColorChartBand: tint($ouiColorLightestShade, 2.5%);
 $ouiShadowColor: #000;
 $ouiShadowColorLarge: #000;
 
-// Breadcrumbs
-$ouiBreadcrumbBlueBackground: #163F66;
-$ouiBreadcrumbGrayBackground: #4C636F;
-$ouiBreadcrumbCollapsedLink: #FFF;
-$ouiBreadCrumbHoverColor: #B0B8BB;
-
 
 /* OUI -> EUI Aliases */
 $euiColorGhost: $ouiColorGhost;
@@ -103,8 +97,4 @@ $euiColorChartLines: $ouiColorChartLines;
 $euiColorChartBand: $ouiColorChartBand;
 $euiShadowColor: $ouiShadowColor;
 $euiShadowColorLarge: $ouiShadowColorLarge;
-$euiBreadcrumbBlueBackground: $ouiBreadcrumbBlueBackground;
-$euiBreadcrumbGrayBackground: $ouiBreadcrumbGrayBackground;
-$euiBreadcrumbCollapsedLink: $ouiBreadcrumbCollapsedLink;
-$euiBreadCrumbHoverColor: $ouiBreadCrumbHoverColor;
 /* End of Aliases */

--- a/src/themes/oui/oui_colors_dark.scss
+++ b/src/themes/oui/oui_colors_dark.scss
@@ -62,12 +62,6 @@ $ouiColorChartBand: tint($ouiColorLightestShade, 2.5%);
 $ouiShadowColor: #000;
 $ouiShadowColorLarge: #000;
 
-// Breadcrumbs
-$ouiBreadcrumbBlueBackground: #163F66;
-$ouiBreadcrumbGrayBackground: #4C636F;
-$ouiBreadcrumbCollapsedLink: #FFF;
-$ouiBreadCrumbHoverColor: #B0B8BB;
-
 
 /* OUI -> EUI Aliases */
 $euiColorGhost: $ouiColorGhost;
@@ -103,8 +97,4 @@ $euiColorChartLines: $ouiColorChartLines;
 $euiColorChartBand: $ouiColorChartBand;
 $euiShadowColor: $ouiShadowColor;
 $euiShadowColorLarge: $ouiShadowColorLarge;
-$euiBreadcrumbBlueBackground: $ouiBreadcrumbBlueBackground;
-$euiBreadcrumbGrayBackground: $ouiBreadcrumbGrayBackground;
-$euiBreadcrumbCollapsedLink: $ouiBreadcrumbCollapsedLink;
-$euiBreadCrumbHoverColor: $ouiBreadCrumbHoverColor;
 /* End of Aliases */


### PR DESCRIPTION
### Description
Fix blurry text in breadcrumbs by using `:before` pseudoelement. Also took this opportunity to make breadcrumb colors come from theme. All accessibility checks pass.

**Current light**
![Screenshot (115)](https://github.com/opensearch-project/oui/assets/6763209/a89d1db1-a7d5-4fb8-a161-8fd9705ff4ba)

**Current dark**
![Screenshot (116)](https://github.com/opensearch-project/oui/assets/6763209/1ed03503-5921-4a12-8c0e-088d068cf7f0)

**Next light**
![Screenshot (117)](https://github.com/opensearch-project/oui/assets/6763209/e5406c13-ab7a-4398-8c00-473fc2c9fca7)

**Next dark**
![Screenshot (118)](https://github.com/opensearch-project/oui/assets/6763209/26831245-ce71-4dde-831d-e8d229997ecc)

### Issues Resolved
Mostly/completely fixes #902

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [x] All tests pass
  - [x] `yarn lint`
  - [x] `yarn test-unit`
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/oui/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
