### PR TITLE
Set link to use semi bold font weight

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### 📈 Features/Enhancements
 - Rename the aliased theme files ([#863](https://github.com/opensearch-project/oui/pull/863))
 - Fix `autofill` text color in dark themes ([#871](https://github.com/opensearch-project/oui/pull/871))
+- Set link to use semi bold font weight ([#961](https://github.com/opensearch-project/oui/pull/961))
 
 
 ### 🐛 Bug Fixes

--- a/src/components/link/_mixins.scss
+++ b/src/components/link/_mixins.scss
@@ -11,6 +11,7 @@
 
 @mixin ouiLink {
   text-align: left;
+  font-weight: 600;
 
   &:hover {
     text-decoration: underline;


### PR DESCRIPTION
### Description

Set link to use semi bold font weight to add more visual distinction from the text around it

**Before**
![Screenshot (125)](https://github.com/opensearch-project/oui/assets/6763209/c927bad8-24b6-4ecc-9cc3-909c3ba05327)

**After**
![Screenshot (124)](https://github.com/opensearch-project/oui/assets/6763209/881c0c64-35e5-4473-b142-da0397521b21)

### Issues Resolved

Fixes #933

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [x] All tests pass
  - [x] `yarn lint`
  - [x] `yarn test-unit`
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/oui/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
