### PR TITLE
Fix (Next Theme): Prefer light text on filled primary buttons

### DIFF
--- a/src-docs/src/views/button/button.js
+++ b/src-docs/src/views/button/button.js
@@ -42,7 +42,56 @@ export default () => (
         </OuiButton>
       </OuiFlexItem>
     </OuiFlexGroup>
+    <OuiFlexGroup gutterSize="s" alignItems="center" responsive={false} wrap>
+      <OuiFlexItem grow={false}>
+        <OuiButton color="secondary" onClick={() => {}}>
+          Secondary
+        </OuiButton>
+      </OuiFlexItem>
 
+      <OuiFlexItem grow={false}>
+        <OuiButton color="secondary" fill onClick={() => {}}>
+          Filled
+        </OuiButton>
+      </OuiFlexItem>
+
+      <OuiFlexItem grow={false}>
+        <OuiButton color="secondary" size="s" onClick={() => {}}>
+          Small
+        </OuiButton>
+      </OuiFlexItem>
+
+      <OuiFlexItem grow={false}>
+        <OuiButton color="secondary" size="s" fill onClick={() => {}}>
+          Small and filled
+        </OuiButton>
+      </OuiFlexItem>
+    </OuiFlexGroup>
+    <OuiFlexGroup gutterSize="s" alignItems="center" responsive={false} wrap>
+      <OuiFlexItem grow={false}>
+        <OuiButton color="accent" onClick={() => {}}>
+          Accent
+        </OuiButton>
+      </OuiFlexItem>
+
+      <OuiFlexItem grow={false}>
+        <OuiButton color="accent" fill onClick={() => {}}>
+          Filled
+        </OuiButton>
+      </OuiFlexItem>
+
+      <OuiFlexItem grow={false}>
+        <OuiButton color="accent" size="s" onClick={() => {}}>
+          Small
+        </OuiButton>
+      </OuiFlexItem>
+
+      <OuiFlexItem grow={false}>
+        <OuiButton color="accent" size="s" fill onClick={() => {}}>
+          Small and filled
+        </OuiButton>
+      </OuiFlexItem>
+    </OuiFlexGroup>
     <OuiFlexGroup gutterSize="s" alignItems="center" responsive={false} wrap>
       <OuiFlexItem grow={false}>
         <OuiButton color="success" onClick={() => {}}>
@@ -68,7 +117,6 @@ export default () => (
         </OuiButton>
       </OuiFlexItem>
     </OuiFlexGroup>
-
     <OuiFlexGroup gutterSize="s" alignItems="center" responsive={false} wrap>
       <OuiFlexItem grow={false}>
         <OuiButton color="warning" onClick={() => {}}>
@@ -94,7 +142,6 @@ export default () => (
         </OuiButton>
       </OuiFlexItem>
     </OuiFlexGroup>
-
     <OuiFlexGroup gutterSize="s" alignItems="center" responsive={false} wrap>
       <OuiFlexItem grow={false}>
         <OuiButton color="danger" onClick={() => {}}>
@@ -120,7 +167,6 @@ export default () => (
         </OuiButton>
       </OuiFlexItem>
     </OuiFlexGroup>
-
     <OuiFlexGroup gutterSize="s" alignItems="center" responsive={false} wrap>
       <OuiFlexItem grow={false}>
         <OuiButton color="text" onClick={() => {}}>

--- a/src/themes/oui-next/global_styling/functions/_colors.scss
+++ b/src/themes/oui-next/global_styling/functions/_colors.scss
@@ -87,7 +87,8 @@
   $lightContrast: contrastRatio($background, $lightText);
   $darkContrast: contrastRatio($background, $darkText);
 
-  @if ($lightContrast > $darkContrast) {
+  // in this theme prefer light text as long as it has sufficient contrast
+  @if ($lightContrast > $ouiContrastRatioGraphic) {
     @return $lightText;
   } @else {
     @return $darkText;


### PR DESCRIPTION
### Description
<!-- Describe what this change achieves -->

- Update the `chooseLightOrDarkText()` fn (only in `next` theme) to prefer light text as long as the contrast ratio is >3.5
- Update the `Button` OUI docs page to provide all the color variants (except ghost) in the initial example

Note that, because primary is the same color for `next` dark and light, it now always has the light text.
The current contrast ratio between primary and ghost in the `next` theme is `3.33`.

![Screenshot 2023-08-16 at 15-15-27 OpenSearch UI](https://github.com/opensearch-project/oui/assets/1679762/40375ff4-38e5-4f3e-89ae-33abfe1d6b32)
![Screenshot 2023-08-16 at 15-15-19 OpenSearch UI](https://github.com/opensearch-project/oui/assets/1679762/990b175e-9dc8-40ed-9ac8-3108a44fa89f)
![Screenshot 2023-08-16 at 15-15-08 OpenSearch UI](https://github.com/opensearch-project/oui/assets/1679762/c01a166f-f4ff-4c37-ba8d-9abb5916ba3f)
![Screenshot 2023-08-16 at 15-14-59 OpenSearch UI](https://github.com/opensearch-project/oui/assets/1679762/19cc5a97-6196-49d3-9d97-036c09b7239f)

### Issues Resolved
<!-- List any issues this PR will resolve. -->
<!-- Example: Fixes #1234 -->

Fixes https://github.com/opensearch-project/oui/issues/935

### Check List


- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] All tests pass
  - [ ] `yarn lint`
  - [ ] `yarn test-unit`
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/oui/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
