### PR TITLE
Update next light theme primary color to #07827E

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Set link to use semi bold font weight ([#961](https://github.com/opensearch-project/oui/pull/961))
 - Adds `SchemaItem` as an experimental component ([#974](https://github.com/opensearch-project/oui/pull/974))
 - Make `CollapsibleNavGroup` background colors theme-able ([#968](https://github.com/opensearch-project/oui/pull/968))
+- Update next light theme primary color to #07827E ([#981](https://github.com/opensearch-project/oui/pull/981))
 
 ### 🐛 Bug Fixes
 

--- a/src/themes/oui-next/global_styling/variables/_colors.scss
+++ b/src/themes/oui-next/global_styling/variables/_colors.scss
@@ -17,7 +17,7 @@ $ouiColorGhost: #FCFEFF !default;
 $ouiColorInk: #0A121A !default;
 
 // Core
-$ouiColorPrimary: #159D8D !default;
+$ouiColorPrimary: #07827E !default;
 $ouiColorSecondary: #017D73 !default;
 $ouiColorAccent: #DD0A73 !default;
 


### PR DESCRIPTION
### Description
Update next light theme primary color to #07827E to work better with the color system

![Screenshot (144)](https://github.com/opensearch-project/oui/assets/6763209/de4072e2-66a2-4a49-9474-42139d4b5e2d)

### Issues Resolved

Fixes #979

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [x] All tests pass
  - [x] `yarn lint`
  - [x] `yarn test-unit`
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/oui/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
