### PR TITLE
(OUI Docs) Update Form validation page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@
 ### 📝 Documentation
 
 - Add dark prop toggles ([#910](https://github.com/opensearch-project/oui/pull/910))
+- Form validation page updated ([#986](https://github.com/opensearch-project/oui/pull/986))
 
 ### 🛠 Maintenance
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,7 @@
 ### 📝 Documentation
 
 - Add dark prop toggles ([#910](https://github.com/opensearch-project/oui/pull/910))
-- Form validation page updated ([#986](https://github.com/opensearch-project/oui/pull/986))
+- Remove language from the form validation documentation that doesn't align with the updated guidelines ([#986](https://github.com/opensearch-project/oui/pull/986))
 
 ### 🛠 Maintenance
 

--- a/src-docs/src/views/form_validation/form_validation_example.js
+++ b/src-docs/src/views/form_validation/form_validation_example.js
@@ -37,9 +37,7 @@ export const FormValidationExample = {
           Validation is achieved by applying <OuiCode>isInvalid</OuiCode> and
           optionally error props onto the <strong>OuiForm</strong> or{' '}
           <strong>OuiFormRow</strong> components. Errors are optional and are
-          passed as an array in case you need to list more than one. You can
-          also hide the callout by passing
-          <OuiCode>invalidCallout=&ldquo;none&ldquo;</OuiCode>.
+          passed as an array in case you need to list more than one.
         </p>
       ),
       source: [


### PR DESCRIPTION
### Description
<!-- Describe what this change achieves -->
Removed the line `You can also hide the callout by passinginvalidCallout=“none“` as described in issue #885

<img width="1041" alt="Screenshot 2023-08-24 at 17 15 17" src="https://github.com/opensearch-project/oui/assets/98167/ce76eeb7-e9b4-4b9c-bc0a-e7c66448267f">



### Issues Resolved
<!-- List any issues this PR will resolve. -->
<!-- Example: Fixes #1234 -->
Closes #885 

### Check List
- [x] All tests pass
  - [x] `yarn lint`
  - [x] `yarn test-unit`
- [x] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/oui/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
