### PR TITLE
Remove `calc` usage from SchemaItem styles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 ### 🐛 Bug Fixes
 
 - Fix blurry text in breadcrumbs by avoiding skewing text ([#959](https://github.com/opensearch-project/oui/pull/959))
+- Remove `calc` usage from SchemaItem styles ([#990](https://github.com/opensearch-project/oui/pull/990))
 
 ### 🚞 Infrastructure
 

--- a/src/components/schema/_schema_item.scss
+++ b/src/components/schema/_schema_item.scss
@@ -29,12 +29,12 @@
 
 .ouiSchemaItem__icon {
   align-self: flex-start;
-  margin: calc($ouiSize / 2) 0; // To align with buttonIcon
+  margin: ($ouiSize / 2) 0; // To align with buttonIcon
 }
 
 .ouiSchemaItem__label {
   flex: 1;
-  margin: calc($ouiSize / 2) 0; // To align with buttonIcon
+  margin: ($ouiSize / 2) 0; // To align with buttonIcon
 }
 
 .ouiSchemaItem__actions {
@@ -68,12 +68,12 @@
   font-size: $ouiFontSizeXS;
 
   .ouiSchemaItem__icon {
-    margin: calc($ouiSizeM / 2) 0;
+    margin: ($ouiSizeM / 2) 0;
     margin-left: $ouiSizeXS;
   }
 
   .ouiSchemaItem__label {
     flex: 1;
-    margin: calc($ouiSizeM / 2) 0;
+    margin: ($ouiSizeM / 2) 0;
   }
 }


### PR DESCRIPTION
`calc()` is not parsed by libsass and shouldn't be used for build-time mathematics.

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] All tests pass
  - [ ] `yarn lint`
  - [ ] `yarn test-unit`
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/oui/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
