### PR TITLE
Adjust background color of `OuiToolTip`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - Make `CollapsibleNavGroup` background colors theme-able ([#968](https://github.com/opensearch-project/oui/pull/968))
 - Update next light theme primary color to #07827E ([#981](https://github.com/opensearch-project/oui/pull/981))
 - Add dismissible prop to OuiCallOut ([#985](https://github.com/opensearch-project/oui/pull/985))
+- Adjust background color of OuiToolTip in `next` theme ([#1004](https://github.com/opensearch-project/oui/pull/1004))
 
 ### 🐛 Bug Fixes
 

--- a/src/themes/oui-next/global_styling/variables/_tool_tip.scss
+++ b/src/themes/oui-next/global_styling/variables/_tool_tip.scss
@@ -9,7 +9,7 @@
  * GitHub history for details.
  */
 
-$ouiTooltipBackgroundColor: tintOrShade($ouiColorFullShade, 25%, 100%) !default;
+$ouiTooltipBackgroundColor: #293847 !default;
 
 $ouiTooltipAnimations: (
   top: ouiToolTipTop,


### PR DESCRIPTION
### Description
<!-- Describe what this change achieves -->
Use `#293847` in `next` theme. Keep current theme tooltips the same.

https://github.com/opensearch-project/oui/assets/1679762/4d0cac30-9689-4071-b2ac-ccf33fab6f0a


### Issues Resolved
<!-- List any issues this PR will resolve. -->
<!-- Example: Fixes #1234 -->
Fixes #953 

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] All tests pass
  - [ ] `yarn lint`
  - [ ] `yarn test-unit`
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/oui/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
