### PR TITLE
Adjust `$ouiFormInputGroupLabelBackground color` in dark `next` theme

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@
 - Make `CollapsibleNavGroup` background colors theme-able ([#968](https://github.com/opensearch-project/oui/pull/968))
 - Update next light theme primary color to #07827E ([#981](https://github.com/opensearch-project/oui/pull/981))
 - Add dismissible prop to OuiCallOut ([#985](https://github.com/opensearch-project/oui/pull/985))
-
+- Adjust $ouiFormInputGroupLabelBackground color in dark `next` theme ([#1005](https://github.com/opensearch-project/oui/pull/1005))
 ### 🐛 Bug Fixes
 
 - Fix blurry text in breadcrumbs by avoiding skewing text ([#959](https://github.com/opensearch-project/oui/pull/959))

--- a/src/themes/oui-next/global_styling/variables/_form.scss
+++ b/src/themes/oui-next/global_styling/variables/_form.scss
@@ -48,8 +48,8 @@ $ouiFormCustomControlBorderColor: shadeOrTint($ouiColorLightestShade, 18%, 30%) 
 $ouiFormControlDisabledColor: $ouiColorMediumShade !default;
 $ouiFormControlBoxShadow: 0 1px 1px -1px transparentize($ouiShadowColor, .8), 0 3px 2px -2px transparentize($ouiShadowColor, .8) !default;
 $ouiFormControlPlaceholderText: makeHighContrastColor($ouiTextSubduedColor, $ouiFormBackgroundColor) !default;
-$ouiFormInputGroupLabelDarkBackgroundColor: #293847 !default;
-$ouiFormInputGroupLabelBackground: lightOrDarkTheme(tint($ouiColorLightShade, 50%), $ouiFormInputGroupLabelDarkBackgroundColor) !default;
+$_ouiFormInputGroupLabelDarkBackgroundColor: #293847 !default;
+$ouiFormInputGroupLabelBackground: lightOrDarkTheme(tint($ouiColorLightShade, 50%), $_ouiFormInputGroupLabelDarkBackgroundColor) !default;
 $ouiFormInputGroupBorder: 1px solid shadeOrTint($ouiFormInputGroupLabelBackground, 2%, 4%) !default;
 $ouiSwitchOffColor: lightOrDarkTheme(transparentize($ouiColorMediumShade, .8), transparentize($ouiColorMediumShade, .3)) !default;
 

--- a/src/themes/oui-next/global_styling/variables/_form.scss
+++ b/src/themes/oui-next/global_styling/variables/_form.scss
@@ -48,7 +48,8 @@ $ouiFormCustomControlBorderColor: shadeOrTint($ouiColorLightestShade, 18%, 30%) 
 $ouiFormControlDisabledColor: $ouiColorMediumShade !default;
 $ouiFormControlBoxShadow: 0 1px 1px -1px transparentize($ouiShadowColor, .8), 0 3px 2px -2px transparentize($ouiShadowColor, .8) !default;
 $ouiFormControlPlaceholderText: makeHighContrastColor($ouiTextSubduedColor, $ouiFormBackgroundColor) !default;
-$ouiFormInputGroupLabelBackground: tintOrShade($ouiColorLightShade, 50%, 40%) !default;
+$ouiFormInputGroupLabelDarkBackgroundColor: #293847 !default;
+$ouiFormInputGroupLabelBackground: lightOrDarkTheme(tint($ouiColorLightShade, 50%), $ouiFormInputGroupLabelDarkBackgroundColor) !default;
 $ouiFormInputGroupBorder: 1px solid shadeOrTint($ouiFormInputGroupLabelBackground, 2%, 4%) !default;
 $ouiSwitchOffColor: lightOrDarkTheme(transparentize($ouiColorMediumShade, .8), transparentize($ouiColorMediumShade, .3)) !default;
 


### PR DESCRIPTION
### Description
<!-- Describe what this change achieves -->
Set to `#293847` for better contrast against both page background and panel background

Definitions for other themes and modes remain the same

https://github.com/opensearch-project/oui/assets/1679762/efb0694e-f21c-41e9-8e84-08dda16b7011


### Issues Resolved
<!-- List any issues this PR will resolve. -->
<!-- Example: Fixes #1234 -->
Fixes #939

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] All tests pass
  - [ ] `yarn lint`
  - [ ] `yarn test-unit`
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/oui/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
