### PR TITLE
Override OuiCollapsibleNav background color in `next` theme

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@
 - Set link to use semi bold font weight ([#961](https://github.com/opensearch-project/oui/pull/961))
 - Update ouiTextSubduedColor in `next` dark theme ([#973](https://github.com/opensearch-project/oui/pull/973))
 - Adds `SchemaItem` as an experimental component ([#974](https://github.com/opensearch-project/oui/pull/974))
-- Make `CollapsibleNavGroup` background colors theme-able ([#968](https://github.com/opensearch-project/oui/pull/968))
+- Make `CollapsibleNav` and `CollapsibleNavGroup` background colors theme-able ([#968](https://github.com/opensearch-project/oui/pull/968), [#1016](https://github.com/opensearch-project/oui/pull/1016))
 - Update next light theme primary color to #07827E ([#981](https://github.com/opensearch-project/oui/pull/981))
 - Add dismissible prop to OuiCallOut ([#985](https://github.com/opensearch-project/oui/pull/985))
 - Adjust $ouiFormInputGroupLabelBackground color in dark `next` theme ([#1005](https://github.com/opensearch-project/oui/pull/1005))

--- a/src/components/collapsible_nav/_collapsible_nav.scss
+++ b/src/components/collapsible_nav/_collapsible_nav.scss
@@ -14,3 +14,7 @@
 .ouiCollapsibleNav:not([class*='push']) {
   z-index: $ouiZNavigation !important; // sass-lint:disable-line no-important
 }
+
+.ouiCollapsibleNav.ouiFlyout {
+  background-color: $ouiCollapsibleNavBackgroundColor;
+}

--- a/src/global_styling/variables/_collapsible_nav.scss
+++ b/src/global_styling/variables/_collapsible_nav.scss
@@ -10,6 +10,8 @@
  */
 
 // Should be same as OuiFlyout background color
+$ouiCollapsibleNavBackgroundColor: null !default;
+
 $ouiCollapsibleNavGroupNoneBackgroundColor: inherit !default;
 
 $ouiCollapsibleNavGroupLightBackgroundColor: $ouiPageBackgroundColor !default;
@@ -26,6 +28,8 @@ $ouiCollapsibleNavGroupDarkHighContrastColor: makeGraphicContrastColor(
 
 
 /* OUI -> EUI Aliases */
+$euiCollapsibleNavBackgroundColor: $ouiCollapsibleNavBackgroundColor;
+$euiCollapsibleNavGroupNoneBackgroundColor: $ouiCollapsibleNavGroupNoneBackgroundColor;
 $euiCollapsibleNavGroupLightBackgroundColor: $ouiCollapsibleNavGroupLightBackgroundColor;
 $euiCollapsibleNavGroupDarkBackgroundColor: $ouiCollapsibleNavGroupDarkBackgroundColor;
 $euiCollapsibleNavGroupDarkHighContrastColor: $ouiCollapsibleNavGroupDarkHighContrastColor;

--- a/src/themes/oui-next/global_styling/variables/_collapsible_nav.scss
+++ b/src/themes/oui-next/global_styling/variables/_collapsible_nav.scss
@@ -9,9 +9,11 @@
  * GitHub history for details.
  */
 
+// Override OuiFlyout background
+$ouiCollapsibleNavBackgroundColor: $ouiPageBackgroundColor !default;
+
 // No distinction between none and light backgrounds in this theme
 $ouiCollapsibleNavGroupNoneBackgroundColor: $ouiPageBackgroundColor !default;
-
 $ouiCollapsibleNavGroupLightBackgroundColor: $ouiPageBackgroundColor !default;
 
 $ouiCollapsibleNavGroupDarkBackgroundColor: lightOrDarkTheme(
@@ -26,6 +28,8 @@ $ouiCollapsibleNavGroupDarkHighContrastColor: makeGraphicContrastColor(
 
 
 /* OUI -> EUI Aliases */
+$euiCollapsibleNavBackgroundColor: $ouiCollapsibleNavBackgroundColor;
+$euiCollapsibleNavGroupNoneBackgroundColor: $ouiCollapsibleNavGroupNoneBackgroundColor;
 $euiCollapsibleNavGroupLightBackgroundColor: $ouiCollapsibleNavGroupLightBackgroundColor;
 $euiCollapsibleNavGroupDarkBackgroundColor: $ouiCollapsibleNavGroupDarkBackgroundColor;
 $euiCollapsibleNavGroupDarkHighContrastColor: $ouiCollapsibleNavGroupDarkHighContrastColor;


### PR DESCRIPTION
### Description
<!-- Describe what this change achieves -->

`OuiCollapsibleNav` is a wrapper of `OuiFlyout`, but in the next theme, we want to have a different background styling by default. We introduce a new theme variable that's only set in the `next` theme.

In current theme, background should still come from OuiFlyout default styling

From: https://oui.opensearch.org/1.2/#/navigation/collapsible-nav/collapsible-nav-all
![Screenshot 2023-09-05 at 10-40-43 OpenSearch UI](https://github.com/opensearch-project/oui/assets/1679762/c2149ff0-923b-4cff-88d7-52bd66541556)

![Screenshot 2023-09-05 at 10-40-27 OpenSearch UI](https://github.com/opensearch-project/oui/assets/1679762/c04cd815-354e-4e5a-b5b7-9fe2c1643f53)

![Screenshot 2023-09-05 at 10-41-13 OpenSearch UI](https://github.com/opensearch-project/oui/assets/1679762/b3cf978e-a3e9-46fe-89a0-80d37cc77d93)

![Screenshot 2023-09-05 at 10-41-00 OpenSearch UI](https://github.com/opensearch-project/oui/assets/1679762/94e46cda-4335-4088-8875-9f54c5003914)

### Issues Resolved
<!-- List any issues this PR will resolve. -->
<!-- Example: Fixes #1234 -->

Fixes https://github.com/opensearch-project/OpenSearch-Dashboards/issues/4878

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] All tests pass
  - [ ] `yarn lint`
  - [ ] `yarn test-unit`
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/oui/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
