### PR TITLE
Fix alignment of left icon for OuiListGroupItem

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,7 @@
 - Fix blurry text in breadcrumbs by avoiding skewing text ([#959](https://github.com/opensearch-project/oui/pull/959))
 - Remove `calc` usage from SchemaItem styles ([#990](https://github.com/opensearch-project/oui/pull/990))
 - Add support for null types when deriving JSON from Sass variables ([#1019](https://github.com/opensearch-project/oui/pull/1019))
-- Fix alignment of left icon for OuiListGroupItem with multiline text 
+- Fix alignment of left icon for OuiListGroupItem with multiline text ([#1027](https://github.com/opensearch-project/oui/pull/1027))
 
 ### 🚞 Infrastructure
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
 - Fix blurry text in breadcrumbs by avoiding skewing text ([#959](https://github.com/opensearch-project/oui/pull/959))
 - Remove `calc` usage from SchemaItem styles ([#990](https://github.com/opensearch-project/oui/pull/990))
 - Add support for null types when deriving JSON from Sass variables ([#1019](https://github.com/opensearch-project/oui/pull/1019))
+- Fix alignment of left icon for OuiListGroupItem with multiline text 
 
 ### 🚞 Infrastructure
 

--- a/src-docs/src/views/list_group/list_group_extra.js
+++ b/src-docs/src/views/list_group/list_group_extra.js
@@ -34,5 +34,12 @@ export default () => (
       wrapText
       label="Fourth very, very long item with wrapping enabled that will not force truncation"
     />
+
+    <OuiListGroupItem
+      iconType={'package'}
+      onClick={() => {}}
+      wrapText
+      label="Fifth very long item with wrapping enabled and icon included"
+    />
   </OuiListGroup>
 );

--- a/src/components/list_group/_list_group_item.scss
+++ b/src/components/list_group/_list_group_item.scss
@@ -92,6 +92,10 @@
     }
   }
 
+  .ouiListGroupItem__icon {
+    height: $ouiSizeL;
+  }
+
   .ouiListGroupItem-isActive:not(.ouiListGroupItem--ghost) & {
     color: $ouiTextColor;
   }
@@ -117,6 +121,7 @@
 }
 
 .ouiListGroupItem__icon {
+  align-self: flex-start;
   margin-right: $ouiSizeM;
   flex-grow: 0;
   flex-shrink: 0;
@@ -140,12 +145,20 @@
   .ouiListGroupItem__text {
     line-height: $ouiSize;
   }
+
+  .ouiListGroupItem__icon {
+    height: $ouiSize;
+  }
 }
 
 .ouiListGroupItem--large {
   .ouiListGroupItem__button,
   .ouiListGroupItem__text {
     line-height: $ouiSizeXL;
+  }
+
+  .ouiListGroupItem__icon {
+    height: $ouiSizeXL;
   }
 }
 


### PR DESCRIPTION
### Description
<!-- Describe what this change achieves -->
Fix alignment of left icon for OuiListGroupItem with multiline text

**Before:**
<img width="921" alt="Screenshot 2023-09-08 at 18 10 17" src="https://github.com/opensearch-project/oui/assets/98167/0d066173-652a-48e7-ad42-ceead1e2ce43">


**After:**
<img width="908" alt="Screenshot 2023-09-08 at 18 09 09" src="https://github.com/opensearch-project/oui/assets/98167/d6807a2d-a7ff-4554-a3c3-31f54ee28fb3">


### Issues Resolved
<!-- List any issues this PR will resolve. -->
<!-- Example: Fixes #1234 -->
Fixes #1000

### Check List
- [x] All tests pass
  - [x] `yarn lint`
  - [x] `yarn test-unit`
- [x] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/oui/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
