### PR TITLE
Fix next light color guidelines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@
 - Replace Avatar in favor of Icon in OuiFacetButtons example ([#987](https://github.com/opensearch-project/oui/pull/987))
 - Add dark prop toggles ([#910](https://github.com/opensearch-project/oui/pull/910))
 - Remove language from the form validation documentation that doesn't align with the updated guidelines ([#986](https://github.com/opensearch-project/oui/pull/986))
+- Fix next light color guidelines ([#1030](https://github.com/opensearch-project/oui/pull/1030))
 
 ### 🛠 Maintenance
 

--- a/src-docs/src/views/guidelines/_get_sass_vars.js
+++ b/src-docs/src/views/guidelines/_get_sass_vars.js
@@ -11,7 +11,7 @@
 
 import lightColors from '!!sass-vars-to-js-loader!../../../../src/global_styling/variables/_colors.scss';
 import darkColors from '!!sass-vars-to-js-loader!../../../../src/themes/oui/oui_colors_dark.scss';
-import lightNextColors from '!!sass-vars-to-js-loader!../../../../src/themes/oui-next/oui_next_colors_light.scss';
+import lightNextColors from '!!sass-vars-to-js-loader!../../../../src/themes/oui-next/global_styling/variables/_colors.scss';
 import darkNextColors from '!!sass-vars-to-js-loader!../../../../src/themes/oui-next/oui_next_colors_dark.scss';
 
 export const getSassVars = (theme) => {


### PR DESCRIPTION
### Description
Fix issue where Next Light theme color guidelines would come up with current Light color guidelines. Set it to retrieve the colors from the correct place.

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [x] All tests pass
  - [x] `yarn lint`
  - [x] `yarn test-unit`
- [x] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/oui/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
