### PR TITLE
Update caniuse db

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,8 @@
 
 ### 🛠 Maintenance
 
+- Update caniuse database ([#1046](https://github.com/opensearch-project/oui/pull/1046))
+
 ### 🪛 Refactoring
 
 ### 🔩 Tests

--- a/package.json
+++ b/package.json
@@ -133,7 +133,6 @@
     "vfile": "^4.2.0"
   },
   "devDependencies": {
-    "@faker-js/faker": "^8.0.1",
     "@axe-core/puppeteer": "4.6.1",
     "@babel/cli": "^7.10.5",
     "@babel/core": "^7.11.4",
@@ -147,12 +146,13 @@
     "@babel/preset-typescript": "^7.12.1",
     "@elastic/charts": "^30.2.0",
     "@elastic/eslint-config-kibana": "^0.15.0",
+    "@faker-js/faker": "^8.0.1",
     "@opensearch/datemath": "file:./packages/opensearch-datemath",
     "@svgr/core": "^8.0.0",
-    "@svgr/plugin-svgo": "^8.0.1",
     "@svgr/plugin-jsx": "^8.0.1",
-    "@types/enzyme": "3.10.12",
+    "@svgr/plugin-svgo": "^8.0.1",
     "@types/cheerio": "^0.22.31",
+    "@types/enzyme": "3.10.12",
     "@types/jest": "^24.0.6",
     "@types/node": "^10.17.5",
     "@types/react": "^16.9.34",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4366,15 +4366,10 @@ caniuse-api@^3.0.0:
     lodash.memoize "^4.1.2"
     lodash.uniq "^4.5.0"
 
-caniuse-lite@^1.0.0, caniuse-lite@^1.0.30001109, caniuse-lite@^1.0.30001370:
-  version "1.0.30001457"
-  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001457.tgz"
-  integrity sha512-SDIV6bgE1aVbK6XyxdURbUE89zY7+k1BBBaOwYwkNCglXlel/E7mELiHC64HQ+W0xSKlqWhV9Wh7iHxUjMs4fA==
-
-caniuse-lite@^1.0.30001449:
-  version "1.0.30001473"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001473.tgz#3859898b3cab65fc8905bb923df36ad35058153c"
-  integrity sha512-ewDad7+D2vlyy+E4UJuVfiBsU69IL+8oVmTuZnH5Q6CIUbxNfI50uVpRHbUPDD6SUaN2o0Lh4DhTrvLG/Tn1yg==
+caniuse-lite@^1.0.0, caniuse-lite@^1.0.30001109, caniuse-lite@^1.0.30001370, caniuse-lite@^1.0.30001449:
+  version "1.0.30001538"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001538.tgz"
+  integrity sha512-HWJnhnID+0YMtGlzcp3T9drmBJUVDchPJ08tpUGFLs9CYlwWPH2uLgpHn8fND5pCgXVtnGS3H4QR9XLMHVNkHw==
 
 capture-exit@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
### Description

Update `caniuse` db, and reorder package.json dev dependencies. It seems somehow these got out of order at some point, so whenever we update that package.json, this reordering will happen.

Kinda curious if we can do this update automatically...

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [x] All tests pass
  - [x] `yarn lint`
  - [x] `yarn test-unit`
- [x] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/oui/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
