### PR TITLE
Fix docgen babel plugin

### DIFF
--- a/package.json
+++ b/package.json
@@ -222,7 +222,7 @@
     "puppeteer": "^19.11.1",
     "raw-loader": "^4.0.1",
     "react": "^16.14.0",
-    "react-docgen-typescript": "^1.22.0",
+    "react-docgen-typescript": "^2.2.2",
     "react-dom": "^16.12.0",
     "react-helmet": "^6.1.0",
     "react-redux": "^8.0.5",

--- a/scripts/compile-clean.js
+++ b/scripts/compile-clean.js
@@ -11,6 +11,7 @@
 
 const { rimraf } = require('rimraf');
 
+rimraf.sync('.cache-loader');
 rimraf.sync('dist');
 rimraf.sync('lib');
 rimraf.sync('es');

--- a/yarn.lock
+++ b/yarn.lock
@@ -13707,10 +13707,10 @@ react-clientside-effect@^1.2.2:
   dependencies:
     "@babel/runtime" "^7.0.0"
 
-react-docgen-typescript@^1.22.0:
-  version "1.22.0"
-  resolved "https://registry.yarnpkg.com/react-docgen-typescript/-/react-docgen-typescript-1.22.0.tgz#00232c8e8e47f4437cac133b879b3e9437284bee"
-  integrity sha512-MPLbF8vzRwAG3GcjdL+OHQlhgtWsLTXs+7uJiHfEeT3Ur7IsZaNYqRTLQ9sj2nB6M6jylcPCeCmH7qbszJmecg==
+react-docgen-typescript@^2.2.2:
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/react-docgen-typescript/-/react-docgen-typescript-2.2.2.tgz#4611055e569edc071204aadb20e1c93e1ab1659c"
+  integrity sha512-tvg2ZtOpOi6QDwsb3GZhOjDkkX0h8Z2gipvTg6OVMUyoYoURhEiRNePT8NZItTVCDh39JJHnLdfCOkzoLbFnTg==
 
 react-dom@^16.12.0:
   version "16.12.0"


### PR DESCRIPTION
### Description

After merging the Typescript update, there was a bug that popped up when trying to start the docsite. Essentially, the docgen info wasn't being generated. This is because the `react-docgen-typescript` package used a Typescript API that apparently broke in one of the versions between what we updated from and to. Updating that package fixes the issue.

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [x] All tests pass
  - [x] `yarn lint`
  - [x] `yarn test-unit`
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/oui/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
