### PR TITLE
[OSCI] Bug fix: Correct file path for importing Query component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 ### 🐛 Bug Fixes
 
 - Add exit code to compile-scss script on failure ([#1024](https://github.com/opensearch-project/oui/pull/1024))
+- Clarify file path for Query export ([#1069](https://github.com/opensearch-project/oui/pull/1069))
 
 ### 🚞 Infrastructure
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@
 ### 🐛 Bug Fixes
 
 - Add exit code to compile-scss script on failure ([#1024](https://github.com/opensearch-project/oui/pull/1024))
-- Clarify file path for Query export ([#1069](https://github.com/opensearch-project/oui/pull/1069))
+- Correct file path for import of Query component ([#1069](https://github.com/opensearch-project/oui/pull/1069))
 
 ### 🚞 Infrastructure
 

--- a/src/components/search_bar/filters/field_value_selection_filter.tsx
+++ b/src/components/search_bar/filters/field_value_selection_filter.tsx
@@ -37,7 +37,7 @@ import { OuiFilterButton, OuiFilterSelectItem } from '../../filter_group';
 import { OuiLoadingChart } from '../../loading';
 import { OuiSpacer } from '../../spacer';
 import { OuiIcon } from '../../icon';
-import { Query } from '../query';
+import { Query } from '../query/query';
 import { Clause, Operator, OperatorType, Value } from '../query/ast';
 
 export interface FieldValueOptionType {

--- a/src/components/search_bar/filters/field_value_toggle_filter.tsx
+++ b/src/components/search_bar/filters/field_value_toggle_filter.tsx
@@ -31,7 +31,7 @@
 import React, { Component } from 'react';
 import { OuiFilterButton } from '../../filter_group';
 import { isNil } from '../../../services/predicate';
-import { Query } from '../query';
+import { Query } from '../query/query';
 import { Clause, OperatorType, Value } from '../query/ast';
 
 export interface FieldValueToggleFilterConfigType {

--- a/src/components/search_bar/filters/field_value_toggle_group_filter.tsx
+++ b/src/components/search_bar/filters/field_value_toggle_group_filter.tsx
@@ -30,7 +30,7 @@
 
 import React, { Component } from 'react';
 import { OuiFilterButton } from '../../filter_group';
-import { Query } from '../query';
+import { Query } from '../query/query';
 import { OperatorType } from '../query/ast';
 
 export interface FieldValueToggleGroupFilterItemType {

--- a/src/components/search_bar/filters/is_filter.tsx
+++ b/src/components/search_bar/filters/is_filter.tsx
@@ -31,7 +31,7 @@
 import React, { Component } from 'react';
 import { OuiFilterButton } from '../../filter_group';
 import { isNil } from '../../../services/predicate';
-import { Query } from '../query';
+import { Query } from '../query/query';
 import { Clause } from '../query/ast';
 
 export interface IsFilterConfigType {

--- a/src/components/search_bar/search_bar.tsx
+++ b/src/components/search_bar/search_bar.tsx
@@ -33,7 +33,7 @@ import { isString } from '../../services/predicate';
 import { OuiFlexGroup, OuiFlexItem } from '../flex';
 import { OuiSearchBox, SchemaType } from './search_box';
 import { OuiSearchFilters, SearchFilterConfig } from './search_filters';
-import { Query } from './query';
+import { Query } from './query/query';
 import { CommonProps } from '../common';
 import { OuiFieldSearchProps } from '../form/field_search';
 


### PR DESCRIPTION
### Description
This change clarifies the file path for the Query export in five files. Before the change, the OUI documentation site was not loading on my browser, and the console displayed the warnings in the following screenshot:

<img width="1030" alt="Screenshot 2023-10-05 at 5 06 46 PM" src="https://github.com/opensearch-project/oui/assets/109883576/ce25de07-6489-468f-a897-8e23470338f2">

After the change, the documentation site loads successfully, and the warnings regarding the Query export are absent from my console:

<img width="1361" alt="Screenshot 2023-10-09 at 2 00 31 PM" src="https://github.com/opensearch-project/oui/assets/109883576/f963dba3-6b5c-4a7b-9298-54a3b05fd2fb">

### Issues Resolved
Fixes issue [#1063](https://github.com/opensearch-project/oui/issues/1063) 

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [x] All tests pass
  - [x] `yarn lint`
  - [x] `yarn test-unit`
- [x] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/oui/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
