### PR TITLE
Made recommended changes to git pre-commit hook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,7 +74,8 @@
 - Remove language from the form validation documentation that doesn't align with the updated guidelines ([#986](https://github.com/opensearch-project/oui/pull/986))
 
 ### 🛠 Maintenance
-- Made changes to ```pre-commit``` hook to only use ```yarn lint``` instead of running ```test-staged``` script ([#1072](https://github.com/opensearch-project/oui/pull/1072))
+
+- Made changes to `pre-commit` hook to only use `lint` instead of running `test-staged` script ([#1072](https://github.com/opensearch-project/oui/pull/1072))
 - [CVE-2023-26136] Add resolution for tough-cookie to ^4.1.3 ([#889](https://github.com/opensearch-project/oui/pull/889))
 - [CVE-2023-26115] Bump word-wrap from 1.2.3 to 1.2.4 ([#891](https://github.com/opensearch-project/oui/pull/891))
 - Bump Node version to 18.16.0 ([#900](https://github.com/opensearch-project/oui/pull/900))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,7 +74,7 @@
 - Remove language from the form validation documentation that doesn't align with the updated guidelines ([#986](https://github.com/opensearch-project/oui/pull/986))
 
 ### 🛠 Maintenance
-
+- Made changes to ```pre-commit``` hook to only use ```yarn lint``` instead of running ```test-staged``` script ([#1072](https://github.com/opensearch-project/oui/pull/1072))
 - [CVE-2023-26136] Add resolution for tough-cookie to ^4.1.3 ([#889](https://github.com/opensearch-project/oui/pull/889))
 - [CVE-2023-26115] Bump word-wrap from 1.2.3 to 1.2.4 ([#891](https://github.com/opensearch-project/oui/pull/891))
 - Bump Node version to 18.16.0 ([#900](https://github.com/opensearch-project/oui/pull/900))

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "test": "yarn lint && yarn test-unit",
     "test-unit": "cross-env NODE_ENV=test jest --config ./scripts/jest/config.json",
     "test-a11y": "node ./scripts/a11y-testing",
-    "test-staged": "yarn lint && node scripts/test-staged.js",
+    "test-staged": "node scripts/test-staged.js",
     "start-test-server": "BABEL_MODULES=false NODE_ENV=puppeteer NODE_OPTIONS=--max-old-space-size=4096 webpack-dev-server --config src-docs/webpack.config.js --port 9999",
     "yo-component": "yo ./generator-oui/app/component.js",
     "start-test-server-and-a11y-test": "cross-env WAIT_ON_TIMEOUT=600000 start-server-and-test start-test-server http-get://localhost:9999 test-a11y",
@@ -90,7 +90,7 @@
     "yo/meow": "^9.0.0"
   },
   "pre-commit": [
-    "test-staged"
+    "yarn lint"
   ],
   "dependencies": {
     "@types/chroma-js": "^2.4.0",

--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
     "yo/meow": "^9.0.0"
   },
   "pre-commit": [
-    "yarn lint"
+    "lint"
   ],
   "dependencies": {
     "@types/chroma-js": "^2.4.0",


### PR DESCRIPTION
### Description

Changed ```pre-commit``` hook to only use ```yarn lint``` instead of using ```test-staged``` script. 

Changed ```test-staged``` script by removing ```yarn lint``` from it.

### Issues Resolved

solves issue #1070 

### Check List
- [x] New functionality includes testing.
- [X] New functionality has been documented.
- [x] All tests pass
  - [x] `yarn lint`
  - [x] `yarn test-unit`
- [X] Update [CHANGELOG.md](./../CHANGELOG.md)
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/oui/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
