### PR TITLE
New file utils.js, moved teardown function

### DIFF
--- a/scripts/compile-clean.js
+++ b/scripts/compile-clean.js
@@ -10,6 +10,7 @@
  */
 
 const { rimraf } = require('rimraf');
+const { euiBuildTimeAliasTearDown } = require('./utils'); // Import the utility function
 
 rimraf.sync('.cache-loader');
 rimraf.sync('dist');
@@ -17,3 +18,5 @@ rimraf.sync('lib');
 rimraf.sync('es');
 rimraf.sync('test-env');
 rimraf.sync('types');
+
+euiBuildTimeAliasTearDown(); // Call the utility function

--- a/scripts/compile-oui.js
+++ b/scripts/compile-oui.js
@@ -36,6 +36,7 @@ const path = require('path');
 const glob = require('glob');
 const fs = require('fs');
 const dtsGenerator = require('dts-generator').default;
+const { euiBuildTimeAliasTearDown} = require('./utils'); // Import the utility functions
 
 /* OUI -> EUI Aliases */
 function euiBuildTimeAliasSetup() {
@@ -157,22 +158,22 @@ function euiBuildTimeAliasTypeDef(file) {
   fs.writeFileSync(file, '\n' + reExportStatements.join('\n'), { flag: 'a', encoding: 'utf8' });
 }
 
-function euiBuildTimeAliasTearDown() {
-  console.log('Tearing down build-time EUI aliases');
-  shell.rm('-rf', 'src/eui_components');
+// function euiBuildTimeAliasTearDown() {
+//   console.log('Tearing down build-time EUI aliases');
+//   shell.rm('-rf', 'src/eui_components');
 
-  // Remove any changes made at build time
-  shell.ls('src/components/**/*.*').forEach(file => {
-    if (/__snapshots__|\.d\.ts|\.test\.|\.scss/.test(file)) return;
-    let changed;
-    const content = fs.readFileSync(file, 'utf8')
-      .replace(/\n\/\* OUI -> EUI Aliases: Build-Time \*\/.*$/mg, () => {
-        changed = true;
-        return '';
-      });
-    if (changed) fs.writeFileSync(file, content, 'utf8');
-  });
-}
+//   // Remove any changes made at build time
+//   shell.ls('src/components/**/*.*').forEach(file => {
+//     if (/__snapshots__|\.d\.ts|\.test\.|\.scss/.test(file)) return;
+//     let changed;
+//     const content = fs.readFileSync(file, 'utf8')
+//       .replace(/\n\/\* OUI -> EUI Aliases: Build-Time \*\/.*$/mg, () => {
+//         changed = true;
+//         return '';
+//       });
+//     if (changed) fs.writeFileSync(file, content, 'utf8');
+//   });
+// }
 /* End of Aliases */
 
 function compileLib() {

--- a/scripts/utils.js
+++ b/scripts/utils.js
@@ -1,0 +1,23 @@
+const shell = require('shelljs');
+const fs = require('fs');
+
+function euiBuildTimeAliasTearDown() {
+  console.log('Tearing down build-time EUI aliases');
+  shell.rm('-rf', 'src/eui_components');
+
+  // Remove any changes made at build time
+  shell.ls('src/components/**/*.*').forEach(file => {
+    if (/__snapshots__|\.d\.ts|\.test\.|\.scss/.test(file)) return;
+    let changed;
+    const content = fs.readFileSync(file, 'utf8')
+      .replace(/\n\/\* OUI -> EUI Aliases: Build-Time \*\/.*$/mg, () => {
+        changed = true;
+        return '';
+      });
+    if (changed) fs.writeFileSync(file, content, 'utf8');
+  });
+}
+
+module.exports = {
+  euiBuildTimeAliasTearDown,
+};


### PR DESCRIPTION
### Description
<!-- Describe what this change achieves -->
Added a utils file and moved the euiBuildTimeAliasTearDown function to it.
### Issues Resolved
<!-- List any issues this PR will resolve. -->
Works on issue #1601 

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] All tests pass
  - [ ] `yarn lint`
  - [ ] `yarn test-unit`
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/oui/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
