### PR TITLE
[Fix] "Guidelines" Documentation Render Blank Page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 
 - Add exit code to compile-scss script on failure ([#1024](https://github.com/opensearch-project/oui/pull/1024))
 - Correct file path for import of Query component ([#1069](https://github.com/opensearch-project/oui/pull/1069))
+- Fix "Guidelines" documentation rendering blank pages ([#1109](https://github.com/opensearch-project/oui/pull/1110))
 
 ### 🚞 Infrastructure
 

--- a/src/services/color/rgb_to_hex.ts
+++ b/src/services/color/rgb_to_hex.ts
@@ -34,6 +34,10 @@ function asHex(value: string): string {
 }
 
 export function rgbToHex(rgb: string): string {
+  if (!rgb) {
+    return '';
+  }
+
   const withoutWhitespace = rgb.replace(/\s+/g, '');
   const rgbMatch = withoutWhitespace.match(
     /^rgba?\((\d+),(\d+),(\d+)(?:,(?:1(?:\.0*)?|0(?:\.\d+)?))?\)$/i


### PR DESCRIPTION
### Description

 Resolve the issue where the Source Documentation would render blank pages when users clicked on either the "Colors" or "Sass" sections. 

### Issues Resolved
Closes #1109 

### Screenshot
#### Before

https://github.com/opensearch-project/oui/assets/65143821/f46d63e4-e03c-40a4-b8cd-c2ffdd337fd2


#### After


https://github.com/opensearch-project/oui/assets/65143821/fe4e51dc-01b9-431f-b20e-be50bead1e14




### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [x] All tests pass
  - [x] `yarn lint`
  - [x] `yarn test-unit`
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff
