### PR TITLE
[OSCI] Fix Typo in `wiki/consuming.md`

### DIFF
--- a/wiki/consuming.md
+++ b/wiki/consuming.md
@@ -91,7 +91,7 @@ If you want to use the new, but in progress Next theme, you can import it simila
 
 ### Using Sass to customize OUI
 
-OUI's Sass themes are token based, which can be altered to suite your theming needs like changing the primary color. Simply declare your token overrides before importing the whole OUI theme. This will re-compile **all of the OUI components** with your colors.
+OUI's Sass themes are token based, which can be altered to suit your theming needs like changing the primary color. Simply declare your token overrides before importing the whole OUI theme. This will re-compile **all of the OUI components** with your colors.
 
 *Do not use in conjunction with the compiled CSS.*
 


### PR DESCRIPTION
### Description
This change fixes a simple typo in `wiki/consuming.md`.

### Issues Resolved
Because this was a simple spelling error, I did not raise a dedicated issue for it.

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [x] All tests pass
  - [x] `yarn lint`
  - [x] `yarn test-unit`
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/oui/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
