### PR TITLE
[OSCI] Adding props for shrink and basis for OuiFlexItem

### DIFF
--- a/src/components/flex/__snapshots__/flex_item.test.tsx.snap
+++ b/src/components/flex/__snapshots__/flex_item.test.tsx.snap
@@ -1,81 +1,105 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`OuiFlexItem basis auto is rendered 1`] = `
+<div
+  class="ouiFlexItem ouiFlexItem--flexShrink1"
+/>
+`;
+
+exports[`OuiFlexItem basis fit-content is rendered 1`] = `
+<div
+  class="ouiFlexItem ouiFlexItem--flexShrink1"
+/>
+`;
+
+exports[`OuiFlexItem basis max-content is rendered 1`] = `
+<div
+  class="ouiFlexItem ouiFlexItem--flexShrink1"
+/>
+`;
+
+exports[`OuiFlexItem basis min-content is rendered 1`] = `
+<div
+  class="ouiFlexItem ouiFlexItem--flexShrink1"
+/>
+`;
+
 exports[`OuiFlexItem grow 1 is rendered 1`] = `
 <div
-  class="ouiFlexItem ouiFlexItem--flexGrow1"
+  class="ouiFlexItem ouiFlexItem--flexGrow1 ouiFlexItem--flexShrink1"
 />
 `;
 
 exports[`OuiFlexItem grow 2 is rendered 1`] = `
 <div
-  class="ouiFlexItem ouiFlexItem--flexGrow2"
+  class="ouiFlexItem ouiFlexItem--flexGrow2 ouiFlexItem--flexShrink1"
 />
 `;
 
 exports[`OuiFlexItem grow 3 is rendered 1`] = `
 <div
-  class="ouiFlexItem ouiFlexItem--flexGrow3"
+  class="ouiFlexItem ouiFlexItem--flexGrow3 ouiFlexItem--flexShrink1"
 />
 `;
 
 exports[`OuiFlexItem grow 4 is rendered 1`] = `
 <div
-  class="ouiFlexItem ouiFlexItem--flexGrow4"
+  class="ouiFlexItem ouiFlexItem--flexGrow4 ouiFlexItem--flexShrink1"
 />
 `;
 
 exports[`OuiFlexItem grow 5 is rendered 1`] = `
 <div
-  class="ouiFlexItem ouiFlexItem--flexGrow5"
+  class="ouiFlexItem ouiFlexItem--flexGrow5 ouiFlexItem--flexShrink1"
 />
 `;
 
 exports[`OuiFlexItem grow 6 is rendered 1`] = `
 <div
-  class="ouiFlexItem ouiFlexItem--flexGrow6"
+  class="ouiFlexItem ouiFlexItem--flexGrow6 ouiFlexItem--flexShrink1"
 />
 `;
 
 exports[`OuiFlexItem grow 7 is rendered 1`] = `
 <div
-  class="ouiFlexItem ouiFlexItem--flexGrow7"
+  class="ouiFlexItem ouiFlexItem--flexGrow7 ouiFlexItem--flexShrink1"
 />
 `;
 
 exports[`OuiFlexItem grow 8 is rendered 1`] = `
 <div
-  class="ouiFlexItem ouiFlexItem--flexGrow8"
+  class="ouiFlexItem ouiFlexItem--flexGrow8 ouiFlexItem--flexShrink1"
 />
 `;
 
 exports[`OuiFlexItem grow 9 is rendered 1`] = `
 <div
-  class="ouiFlexItem ouiFlexItem--flexGrow9"
+  class="ouiFlexItem ouiFlexItem--flexGrow9 ouiFlexItem--flexShrink1"
 />
 `;
 
 exports[`OuiFlexItem grow 10 is rendered 1`] = `
 <div
-  class="ouiFlexItem ouiFlexItem--flexGrow10"
+  class="ouiFlexItem ouiFlexItem--flexGrow10 ouiFlexItem--flexShrink1"
 />
 `;
 
 exports[`OuiFlexItem grow false is rendered 1`] = `
 <div
-  class="ouiFlexItem ouiFlexItem--flexGrowZero"
+  class="ouiFlexItem ouiFlexItem--flexGrowZero ouiFlexItem--flexShrink1"
 />
 `;
 
 exports[`OuiFlexItem grow true is rendered 1`] = `
 <div
-  class="ouiFlexItem"
+  class="ouiFlexItem ouiFlexItem--flexShrink1"
 />
 `;
 
 exports[`OuiFlexItem is rendered 1`] = `
 <div
   aria-label="aria-label"
-  class="ouiFlexItem testClass1 testClass2"
+  class="ouiFlexItem ouiFlexItem--flexShrink1 testClass1 testClass2"
   data-test-subj="test subject string"
 />
 `;
@@ -137,17 +161,5 @@ exports[`OuiFlexItem shrink 9 is rendered 1`] = `
 exports[`OuiFlexItem shrink 10 is rendered 1`] = `
 <div
   class="ouiFlexItem ouiFlexItem--flexShrink10"
-/>
-`;
-
-exports[`OuiFlexItem shrink false is rendered 1`] = `
-<div
-  class="ouiFlexItem"
-/>
-`;
-
-exports[`OuiFlexItem shrink true is rendered 1`] = `
-<div
-  class="ouiFlexItem"
 />
 `;

--- a/src/components/flex/__snapshots__/flex_item.test.tsx.snap
+++ b/src/components/flex/__snapshots__/flex_item.test.tsx.snap
@@ -79,3 +79,75 @@ exports[`OuiFlexItem is rendered 1`] = `
   data-test-subj="test subject string"
 />
 `;
+
+exports[`OuiFlexItem shrink 1 is rendered 1`] = `
+<div
+  class="ouiFlexItem ouiFlexItem--flexShrink1"
+/>
+`;
+
+exports[`OuiFlexItem shrink 2 is rendered 1`] = `
+<div
+  class="ouiFlexItem ouiFlexItem--flexShrink2"
+/>
+`;
+
+exports[`OuiFlexItem shrink 3 is rendered 1`] = `
+<div
+  class="ouiFlexItem ouiFlexItem--flexShrink3"
+/>
+`;
+
+exports[`OuiFlexItem shrink 4 is rendered 1`] = `
+<div
+  class="ouiFlexItem ouiFlexItem--flexShrink4"
+/>
+`;
+
+exports[`OuiFlexItem shrink 5 is rendered 1`] = `
+<div
+  class="ouiFlexItem ouiFlexItem--flexShrink5"
+/>
+`;
+
+exports[`OuiFlexItem shrink 6 is rendered 1`] = `
+<div
+  class="ouiFlexItem ouiFlexItem--flexShrink6"
+/>
+`;
+
+exports[`OuiFlexItem shrink 7 is rendered 1`] = `
+<div
+  class="ouiFlexItem ouiFlexItem--flexShrink7"
+/>
+`;
+
+exports[`OuiFlexItem shrink 8 is rendered 1`] = `
+<div
+  class="ouiFlexItem ouiFlexItem--flexShrink8"
+/>
+`;
+
+exports[`OuiFlexItem shrink 9 is rendered 1`] = `
+<div
+  class="ouiFlexItem ouiFlexItem--flexShrink9"
+/>
+`;
+
+exports[`OuiFlexItem shrink 10 is rendered 1`] = `
+<div
+  class="ouiFlexItem ouiFlexItem--flexShrink10"
+/>
+`;
+
+exports[`OuiFlexItem shrink false is rendered 1`] = `
+<div
+  class="ouiFlexItem"
+/>
+`;
+
+exports[`OuiFlexItem shrink true is rendered 1`] = `
+<div
+  class="ouiFlexItem"
+/>
+`;

--- a/src/components/flex/_flex_item.scss
+++ b/src/components/flex/_flex_item.scss
@@ -24,18 +24,38 @@
 
   /*
    * 1. We need the extra specificity here to override the FlexGroup > FlexItem styles.
-   * 2. FlexItem can be manually set to not grow if needed.
+   * 2. FlexItem can be manually set to not grow if needed (default).
+   * 3. FlexItem also can be given values for grow, shrink and basis:
+   *    - grow: 1..10
+   *    - shrink: 1..10
+   *    - basis: auto, 0%, 25%, 50%, 75% or 100%
    */
+
   &.ouiFlexItem--flexGrowZero { /* 1 */
     flex-grow: 0; /* 2 */
     flex-basis: auto; /* 2 */
   }
 
-  @for $i from 1 through 10 {
-    &.ouiFlexItem--flexGrow#{$i} {
-      flex-grow: $i;
+  @for $i from 1 through 10 { /* 3 */
+    &.ouiFlexItem--flexGrow#{$i} { /* 3 */
+      flex-grow: $i; /* 3 */
     }
   }
+
+  @for $i from 1 through 10 { /* 3 */
+    &.ouiFlexItem--flexShrink#{$i} { /* 3 */
+      flex-shrink: $i; /* 3 */
+    }
+  }
+
+  $flexBasisOptions: 'auto', '0%', '25%', '50%', '75%', '100%'; /* 3 */
+
+  @each $basis in $flexBasisOptions { /* 3 */
+    .ouiFlexItem--flexBasis#{$basis} { /* 3 */
+      flex-basis: $basis; /* 3 */
+    }
+  }
+
 }
 
 // On mobile we force them to stack and act the same.

--- a/src/components/flex/_flex_item.scss
+++ b/src/components/flex/_flex_item.scss
@@ -24,14 +24,19 @@
 
   /*
    * 1. We need the extra specificity here to override the FlexGroup > FlexItem styles.
-   * 2. FlexItem can be manually set to not grow if needed (default).
+   * 2. FlexItem can be manually set to not grow or shrink if needed (default).
    * 3. FlexItem also can be given values for grow, shrink and basis:
    *    - grow: 1..10
    *    - shrink: 1..10
-   *    - basis: auto, 0%, 25%, 50%, 75% or 100%
+   *    - basis: auto, max-content, min-content, fit-content
    */
 
   &.ouiFlexItem--flexGrowZero { /* 1 */
+    flex-grow: 0; /* 2 */
+    flex-basis: auto; /* 2 */
+  }
+
+  &.ouiFlexItem--flexShrinkZero { /* 1 */
     flex-grow: 0; /* 2 */
     flex-basis: auto; /* 2 */
   }
@@ -48,7 +53,7 @@
     }
   }
 
-  $flexBasisOptions: 'auto', '0%', '25%', '50%', '75%', '100%'; /* 3 */
+  $flexBasisOptions: 'auto', 'max-content', 'min-content', 'fit-content'; /* 3 */
 
   @each $basis in $flexBasisOptions { /* 3 */
     .ouiFlexItem--flexBasis#{$basis} { /* 3 */

--- a/src/components/flex/flex_item.test.tsx
+++ b/src/components/flex/flex_item.test.tsx
@@ -36,7 +36,7 @@ import {
   stopThrowingReactWarnings,
 } from '../../test';
 
-import { OuiFlexItem, GROW_SIZES } from './flex_item';
+import { OuiFlexItem, GROW_SIZES, SHRINK_SIZES, BASIS_VALUES } from './flex_item';
 
 beforeAll(startThrowingReactWarnings);
 afterAll(stopThrowingReactWarnings);
@@ -52,6 +52,26 @@ describe('OuiFlexItem', () => {
     GROW_SIZES.concat([true, false]).forEach((value) => {
       test(`${value} is rendered`, () => {
         const component = render(<OuiFlexItem grow={value} />);
+
+        expect(component).toMatchSnapshot();
+      });
+    });
+  });
+
+  describe('shrink', () => {
+    SHRINK_SIZES.forEach((value) => {
+      test(`${value} is rendered`, () => {
+        const component = render(<OuiFlexItem shrink={value} />);
+
+        expect(component).toMatchSnapshot();
+      });
+    });
+  });
+
+  describe('basis', () => {
+    BASIS_VALUES.forEach((value) => {
+      test(`${value} is rendered`, () => {
+        const component = render(<OuiFlexItem basis={value} />);
 
         expect(component).toMatchSnapshot();
       });

--- a/src/components/flex/flex_item.test.tsx
+++ b/src/components/flex/flex_item.test.tsx
@@ -36,7 +36,12 @@ import {
   stopThrowingReactWarnings,
 } from '../../test';
 
-import { OuiFlexItem, GROW_SIZES, SHRINK_SIZES, BASIS_VALUES } from './flex_item';
+import {
+  OuiFlexItem,
+  GROW_SIZES,
+  SHRINK_SIZES,
+  BASIS_VALUES,
+} from './flex_item';
 
 beforeAll(startThrowingReactWarnings);
 afterAll(stopThrowingReactWarnings);

--- a/src/components/flex/flex_item.tsx
+++ b/src/components/flex/flex_item.tsx
@@ -82,7 +82,14 @@ export const SHRINK_SIZES: FlexItemShrinkSize[] = [
   9,
   10,
 ];
-export const BASIS_VALUES:FlexItemBasisValue[] = ['auto','0%','25%','50%','75%','100%']
+export const BASIS_VALUES: FlexItemBasisValue[] = [
+  'auto',
+  '0%',
+  '25%',
+  '50%',
+  '75%',
+  '100%',
+];
 
 export const OuiFlexItem: FunctionComponent<
   CommonProps &
@@ -108,9 +115,13 @@ export const OuiFlexItem: FunctionComponent<
       [`ouiFlexItem--flexGrow${grow}`]:
         typeof grow === 'number' ? GROW_SIZES.indexOf(grow) >= 0 : undefined,
       [`ouiFlexItem--flexShrink${shrink}`]:
-        typeof shrink === 'number' ? SHRINK_SIZES.indexOf(shrink) >= 0 : undefined,
+        typeof shrink === 'number'
+          ? SHRINK_SIZES.indexOf(shrink) >= 0
+          : undefined,
       [`ouiFlexItem--flexBasis${basis}`]:
-        typeof shrink === 'string' ? BASIS_VALUES.indexOf(shrink) >= 0 : undefined,
+        typeof shrink === 'string'
+          ? BASIS_VALUES.indexOf(shrink) >= 0
+          : undefined,
     },
     className
   );

--- a/src/components/flex/flex_item.tsx
+++ b/src/components/flex/flex_item.tsx
@@ -46,13 +46,43 @@ export type FlexItemGrowSize =
   | true
   | false
   | null;
+export type FlexItemShrinkSize =
+  | 1
+  | 2
+  | 3
+  | 4
+  | 5
+  | 6
+  | 7
+  | 8
+  | 9
+  | 10
+  | true
+  | false
+  | null;
+export type FlexItemBasisValue = string | true | false | null;
 
 export interface OuiFlexItemProps {
   grow?: FlexItemGrowSize;
+  shrink?: FlexItemShrinkSize;
+  basis?: FlexItemBasisValue;
   component?: keyof JSX.IntrinsicElements;
 }
 
 export const GROW_SIZES: FlexItemGrowSize[] = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
+export const SHRINK_SIZES: FlexItemShrinkSize[] = [
+  1,
+  2,
+  3,
+  4,
+  5,
+  6,
+  7,
+  8,
+  9,
+  10,
+];
+export const BASIS_VALUES:FlexItemBasisValue[] = ['auto','0%','25%','50%','75%','100%']
 
 export const OuiFlexItem: FunctionComponent<
   CommonProps &
@@ -61,11 +91,15 @@ export const OuiFlexItem: FunctionComponent<
 > = ({
   children,
   className,
-  grow = true,
+  grow = true, // default true -> keep grow 1 coming from flex_grid
+  shrink = 1, // default 1 for shrink
+  basis = 'auto', // default 'auto' basis
   component: Component = 'div',
   ...rest
 }) => {
   validateGrowValue(grow);
+  validateShrinkValue(shrink);
+  validateBasisValue(basis);
 
   const classes = classNames(
     'ouiFlexItem',
@@ -73,6 +107,10 @@ export const OuiFlexItem: FunctionComponent<
       'ouiFlexItem--flexGrowZero': !grow,
       [`ouiFlexItem--flexGrow${grow}`]:
         typeof grow === 'number' ? GROW_SIZES.indexOf(grow) >= 0 : undefined,
+      [`ouiFlexItem--flexShrink${shrink}`]:
+        typeof shrink === 'number' ? SHRINK_SIZES.indexOf(shrink) >= 0 : undefined,
+      [`ouiFlexItem--flexBasis${basis}`]:
+        typeof shrink === 'string' ? BASIS_VALUES.indexOf(shrink) >= 0 : undefined,
     },
     className
   );
@@ -91,6 +129,29 @@ function validateGrowValue(value: OuiFlexItemProps['grow']) {
   if (validValues.indexOf(value) === -1) {
     throw new Error(
       `Prop \`grow\` passed to \`OuiFlexItem\` must be a boolean or an integer between 1 and 10, received \`${value}\``
+    );
+  }
+}
+
+function validateShrinkValue(value: OuiFlexItemProps['shrink']) {
+  // New function
+  const validValues = [null, undefined, true, false, ...SHRINK_SIZES];
+
+  if (validValues.indexOf(value) === -1) {
+    throw new Error(
+      `Prop \`shrink\` passed to \`OuiFlexItem\` must be a boolean or an integer between 1 and 10, received \`${value}\``
+    );
+  }
+}
+
+function validateBasisValue(value: OuiFlexItemProps['basis']) {
+  // Define the valid values for 'flex-basis'. These can be 'auto' or specific percentages.
+  const validValues = [null, undefined, true, false, ...BASIS_VALUES];
+
+  // Check if the passed value is one of the valid values.
+  if (!validValues.includes(value)) {
+    throw new Error(
+      `Prop \`basis\` passed to \`OuiFlexItem\` must be one of ['auto', '0%', '25%', '50%', '75%', '100%'], received \`${value}\``
     );
   }
 }

--- a/src/components/flex/flex_item.tsx
+++ b/src/components/flex/flex_item.tsx
@@ -84,11 +84,9 @@ export const SHRINK_SIZES: FlexItemShrinkSize[] = [
 ];
 export const BASIS_VALUES: FlexItemBasisValue[] = [
   'auto',
-  '0%',
-  '25%',
-  '50%',
-  '75%',
-  '100%',
+  'max-content',
+  'min-content',
+  'fit-content',
 ];
 
 export const OuiFlexItem: FunctionComponent<
@@ -112,6 +110,7 @@ export const OuiFlexItem: FunctionComponent<
     'ouiFlexItem',
     {
       'ouiFlexItem--flexGrowZero': !grow,
+      'ouiFlexItem--flexShrinkZero': !shrink,
       [`ouiFlexItem--flexGrow${grow}`]:
         typeof grow === 'number' ? GROW_SIZES.indexOf(grow) >= 0 : undefined,
       [`ouiFlexItem--flexShrink${shrink}`]:


### PR DESCRIPTION
### Description
Props `shrink` and `basis` have been added for OuiFlexItem. Behaviour similar to `grow` prop. Accepted values:

- `shrink`: true, false, null, 1..10
- `basis`: true, false, null, 'auto', 'max-content', 'min-content', 'fit-content',

### Issues Resolved
Fixes issue #776 

### Check List
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
- [x] All tests pass
  - [x] `yarn lint`
  - [x] `yarn test-unit`
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/oui/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
