### PR TITLE
[Fix] Theme selector incorrectly focus on first item after selection

### DIFF
--- a/src-docs/src/components/guide_version_selector/guide_version_selector.tsx
+++ b/src-docs/src/components/guide_version_selector/guide_version_selector.tsx
@@ -78,7 +78,7 @@ export const GuideVersionSelector: FunctionComponent<GuideVersionSelectorProps> 
           href={`/${option}`}
           onClick={onChange(option)}>
           <OuiFlexGroup direction="row" wrap={false}>
-            <OuiFlexItem>v{option}</OuiFlexItem>
+            <OuiFlexItem>{option}</OuiFlexItem>
             {i === 0 && (
               <OuiFlexItem>
                 <OuiBadge>Latest</OuiBadge>

--- a/src/components/basic_table/__snapshots__/collapsed_item_actions.test.tsx.snap
+++ b/src/components/basic_table/__snapshots__/collapsed_item_actions.test.tsx.snap
@@ -45,7 +45,7 @@ exports[`CollapsedItemActions render with href and _target provided 1`] = `
   hasArrow={true}
   id="id-actions"
   isOpen={true}
-  ownFocus={true}
+  ownFocus={false}
   panelPaddingSize="none"
   popoverRef={[Function]}
 >

--- a/src/components/basic_table/__snapshots__/in_memory_table.test.tsx.snap
+++ b/src/components/basic_table/__snapshots__/in_memory_table.test.tsx.snap
@@ -380,75 +380,84 @@ exports[`OuiInMemoryTable behavior pagination 1`] = `
                       display="inlineBlock"
                       hasArrow={true}
                       isOpen={false}
-                      ownFocus={true}
+                      ownFocus={false}
                       panelPaddingSize="none"
                     >
-                      <div
-                        className="ouiPopover ouiPopover--anchorUpRight"
+                      <OuiOutsideClickDetector
+                        onOutsideClick={[Function]}
                       >
                         <div
-                          className="ouiPopover__anchor"
+                          className="ouiPopover ouiPopover--anchorUpRight"
+                          onKeyDown={[Function]}
+                          onMouseDown={[Function]}
+                          onMouseUp={[Function]}
+                          onTouchEnd={[Function]}
+                          onTouchStart={[Function]}
                         >
-                          <OuiButtonEmpty
-                            color="text"
-                            data-test-subj="tablePaginationPopoverButton"
-                            iconSide="right"
-                            iconType="arrowDown"
-                            onClick={[Function]}
-                            size="xs"
+                          <div
+                            className="ouiPopover__anchor"
                           >
-                            <button
-                              className="ouiButtonEmpty ouiButtonEmpty--text ouiButtonEmpty--xSmall"
+                            <OuiButtonEmpty
+                              color="text"
                               data-test-subj="tablePaginationPopoverButton"
-                              disabled={false}
+                              iconSide="right"
+                              iconType="arrowDown"
                               onClick={[Function]}
-                              type="button"
+                              size="xs"
                             >
-                              <OuiButtonContent
-                                className="ouiButtonEmpty__content"
-                                iconSide="right"
-                                iconSize="s"
-                                iconType="arrowDown"
-                                textProps={
-                                  Object {
-                                    "className": "ouiButtonEmpty__text",
-                                  }
-                                }
+                              <button
+                                className="ouiButtonEmpty ouiButtonEmpty--text ouiButtonEmpty--xSmall"
+                                data-test-subj="tablePaginationPopoverButton"
+                                disabled={false}
+                                onClick={[Function]}
+                                type="button"
                               >
-                                <span
-                                  className="ouiButtonContent ouiButtonContent--iconRight ouiButtonEmpty__content"
+                                <OuiButtonContent
+                                  className="ouiButtonEmpty__content"
+                                  iconSide="right"
+                                  iconSize="s"
+                                  iconType="arrowDown"
+                                  textProps={
+                                    Object {
+                                      "className": "ouiButtonEmpty__text",
+                                    }
+                                  }
                                 >
-                                  <OuiIcon
-                                    className="ouiButtonContent__icon"
-                                    color="inherit"
-                                    size="s"
-                                    type="arrowDown"
+                                  <span
+                                    className="ouiButtonContent ouiButtonContent--iconRight ouiButtonEmpty__content"
                                   >
-                                    <span
+                                    <OuiIcon
                                       className="ouiButtonContent__icon"
                                       color="inherit"
-                                      data-ouiicon-type="arrowDown"
                                       size="s"
-                                    />
-                                  </OuiIcon>
-                                  <span
-                                    className="ouiButtonEmpty__text"
-                                  >
-                                    <OuiI18n
-                                      default="Rows per page"
-                                      token="ouiTablePagination.rowsPerPage"
+                                      type="arrowDown"
                                     >
-                                      Rows per page
-                                    </OuiI18n>
-                                    : 
-                                    2
+                                      <span
+                                        className="ouiButtonContent__icon"
+                                        color="inherit"
+                                        data-ouiicon-type="arrowDown"
+                                        size="s"
+                                      />
+                                    </OuiIcon>
+                                    <span
+                                      className="ouiButtonEmpty__text"
+                                    >
+                                      <OuiI18n
+                                        default="Rows per page"
+                                        token="ouiTablePagination.rowsPerPage"
+                                      >
+                                        Rows per page
+                                      </OuiI18n>
+                                      : 
+                                      2
+                                    </span>
                                   </span>
-                                </span>
-                              </OuiButtonContent>
-                            </button>
-                          </OuiButtonEmpty>
+                                </OuiButtonContent>
+                              </button>
+                            </OuiButtonEmpty>
+                          </div>
                         </div>
-                      </div>
+                      </OuiOutsideClickDetector>
                     </OuiPopover>
                   </div>
                 </OuiFlexItem>

--- a/src/components/date_picker/super_date_picker/quick_select_popover/__snapshots__/quick_select_popover.test.tsx.snap
+++ b/src/components/date_picker/super_date_picker/quick_select_popover/__snapshots__/quick_select_popover.test.tsx.snap
@@ -29,7 +29,7 @@ exports[`OuiQuickSelectPopover is rendered 1`] = `
   display="inlineBlock"
   hasArrow={true}
   isOpen={false}
-  ownFocus={true}
+  ownFocus={false}
   panelPaddingSize="m"
 >
   <div
@@ -113,7 +113,7 @@ exports[`OuiQuickSelectPopover isAutoRefreshOnly 1`] = `
   display="inlineBlock"
   hasArrow={true}
   isOpen={false}
-  ownFocus={true}
+  ownFocus={false}
   panelPaddingSize="m"
 >
   <div

--- a/src/components/popover/__snapshots__/popover.test.tsx.snap
+++ b/src/components/popover/__snapshots__/popover.test.tsx.snap
@@ -104,14 +104,11 @@ exports[`OuiPopover props arrowChildren is rendered 1`] = `
       data-focus-lock-disabled="disabled"
     >
       <div
-        aria-describedby="generated-id"
-        aria-live="off"
+        aria-live="assertive"
         aria-modal="true"
         class="ouiPanel ouiPanel--paddingMedium ouiPanel--borderRadiusMedium ouiPanel--plain ouiPanel--noShadow ouiPopover__panel ouiPopover__panel--bottom ouiPopover__panel-isOpen"
-        data-autofocus="true"
         role="dialog"
         style="top: 16px; left: -22px; will-change: transform, opacity; z-index: 2000;"
-        tabindex="0"
       >
         <div
           class="ouiPopover__panelArrow ouiPopover__panelArrow--bottom"
@@ -119,12 +116,6 @@ exports[`OuiPopover props arrowChildren is rendered 1`] = `
         >
           <span />
         </div>
-        <p
-          class="ouiScreenReaderOnly"
-          id="generated-id"
-        >
-          You are in a dialog. To close this dialog, hit escape.
-        </p>
         <div />
       </div>
     </div>
@@ -162,25 +153,16 @@ exports[`OuiPopover props buffer 1`] = `
       data-focus-lock-disabled="disabled"
     >
       <div
-        aria-describedby="generated-id"
-        aria-live="off"
+        aria-live="assertive"
         aria-modal="true"
         class="ouiPanel ouiPanel--paddingMedium ouiPanel--borderRadiusMedium ouiPanel--plain ouiPanel--noShadow ouiPopover__panel ouiPopover__panel--bottom ouiPopover__panel-isOpen"
-        data-autofocus="true"
         role="dialog"
         style="top: 16px; left: -22px; will-change: transform, opacity; z-index: 2000;"
-        tabindex="0"
       >
         <div
           class="ouiPopover__panelArrow ouiPopover__panelArrow--bottom"
           style="left: 10px; top: 0px;"
         />
-        <p
-          class="ouiScreenReaderOnly"
-          id="generated-id"
-        >
-          You are in a dialog. To close this dialog, hit escape.
-        </p>
         <div />
       </div>
     </div>
@@ -218,25 +200,16 @@ exports[`OuiPopover props buffer for all sides 1`] = `
       data-focus-lock-disabled="disabled"
     >
       <div
-        aria-describedby="generated-id"
-        aria-live="off"
+        aria-live="assertive"
         aria-modal="true"
         class="ouiPanel ouiPanel--paddingMedium ouiPanel--borderRadiusMedium ouiPanel--plain ouiPanel--noShadow ouiPopover__panel ouiPopover__panel--bottom ouiPopover__panel-isOpen"
-        data-autofocus="true"
         role="dialog"
         style="top: 16px; left: -22px; will-change: transform, opacity; z-index: 2000;"
-        tabindex="0"
       >
         <div
           class="ouiPopover__panelArrow ouiPopover__panelArrow--bottom"
           style="left: 10px; top: 0px;"
         />
-        <p
-          class="ouiScreenReaderOnly"
-          id="generated-id"
-        >
-          You are in a dialog. To close this dialog, hit escape.
-        </p>
         <div />
       </div>
     </div>
@@ -287,25 +260,16 @@ exports[`OuiPopover props focusTrapProps is rendered 1`] = `
       data-focus-lock-disabled="disabled"
     >
       <div
-        aria-describedby="generated-id"
-        aria-live="off"
+        aria-live="assertive"
         aria-modal="true"
         class="ouiPanel ouiPanel--paddingMedium ouiPanel--borderRadiusMedium ouiPanel--plain ouiPanel--noShadow ouiPopover__panel ouiPopover__panel--bottom ouiPopover__panel-isOpen"
-        data-autofocus="true"
         role="dialog"
         style="top: 16px; left: -22px; will-change: transform, opacity; z-index: 2000;"
-        tabindex="0"
       >
         <div
           class="ouiPopover__panelArrow ouiPopover__panelArrow--bottom"
           style="left: 10px; top: 0px;"
         />
-        <p
-          class="ouiScreenReaderOnly"
-          id="generated-id"
-        >
-          You are in a dialog. To close this dialog, hit escape.
-        </p>
         <div />
       </div>
     </div>
@@ -356,25 +320,16 @@ exports[`OuiPopover props isOpen renders true 1`] = `
       data-focus-lock-disabled="disabled"
     >
       <div
-        aria-describedby="generated-id"
-        aria-live="off"
+        aria-live="assertive"
         aria-modal="true"
         class="ouiPanel ouiPanel--paddingMedium ouiPanel--borderRadiusMedium ouiPanel--plain ouiPanel--noShadow ouiPopover__panel ouiPopover__panel--bottom ouiPopover__panel-isOpen"
-        data-autofocus="true"
         role="dialog"
         style="top: 16px; left: -22px; will-change: transform, opacity; z-index: 2000;"
-        tabindex="0"
       >
         <div
           class="ouiPopover__panelArrow ouiPopover__panelArrow--bottom"
           style="left: 10px; top: 0px;"
         />
-        <p
-          class="ouiScreenReaderOnly"
-          id="generated-id"
-        >
-          You are in a dialog. To close this dialog, hit escape.
-        </p>
         <div />
       </div>
     </div>
@@ -413,25 +368,16 @@ exports[`OuiPopover props offset with arrow 1`] = `
       data-focus-lock-disabled="disabled"
     >
       <div
-        aria-describedby="generated-id"
-        aria-live="off"
+        aria-live="assertive"
         aria-modal="true"
         class="ouiPanel ouiPanel--paddingMedium ouiPanel--borderRadiusMedium ouiPanel--plain ouiPanel--noShadow ouiPopover__panel ouiPopover__panel--bottom ouiPopover__panel-isOpen"
-        data-autofocus="true"
         role="dialog"
         style="top: 26px; left: -22px; will-change: transform, opacity; z-index: 2000;"
-        tabindex="0"
       >
         <div
           class="ouiPopover__panelArrow ouiPopover__panelArrow--bottom"
           style="left: 10px; top: 0px;"
         />
-        <p
-          class="ouiScreenReaderOnly"
-          id="generated-id"
-        >
-          You are in a dialog. To close this dialog, hit escape.
-        </p>
         <div />
       </div>
     </div>
@@ -470,24 +416,15 @@ exports[`OuiPopover props offset without arrow 1`] = `
       data-focus-lock-disabled="disabled"
     >
       <div
-        aria-describedby="generated-id"
-        aria-live="off"
+        aria-live="assertive"
         aria-modal="true"
         class="ouiPanel ouiPanel--paddingMedium ouiPanel--borderRadiusMedium ouiPanel--plain ouiPanel--noShadow ouiPopover__panel ouiPopover__panel--bottom ouiPopover__panel-isOpen ouiPopover__panel-noArrow"
-        data-autofocus="true"
         role="dialog"
         style="top: 18px; left: -22px; will-change: transform, opacity; z-index: 2000;"
-        tabindex="0"
       >
         <div
           class="ouiPopover__panelArrow ouiPopover__panelArrow--bottom"
         />
-        <p
-          class="ouiScreenReaderOnly"
-          id="generated-id"
-        >
-          You are in a dialog. To close this dialog, hit escape.
-        </p>
         <div />
       </div>
     </div>
@@ -525,25 +462,16 @@ exports[`OuiPopover props ownFocus defaults to true 1`] = `
       data-focus-lock-disabled="disabled"
     >
       <div
-        aria-describedby="generated-id"
-        aria-live="off"
+        aria-live="assertive"
         aria-modal="true"
         class="ouiPanel ouiPanel--paddingMedium ouiPanel--borderRadiusMedium ouiPanel--plain ouiPanel--noShadow ouiPopover__panel ouiPopover__panel--bottom ouiPopover__panel-isOpen"
-        data-autofocus="true"
         role="dialog"
         style="top: 16px; left: -22px; will-change: transform, opacity; z-index: 2000;"
-        tabindex="0"
       >
         <div
           class="ouiPopover__panelArrow ouiPopover__panelArrow--bottom"
           style="left: 10px; top: 0px;"
         />
-        <p
-          class="ouiScreenReaderOnly"
-          id="generated-id"
-        >
-          You are in a dialog. To close this dialog, hit escape.
-        </p>
         <div />
       </div>
     </div>
@@ -628,25 +556,16 @@ exports[`OuiPopover props panelClassName is rendered 1`] = `
       data-focus-lock-disabled="disabled"
     >
       <div
-        aria-describedby="generated-id"
-        aria-live="off"
+        aria-live="assertive"
         aria-modal="true"
         class="ouiPanel ouiPanel--paddingMedium ouiPanel--borderRadiusMedium ouiPanel--plain ouiPanel--noShadow ouiPopover__panel ouiPopover__panel--bottom ouiPopover__panel-isOpen test"
-        data-autofocus="true"
         role="dialog"
         style="top: 16px; left: -22px; will-change: transform, opacity; z-index: 2000;"
-        tabindex="0"
       >
         <div
           class="ouiPopover__panelArrow ouiPopover__panelArrow--bottom"
           style="left: 10px; top: 0px;"
         />
-        <p
-          class="ouiScreenReaderOnly"
-          id="generated-id"
-        >
-          You are in a dialog. To close this dialog, hit escape.
-        </p>
         <div />
       </div>
     </div>
@@ -684,25 +603,16 @@ exports[`OuiPopover props panelPaddingSize is rendered 1`] = `
       data-focus-lock-disabled="disabled"
     >
       <div
-        aria-describedby="generated-id"
-        aria-live="off"
+        aria-live="assertive"
         aria-modal="true"
         class="ouiPanel ouiPanel--paddingSmall ouiPanel--borderRadiusMedium ouiPanel--plain ouiPanel--noShadow ouiPopover__panel ouiPopover__panel--bottom ouiPopover__panel-isOpen"
-        data-autofocus="true"
         role="dialog"
         style="top: 16px; left: -22px; will-change: transform, opacity; z-index: 2000;"
-        tabindex="0"
       >
         <div
           class="ouiPopover__panelArrow ouiPopover__panelArrow--bottom"
           style="left: 10px; top: 0px;"
         />
-        <p
-          class="ouiScreenReaderOnly"
-          id="generated-id"
-        >
-          You are in a dialog. To close this dialog, hit escape.
-        </p>
         <div />
       </div>
     </div>
@@ -740,26 +650,17 @@ exports[`OuiPopover props panelProps is rendered 1`] = `
       data-focus-lock-disabled="disabled"
     >
       <div
-        aria-describedby="generated-id"
-        aria-live="off"
+        aria-live="assertive"
         aria-modal="true"
         class="ouiPanel ouiPanel--paddingMedium ouiPanel--borderRadiusMedium ouiPanel--plain ouiPanel--noShadow ouiPopover__panel ouiPopover__panel--bottom ouiPopover__panel-isOpen testClass1 testClass2"
-        data-autofocus="true"
         data-test-subj="test subject string"
         role="dialog"
         style="top: 16px; left: -22px; will-change: transform, opacity; z-index: 2000;"
-        tabindex="0"
       >
         <div
           class="ouiPopover__panelArrow ouiPopover__panelArrow--bottom"
           style="left: 10px; top: 0px;"
         />
-        <p
-          class="ouiScreenReaderOnly"
-          id="generated-id"
-        >
-          You are in a dialog. To close this dialog, hit escape.
-        </p>
         <div />
       </div>
     </div>

--- a/src/components/popover/popover.tsx
+++ b/src/components/popover/popover.tsx
@@ -333,7 +333,7 @@ type PropsWithDefaults = Props & {
 export class OuiPopover extends Component<Props, State> {
   static defaultProps: Partial<PropsWithDefaults> = {
     isOpen: false,
-    ownFocus: true,
+    ownFocus: false,
     anchorPosition: 'downCenter',
     panelPaddingSize: 'm',
     hasArrow: true,

--- a/src/components/search_bar/filters/__snapshots__/field_value_selection_filter.test.tsx.snap
+++ b/src/components/search_bar/filters/__snapshots__/field_value_selection_filter.test.tsx.snap
@@ -20,7 +20,7 @@ exports[`FieldValueSelectionFilter active - field is global 1`] = `
   hasArrow={true}
   id="field_value_selection_0"
   isOpen={false}
-  ownFocus={true}
+  ownFocus={false}
   panelClassName="ouiFilterGroup__popoverPanel"
   panelPaddingSize="none"
 >
@@ -63,7 +63,7 @@ exports[`FieldValueSelectionFilter active - fields in options 1`] = `
   hasArrow={true}
   id="field_value_selection_0"
   isOpen={false}
-  ownFocus={true}
+  ownFocus={false}
   panelClassName="ouiFilterGroup__popoverPanel"
   panelPaddingSize="none"
 >
@@ -106,7 +106,7 @@ exports[`FieldValueSelectionFilter inactive - field is global 1`] = `
   hasArrow={true}
   id="field_value_selection_0"
   isOpen={false}
-  ownFocus={true}
+  ownFocus={false}
   panelClassName="ouiFilterGroup__popoverPanel"
   panelPaddingSize="none"
 >
@@ -162,7 +162,7 @@ exports[`FieldValueSelectionFilter inactive - fields in options 1`] = `
   hasArrow={true}
   id="field_value_selection_0"
   isOpen={false}
-  ownFocus={true}
+  ownFocus={false}
   panelClassName="ouiFilterGroup__popoverPanel"
   panelPaddingSize="none"
 >
@@ -218,7 +218,7 @@ exports[`FieldValueSelectionFilter render - all configurations 1`] = `
   hasArrow={true}
   id="field_value_selection_0"
   isOpen={false}
-  ownFocus={true}
+  ownFocus={false}
   panelClassName="ouiFilterGroup__popoverPanel"
   panelPaddingSize="none"
 >
@@ -261,7 +261,7 @@ exports[`FieldValueSelectionFilter render - fields in options 1`] = `
   hasArrow={true}
   id="field_value_selection_0"
   isOpen={false}
-  ownFocus={true}
+  ownFocus={false}
   panelClassName="ouiFilterGroup__popoverPanel"
   panelPaddingSize="none"
 >
@@ -317,7 +317,7 @@ exports[`FieldValueSelectionFilter render - multi-select OR 1`] = `
   hasArrow={true}
   id="field_value_selection_0"
   isOpen={false}
-  ownFocus={true}
+  ownFocus={false}
   panelClassName="ouiFilterGroup__popoverPanel"
   panelPaddingSize="none"
 >
@@ -360,7 +360,7 @@ exports[`FieldValueSelectionFilter render - options as a function 1`] = `
   hasArrow={true}
   id="field_value_selection_0"
   isOpen={false}
-  ownFocus={true}
+  ownFocus={false}
   panelClassName="ouiFilterGroup__popoverPanel"
   panelPaddingSize="none"
 >
@@ -403,7 +403,7 @@ exports[`FieldValueSelectionFilter render - options as an array 1`] = `
   hasArrow={true}
   id="field_value_selection_0"
   isOpen={false}
-  ownFocus={true}
+  ownFocus={false}
   panelClassName="ouiFilterGroup__popoverPanel"
   panelPaddingSize="none"
 >


### PR DESCRIPTION
### Description

This PR removes the initial focusing state when opening up the theme selector popup.

### Issues Resolved
Fixes #1163 

### Demo
#### Before

https://github.com/opensearch-project/oui/assets/65143821/c15db0c1-fd19-48d9-a458-cab4642d459d

#### After

https://github.com/opensearch-project/oui/assets/65143821/6326c9d9-db29-45a0-87ef-fbcc2703195d

### Misc

Also fix a typo in `guide_version_selector.tsx`.

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] All tests pass
  - [ ] `yarn lint`
  - [ ] `yarn test-unit`
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff
