### PR TITLE
Skip build and test on dependabot

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -2,7 +2,7 @@ name: Build and test
 
 on:
   push:
-    branches: ['**', '!backport/**', '!whitesource-remediate/**']
+    branches: ['**', '!backport/**', '!dependabot/**', '!whitesource-remediate/**']
     paths-ignore:
       - '**/*.md'
   pull_request:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 ### 🚞 Infrastructure
 
 - Add integration test with OSD workflows ([#1017](https://github.com/opensearch-project/oui/pull/1017))
+- Skip build and test workflows on dependabot PR ([#1170](https://github.com/opensearch-project/oui/pull/1170))
 
 ### 📝 Documentation
 


### PR DESCRIPTION
### Description
Skip depedabot PR runs on push. This prevents duplicated runs in dependabot PRs, as they run on PR as well.

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [x] All tests pass
  - [x] `yarn lint`
  - [x] `yarn test-unit`
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/oui/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
