### PR TITLE
[Enhance] Add Explanation for external Prop in OuiLink

### DIFF
--- a/src-docs/src/views/link/link.js
+++ b/src-docs/src/views/link/link.js
@@ -11,7 +11,7 @@
 
 import React from 'react';
 
-import { OuiCode, OuiLink, OuiText } from '../../../../src/components';
+import { OuiCode, OuiLink, OuiText, OuiIcon } from '../../../../src/components';
 
 export default () => (
   <OuiText>
@@ -28,7 +28,9 @@ export default () => (
       <OuiLink href="https://oui.opensearch.org/latest/" external>
         link
       </OuiLink>{' '}
-      has the <OuiCode>external</OuiCode> prop set to true.
+      has the <OuiCode>external</OuiCode> prop set to true. A pop-out icon{' '}
+      <OuiIcon type="popout" size="s" /> will be automatically rendered to
+      indicate that it leads to an external resource.
     </p>
     <p>
       This link is actually a <OuiLink onClick={() => {}}>button</OuiLink> with


### PR DESCRIPTION
### Description

This PR updates the documentation to include a clearer explanation of the `external` prop in the `OuiLink` component. The modification explicitly describes the automatic rendering of a `pop-out` icon when the external prop is set to true, enhancing the documentation's clarity.

### Issues Resolved

See the discussion here: https://github.com/opensearch-project/OpenSearch-Dashboards/pull/5511

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] All tests pass
  - [ ] `yarn lint`
  - [ ] `yarn test-unit`
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/oui/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
