### PR TITLE
Eliminate screenreader content when copying and pasting data grid table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 - Implement validation for icon input source & set default icon to `Beaker` ([#1137](https://github.com/opensearch-project/oui/pull/1137))
 - Add `Docking` icons ([#1041](https://github.com/opensearch-project/oui/pull/1041))
 - Add SplitButton control ([#1193](https://github.com/opensearch-project/oui/pull/1193))
+- Eliminate screenreader content when copying and pasting data grid table ([#1198](https://github.com/opensearch-project/oui/pull/1198))
 
 ### 🐛 Bug Fixes
 

--- a/src/global_styling/mixins/_helpers.scss
+++ b/src/global_styling/mixins/_helpers.scss
@@ -114,6 +114,7 @@
   width: 1px;
   height: 1px;
   overflow: hidden;
+  user-select: none;
 }
 
 // Specifically target IE11, but not Edge.

--- a/src/themes/oui-next/global_styling/mixins/_helpers.scss
+++ b/src/themes/oui-next/global_styling/mixins/_helpers.scss
@@ -114,6 +114,7 @@
   width: 1px;
   height: 1px;
   overflow: hidden;
+  user-select: none;
 }
 
 // Specifically target IE11, but not Edge.


### PR DESCRIPTION
### Description
Eliminate the extra "Row # Column #" when selecting data grid table and pasting.

### Issues Resolved
resolves https://github.com/opensearch-project/OpenSearch-Dashboards/issues/5570

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] All tests pass
  - [ ] `yarn lint`
  - [ ] `yarn test-unit`
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/oui/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
