### PR TITLE
Fix version selector for parity with previous version

### DIFF
--- a/src-docs/src/components/guide_version_selector/guide_version_selector.tsx
+++ b/src-docs/src/components/guide_version_selector/guide_version_selector.tsx
@@ -45,7 +45,7 @@ export const GuideVersionSelector: FunctionComponent<GuideVersionSelectorProps> 
 
       closePopover();
       setSelectedOption(value);
-      window.location.href = `/${value}`;
+      window.location.href = `/${value}/`;
     },
     []
   );
@@ -57,14 +57,17 @@ export const GuideVersionSelector: FunctionComponent<GuideVersionSelectorProps> 
 
     fetch('/versions.json')
       .then((response) => {
-        if (!response.ok) {
-          return Promise.reject(response.text());
-        }
+        return new Promise((resolve, reject) => {
+          if (!response.ok) {
+            response.text().then(reject);
+            return;
+          }
 
-        return response.json();
+          response.json().then(resolve);
+        });
       })
-      .then((branches: string[]) => {
-        setOptions(branches);
+      .then((branches) => {
+        setOptions(branches as string[]);
       })
       .catch(console.error);
   }, [isLocalDev]);
@@ -75,7 +78,7 @@ export const GuideVersionSelector: FunctionComponent<GuideVersionSelectorProps> 
         <OuiContextMenuItem
           key={option}
           icon={option === selectedOption ? 'check' : 'empty'}
-          href={`/${option}`}
+          href={`/${option}/`}
           onClick={onChange(option)}>
           <OuiFlexGroup direction="row" wrap={false}>
             <OuiFlexItem>v{option}</OuiFlexItem>


### PR DESCRIPTION
### Description
The current version selector navigates to `<url>/<version>` instead of `<url>/<version>/`. The trailing `/` is necessary to navigate to the correct version. Currently, if you try navigating to a different version on https://oui.opensearch.org/1.4/, it won't change the version.

Additionally, I made a change to the way the response promise is handled to properly handle case where there is an error with the fetch.

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [x] All tests pass
  - [x] `yarn lint`
  - [x] `yarn test-unit`
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/oui/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
