### PR TITLE
[Next Theme] Set base font size to 18px

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 - Add `Docking` icons ([#1041](https://github.com/opensearch-project/oui/pull/1041))
 - Add SplitButton control ([#1193](https://github.com/opensearch-project/oui/pull/1193))
 - Eliminate screenreader content when copying and pasting data grid table ([#1198](https://github.com/opensearch-project/oui/pull/1198))
+- [Next Theme] Set base font size to 18px ([#1221](https://github.com/opensearch-project/oui/pull/1221))
 
 ### 🐛 Bug Fixes
 

--- a/src/components/suggest/_suggest_item.scss
+++ b/src/components/suggest/_suggest_item.scss
@@ -62,7 +62,7 @@
 
   .ouiSuggestItem__label {
     @include ouiTextTruncate;
-    font-family: var(--oui-code-font-family);
+    @include ouiCodeFont;
     overflow: hidden;
     text-overflow: ellipsis;
     padding: $ouiSizeXS $ouiSizeS;

--- a/src/themes/oui-next/global_styling/mixins/_typography.scss
+++ b/src/themes/oui-next/global_styling/mixins/_typography.scss
@@ -25,6 +25,7 @@
 @mixin ouiCodeFont {
   font-family: var(--oui-code-font-family);
   letter-spacing: normal;
+  line-height: 1.5;
 }
 
 @mixin ouiText {
@@ -84,7 +85,7 @@
       #{$property}: $value;
     }
   }
-  line-height: 1.25;
+  line-height: 1.111111;
 }
 
 @mixin ouiFontSizeXXL {
@@ -95,7 +96,7 @@
       #{$property}: $value;
     }
   }
-  line-height: 1.25;
+  line-height: 1.111111;
 }
 
 @mixin ouiTextBreakWord {

--- a/src/themes/oui-next/global_styling/reset/_reset.scss
+++ b/src/themes/oui-next/global_styling/reset/_reset.scss
@@ -42,6 +42,8 @@ time, mark, audio, video {
 
 code, pre, kbd, samp {
   font-family: var(--oui-code-font-family);
+  font-size: 16px;
+  line-height: 1.5;
 }
 
 h1, h2, h3, h4, h5, h6, p {

--- a/src/themes/oui-next/global_styling/variables/_typography.scss
+++ b/src/themes/oui-next/global_styling/variables/_typography.scss
@@ -29,8 +29,10 @@
 // EX: A proper line-height for text is 1.5 times the font-size.
 //     If our base font size (ouiFontSize) is 16, our baseline is 8 (16*1.5 / 3). To ensure the
 //     text stays on the baseline, we pass a multiplier to calculate a line-height in rems.
+// To maintain v7 line-heights, $ouiFontSize is replaced with 16px
 @function lineHeightFromBaseline($multiplier: 3) {
-  @return convertToRem(calc($ouiFontSize/2)*$multiplier);
+  @return convertToRem(calc(16px/2)*$multiplier);
+  //@return convertToRem(calc($ouiFontSize/2)*$multiplier);
 }
 @mixin lineHeightFromBaseline($multiplier: 3) {
   line-height: lineHeightFromBaseline($multiplier);
@@ -47,7 +49,7 @@ $ouiFontFeatureSettings: 'calt' 1, 'kern' 1, 'liga' 1 !default;
 // Font sizes -- scale is loosely based on Major Third (1.250)
 $ouiTextScale:      2.25, 1.75, 1.25, 1.125, 1, .875, .75 !default;
 
-$ouiFontSize:       $ouiSize !default; // 5th position in scale
+$ouiFontSize:       18px !default; // 5th position in scale
 $ouiFontSizeXS:     $ouiFontSize * nth($ouiTextScale, 7) !default; // 12px
 $ouiFontSizeS:      $ouiFontSize * nth($ouiTextScale, 6) !default; // 14px
 $ouiFontSizeM:      $ouiFontSize * nth($ouiTextScale, 4) !default; // 18px
@@ -56,7 +58,7 @@ $ouiFontSizeXL:     $ouiFontSize * nth($ouiTextScale, 2) !default; // 28px
 $ouiFontSizeXXL:    $ouiFontSize * nth($ouiTextScale, 1) !default; // 36px
 
 // Line height
-$ouiLineHeight:     1.5 !default;
+$ouiLineHeight:     1.333333 !default;
 $ouiBodyLineHeight: 1 !default;
 
 // Font weights


### PR DESCRIPTION
### Description
Since the text font for the Next theme has a smaller appearance, a larger font-size is employed.

PS, this will probably need some followups to fine tune other areas.

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] All tests pass
  - [ ] `yarn lint`
  - [ ] `yarn test-unit`
- [x] Update [CHANGELOG.md](./../CHANGELOG.md)
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/oui/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
