### PR TITLE
[Next Theme] Revert `font-weight` of OuiButton to normal from semi-bold

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 - Add `Docking` icons ([#1041](https://github.com/opensearch-project/oui/pull/1041))
 - Add SplitButton control ([#1193](https://github.com/opensearch-project/oui/pull/1193))
 - Eliminate screenreader content when copying and pasting data grid table ([#1198](https://github.com/opensearch-project/oui/pull/1198))
+- [Next Theme] Revert `font-weight` of OuiButton to normal from semi-bold ([#1222](https://github.com/opensearch-project/oui/pull/1222))
 
 ### 🐛 Bug Fixes
 

--- a/src/themes/oui-next/global_styling/mixins/_button.scss
+++ b/src/themes/oui-next/global_styling/mixins/_button.scss
@@ -51,7 +51,7 @@
 
   text-decoration: none;
   border: solid 1px transparent;
-  font-weight: 600;
+  font-weight: 400;
 
   // sass-lint:disable mixins-before-declarations
   // focus states should come after all default styles


### PR DESCRIPTION
[Next Theme] Revert `font-weight` of OuiButton to normal from semi-bold

* The larger font-size eliminates the need for bolder text

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] All tests pass
  - [ ] `yarn lint`
  - [ ] `yarn test-unit`
- [X] Update [CHANGELOG.md](./../CHANGELOG.md)
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/oui/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
