### PR TITLE
Prevent collapsable button of a resizable from adding to the height when hidden

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@
 - Fix "Guidelines" documentation links rendering blank pages ([#1111](https://github.com/opensearch-project/oui/pull/1111))
 - Fix bug in OuiButtonContent for showing info tooltip in icon-only buttons when hovered([#1160](https://github.com/opensearch-project/oui/pull/1160))
 - Fix playground support check ([#1162](https://github.com/opensearch-project/oui/pull/1162))
+- Prevent collapsable button of a resizable from adding to the height when hidden ([#1223](https://github.com/opensearch-project/oui/pull/1223))
 
 ### 🚞 Infrastructure
 

--- a/src/components/resizable_container/_resizable_collapse_button.scss
+++ b/src/components/resizable_container/_resizable_collapse_button.scss
@@ -40,6 +40,7 @@
 
   &:not(:focus):not(:active):not(.ouiResizableToggleButton-isVisible):not(.ouiResizableToggleButton-isCollapsed) {
     @include ouiScreenReaderOnly;
+    margin: -2px; // To accomodate ouiButtonIcon's border
   }
 }
 


### PR DESCRIPTION
### Description
Prevent collapsable button of a resizable from adding to the height when hidden

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] All tests pass
  - [ ] `yarn lint`
  - [ ] `yarn test-unit`
- [X] Update [CHANGELOG.md](./../CHANGELOG.md)
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/oui/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
