### PR TITLE
Convert shorthand palette colors to full 6-char hex

### DIFF
--- a/.sass-lint.yml
+++ b/.sass-lint.yml
@@ -90,3 +90,5 @@ rules:
   no-warn: 0
   # Transition all is useful in certain situations and there's no recent info to suggest slowdown
   no-transition-all: 0
+
+  hex-length: 'long'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 - Eliminate screenreader content when copying and pasting data grid table ([#1198](https://github.com/opensearch-project/oui/pull/1198))
 - [Next Theme] Set base font size to 18px ([#1221](https://github.com/opensearch-project/oui/pull/1221))
 - [Next Theme] Revert `font-weight` of OuiButton to normal from semi-bold ([#1222](https://github.com/opensearch-project/oui/pull/1222))
+- Convert shorthand palette colors to full 6-char hex ([#1262](https://github.com/opensearch-project/oui/pull/1262))
 
 ### 🐛 Bug Fixes
 

--- a/src/services/color/oui_palettes.ts
+++ b/src/services/color/oui_palettes.ts
@@ -178,7 +178,7 @@ export const ouiPaletteForLightBackground = function (): OuiPalette {
 };
 
 export const ouiPaletteForDarkBackground = function (): OuiPalette {
-  return ['#1BA9F5', '#7DE2D1', '#F990C0', '#F66', '#FFCE7A'];
+  return ['#1BA9F5', '#7DE2D1', '#F990C0', '#FF6666', '#FFCE7A'];
 };
 
 const positiveColor: HEX = '#209280';

--- a/src/themes/oui-next/oui_next_colors_dark.scss
+++ b/src/themes/oui-next/oui_next_colors_dark.scss
@@ -23,7 +23,7 @@ $ouiColorAccent: #F990C0;
 // Status
 $ouiColorSuccess: $ouiColorSecondary;
 $ouiColorWarning: #FFCE7A;
-$ouiColorDanger: #F66;
+$ouiColorDanger: #FF6666;
 
 // Grays
 $ouiColorEmptyShade: #0A121A;

--- a/src/themes/oui/oui_colors_dark.scss
+++ b/src/themes/oui/oui_colors_dark.scss
@@ -23,7 +23,7 @@ $ouiColorAccent: #F990C0;
 // Status
 $ouiColorSuccess: $ouiColorSecondary;
 $ouiColorWarning: #FFCE7A;
-$ouiColorDanger: #F66;
+$ouiColorDanger: #FF6666;
 
 // Grays
 $ouiColorEmptyShade: #1D1E24;


### PR DESCRIPTION
### Description
Shorthand colors are not handled by nested deps and as a result we need to force all colors to be full hexes.

### Issues Resolved
https://github.com/opensearch-project/OpenSearch-Dashboards/issues/6243

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [X] All tests pass
  - [ ] `yarn lint`
  - [ ] `yarn test-unit`
- [x] Update [CHANGELOG.md](./../CHANGELOG.md)
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/oui/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
