### PR TITLE
feat: use consistent font sizes in buttons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 - [Next Theme] Set base font size to 18px ([#1221](https://github.com/opensearch-project/oui/pull/1221))
 - [Next Theme] Revert `font-weight` of OuiButton to normal from semi-bold ([#1222](https://github.com/opensearch-project/oui/pull/1222))
 - Convert shorthand palette colors to full 6-char hex ([#1262](https://github.com/opensearch-project/oui/pull/1262))
+- Use small font size consistently in buttons and button groups 
 
 ### 🐛 Bug Fixes
 

--- a/src/components/button/button_group/_button_group_button.scss
+++ b/src/components/button/button_group/_button_group_button.scss
@@ -12,7 +12,7 @@
 .ouiButtonGroupButton {
   @include ouiButtonBase;
   @include ouiFont;
-  @include ouiFontSize;
+  @include ouiFontSizeS;
 
   // sass-lint:disable-block indentation
   transition: background-color $ouiAnimSpeedNormal ease-in-out,

--- a/src/global_styling/mixins/_button.scss
+++ b/src/global_styling/mixins/_button.scss
@@ -47,7 +47,7 @@
 @mixin ouiButton {
   @include ouiButtonBase;
   @include ouiFont;
-  @include ouiFontSize;
+  @include ouiFontSizeS;
 
   text-decoration: none;
   border: solid 1px transparent;

--- a/src/themes/oui-next/global_styling/mixins/_button.scss
+++ b/src/themes/oui-next/global_styling/mixins/_button.scss
@@ -47,7 +47,7 @@
 @mixin ouiButton {
   @include ouiButtonBase;
   @include ouiFont;
-  @include ouiFontSize;
+  @include ouiFontSizeS;
 
   text-decoration: none;
   border: solid 1px transparent;


### PR DESCRIPTION
### Description
Sets font-size of buttons to use small font size by default, making the font size of buttons consistent across all buttons, and consistent across input sizes which they're commonly aligned with.

| Type | Before (v7light) | After (v7light) | Before (v8dark) | After (v8dark) |
| ------------- | ------------- | ------------- |  ------------- | ------------- |
| Normal |![image](https://github.com/opensearch-project/oui/assets/1366272/b06e89d1-8847-4dd4-8cc1-c6c79ddc1921) | ![image](https://github.com/opensearch-project/oui/assets/1366272/96d7eba9-9b96-4cdc-a0ec-e743905a9425)| ![image](https://github.com/opensearch-project/oui/assets/1366272/308048a2-5b05-4312-a1ea-fd8aa83db465) | ![image](https://github.com/opensearch-project/oui/assets/1366272/3a89f2f4-7433-4ece-aa4e-37a9babd9951)  |
| Empty |![image](https://github.com/opensearch-project/oui/assets/1366272/0026af41-018b-46bd-8933-999411a55d41) |![image](https://github.com/opensearch-project/oui/assets/1366272/f5e41921-e151-45f0-9a8b-49b7f26750ec) | ![image](https://github.com/opensearch-project/oui/assets/1366272/bd3b375f-81a7-41bf-9823-be43fdaf0256) | ![image](https://github.com/opensearch-project/oui/assets/1366272/8b8e53d3-6d1c-40cd-a619-537648541712) |
| Toggle |![image](https://github.com/opensearch-project/oui/assets/1366272/a2a72463-c81c-4cbd-a92c-41ad3116ce88) | ![image](https://github.com/opensearch-project/oui/assets/1366272/54bd17fe-f705-4cfd-b5bd-7ab56fd23f8d) | ![image](https://github.com/opensearch-project/oui/assets/1366272/f6ece0cb-c140-4b62-8665-a56bce36e2a6) | ![image](https://github.com/opensearch-project/oui/assets/1366272/e2eafd75-2aad-46e1-8709-f338015d286b) |
| Button Group | ![image](https://github.com/opensearch-project/oui/assets/1366272/95a05b7f-6a48-48ac-b344-f7d1a879822d) | ![image](https://github.com/opensearch-project/oui/assets/1366272/db75f44d-8640-4621-915b-be64bcb51c61)  | ![image](https://github.com/opensearch-project/oui/assets/1366272/ec65cb93-9a55-45c2-97a6-fbbfcf1eafc2) | ![image](https://github.com/opensearch-project/oui/assets/1366272/cfd154a0-e489-4afb-8403-6dfd8d25228e) |
| Ghost |![image](https://github.com/opensearch-project/oui/assets/1366272/6de58a68-2334-4897-9708-df0e740da92b) |![image](https://github.com/opensearch-project/oui/assets/1366272/86ddbcae-b85a-4666-bcba-07786fb45817) | ![image](https://github.com/opensearch-project/oui/assets/1366272/82c4d169-0acb-489d-bbdf-4262328e9e02) | ![image](https://github.com/opensearch-project/oui/assets/1366272/e5602152-1f3e-4be4-a330-6978af4c4d83) |
| Split Button |![image](https://github.com/opensearch-project/oui/assets/1366272/13e78990-5c55-4344-8100-6ebc7247a5ab) |![image](https://github.com/opensearch-project/oui/assets/1366272/611eaaa9-a92c-4295-a36a-f20101f2078c) |![image](https://github.com/opensearch-project/oui/assets/1366272/302dcef4-c420-4e2b-b049-f68c7a25e4a1) |![image](https://github.com/opensearch-project/oui/assets/1366272/62ac39ad-459d-4354-bbf5-ed057353899b) |

Note: there's some weirdness with icon alignment to text, but that weirdness pre-existed for some icons + it is more due to the icon set than css as icons and text are all center aligned.

fyi: @lauralexis 

### Issues Resolved
N/A

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [X] All tests pass
  - [X] `yarn lint`
  - [X] `yarn test-unit`
- [X] Update [CHANGELOG.md](./../CHANGELOG.md)
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/oui/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
