### PR TITLE
feat: use faster animations for modals, popovers, and tooltips

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 - [Next Theme] Set base font size to 18px ([#1221](https://github.com/opensearch-project/oui/pull/1221))
 - [Next Theme] Revert `font-weight` of OuiButton to normal from semi-bold ([#1222](https://github.com/opensearch-project/oui/pull/1222))
 - Convert shorthand palette colors to full 6-char hex ([#1262](https://github.com/opensearch-project/oui/pull/1262))
+- Use faster animations for modals, popovers, and tooltips ([#1282](https://github.com/opensearch-project/oui/pull/1282))
 
 ### 🐛 Bug Fixes
 

--- a/src/components/modal/_modal.scss
+++ b/src/components/modal/_modal.scss
@@ -27,7 +27,7 @@
   border-radius: $ouiBorderRadius;
   z-index: $ouiZModal;
   min-width: $ouiFormMaxWidth;
-  animation: ouiModal $ouiAnimSpeedSlow $ouiAnimSlightBounce;
+  animation: ouiModal $ouiAnimSpeedExtraFast $ouiAnimSlightBounce;
   max-width: calc(100vw - #{$ouiSize});
 
   // Remove the outline from the focusable container

--- a/src/components/popover/_popover.scss
+++ b/src/components/popover/_popover.scss
@@ -51,16 +51,16 @@
   opacity: 0; /* 2 */
   visibility: hidden; /* 2 */
   transition: /* 2 */
-    opacity $ouiAnimSlightBounce $ouiAnimSpeedSlow,
-    visibility $ouiAnimSlightBounce $ouiAnimSpeedSlow;
+    opacity $ouiAnimSlightBounce $ouiAnimSpeedExtraFast,
+    visibility $ouiAnimSlightBounce $ouiAnimSpeedExtraFast;
 
   // Don't animate when using the attached mode like for inputs
   &:not(.ouiPopover__panel-isAttached) {
     transform: translateY(0) translateX(0) translateZ(0); /* 2 */
     transition: /* 2 */
-      opacity $ouiAnimSlightBounce $ouiAnimSpeedSlow,
-      visibility $ouiAnimSlightBounce $ouiAnimSpeedSlow,
-      transform $ouiAnimSlightBounce ($ouiAnimSpeedSlow + 100ms);
+      opacity $ouiAnimSlightBounce $ouiAnimSpeedExtraFast,
+      visibility $ouiAnimSlightBounce $ouiAnimSpeedExtraFast,
+      transform $ouiAnimSlightBounce ($ouiAnimSpeedExtraFast + 100ms);
   }
 
   &.ouiPopover__panel-isOpen {

--- a/src/components/tool_tip/_tool_tip.scss
+++ b/src/components/tool_tip/_tool_tip.scss
@@ -86,47 +86,39 @@
 @keyframes ouiToolTipTop {
   0% {
     opacity: 0;
-    transform: translateY(-$ouiSize);
   }
 
   100% {
     opacity: 1;
-    transform: translateY(0);
   }
 }
 
 @keyframes ouiToolTipBottom {
   0% {
     opacity: 0;
-    transform: translateY($ouiSize);
   }
 
   100% {
     opacity: 1;
-    transform: translateY(0);
   }
 }
 
 @keyframes ouiToolTipLeft {
   0% {
     opacity: 0;
-    transform: translateX(-$ouiSize);
   }
 
   100% {
     opacity: 1;
-    transform: translateY(0);
   }
 }
 
 @keyframes ouiToolTipRight {
   0% {
     opacity: 0;
-    transform: translateX($ouiSize);
   }
 
   100% {
     opacity: 1;
-    transform: translateY(0);
   }
 }

--- a/src/global_styling/mixins/_tool_tip.scss
+++ b/src/global_styling/mixins/_tool_tip.scss
@@ -35,7 +35,7 @@
 }
 
 @mixin ouiToolTipAnimation($side: 'top') {
-  animation: #{map-get($ouiTooltipAnimations, $side)} $ouiAnimSpeedSlow ease-out 0s forwards;
+  animation: #{map-get($ouiTooltipAnimations, $side)} $ouiAnimSpeedExtraFast ease-out 0s forwards;
 }
 
 

--- a/src/themes/oui-next/global_styling/mixins/_tool_tip.scss
+++ b/src/themes/oui-next/global_styling/mixins/_tool_tip.scss
@@ -35,7 +35,7 @@
 }
 
 @mixin ouiToolTipAnimation($side: 'top') {
-  animation: #{map-get($ouiTooltipAnimations, $side)} $ouiAnimSpeedSlow ease-out 0s forwards;
+  animation: #{map-get($ouiTooltipAnimations, $side)} $ouiAnimSpeedExtraFast ease-out 0s forwards;
 }
 
 


### PR DESCRIPTION
### Description
Increase animation speed/behavior for modals, popovers, and tooltips

| Component | Before | After |
| ---- | ---- | ---- |
| Modals |![modal before](https://github.com/opensearch-project/oui/assets/1366272/d6b62a85-19b3-4383-b4ca-bd26d79dab66) | ![modal after](https://github.com/opensearch-project/oui/assets/1366272/fbe5d797-18f8-47af-86e1-5ca010025bd3)| 
| Popovers |![popover before](https://github.com/opensearch-project/oui/assets/1366272/ed4e1546-9b00-405e-9195-e6af54c5ecbf) | ![popover after](https://github.com/opensearch-project/oui/assets/1366272/056df2cc-d611-48dc-ac2f-447d904d44a9)| 
| Tooltips |![tooltip before](https://github.com/opensearch-project/oui/assets/1366272/71d7d9c7-3abb-4062-b681-77f878098fc4)| ![tooltip after](https://github.com/opensearch-project/oui/assets/1366272/aa1a0cf2-8222-4a5f-b7af-ae7e72b9a216)| 

fyi: @lauralexis 

### Issues Resolved
N/A

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [X] All tests pass
  - [x] `yarn lint`
  - [x] `yarn test-unit`
- [x] Update [CHANGELOG.md](./../CHANGELOG.md)
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/oui/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
