### PR TITLE
feat: adjust popover and context menu title styles and tooltip padding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 - [Next Theme] Set base font size to 18px ([#1221](https://github.com/opensearch-project/oui/pull/1221))
 - [Next Theme] Revert `font-weight` of OuiButton to normal from semi-bold ([#1222](https://github.com/opensearch-project/oui/pull/1222))
 - Convert shorthand palette colors to full 6-char hex ([#1262](https://github.com/opensearch-project/oui/pull/1262))
+- Adjust popover and context menu title styles and tooltip padding ([#1283](https://github.com/opensearch-project/oui/pull/1283))
 
 ### 🐛 Bug Fixes
 

--- a/src/components/context_menu/_context_menu_panel.scss
+++ b/src/components/context_menu/_context_menu_panel.scss
@@ -62,7 +62,7 @@
   }
 
   &--small {
-    @include ouiPopoverTitle('s');
+    @include ouiPopoverTitle;
     padding: ($ouiSizeS * .75) $ouiSizeS;
   }
 }

--- a/src/components/tool_tip/_tool_tip.scss
+++ b/src/components/tool_tip/_tool_tip.scss
@@ -14,7 +14,7 @@
  */
 
 .ouiToolTip {
-  @include ouiToolTipStyle;
+  @include ouiToolTipStyle('s');
   @include ouiToolTipAnimation('top');
   position: absolute;
   opacity: 0;

--- a/src/global_styling/mixins/_popover.scss
+++ b/src/global_styling/mixins/_popover.scss
@@ -19,7 +19,7 @@
   }
 
   padding: $ouiSizeM;
-  text-transform: uppercase;
+  text-transform: none;
   border-bottom: $ouiBorderThin;
 }
 

--- a/src/themes/oui-next/global_styling/mixins/_popover.scss
+++ b/src/themes/oui-next/global_styling/mixins/_popover.scss
@@ -19,7 +19,7 @@
   }
 
   padding: $ouiSizeM;
-  text-transform: uppercase;
+  text-transform: none;
   border-bottom: $ouiBorderThin;
 }
 


### PR DESCRIPTION
### Description
Adjusts popover/context menu titles to use normal casing, for small context menus to use normal font size to match popovers, and for tooltips to be forced to small size (padding and font size).

| Item |  Before (v7dark) | After (v7dark) | Before (v8dark) | After (v8dark) |
| ---- | ---- | ---- | ---- | ---- | 
| Popover |![image](https://github.com/opensearch-project/oui/assets/1366272/fbdf8eb8-f36b-42a1-8418-7388cf5a1a10) | ![image](https://github.com/opensearch-project/oui/assets/1366272/f87dd23b-a8f4-42e5-a339-2eb521d09b28)|![image](https://github.com/opensearch-project/oui/assets/1366272/3ed771da-eaed-43f9-bd0d-d216aed1b16f) | ![image](https://github.com/opensearch-project/oui/assets/1366272/8b0c0e82-bd8f-457a-8da9-75907fca1633)|
| Context Menu | ![image](https://github.com/opensearch-project/oui/assets/1366272/a0ee7946-a4c4-49e8-9c7b-84ddc9c376e7)|![image](https://github.com/opensearch-project/oui/assets/1366272/4bb7b4d0-c1a8-448c-8f58-212b95f39dee)|![image](https://github.com/opensearch-project/oui/assets/1366272/cc5bb7f6-7b6c-42c8-ab6e-bf0e61a009bf) |![image](https://github.com/opensearch-project/oui/assets/1366272/d842c7e6-ac99-46bd-a211-45050b3c7b5f) |
| Small Context Menu |![image](https://github.com/opensearch-project/oui/assets/1366272/e583f2a1-9257-4add-9581-14ca40c9890e) |![image](https://github.com/opensearch-project/oui/assets/1366272/24b85e1c-51b5-42a4-abdb-bbc69c35181a) |![image](https://github.com/opensearch-project/oui/assets/1366272/12b3a855-a43e-4734-9cae-19cc3078cda2) | ![image](https://github.com/opensearch-project/oui/assets/1366272/941c9f1f-bb61-4db3-9d52-86ed45776b08)|
| Tooltip |![image](https://github.com/opensearch-project/oui/assets/1366272/b49628bd-9fb0-4bfe-99f7-1ea4f1943e80) | ![image](https://github.com/opensearch-project/oui/assets/1366272/71b3c6e6-ca9b-4a10-af70-5ec7d41cf93c) |![image](https://github.com/opensearch-project/oui/assets/1366272/d986a99d-938a-4f03-b850-5a5d121bf94f) | ![image](https://github.com/opensearch-project/oui/assets/1366272/a0b85db0-6c11-43f4-bff6-aec249aa61d3)|

For titles no longer being uppercase, searched for all EuiContextMenus and EuiPopoverTitles in code base, and all had normal titles (no reliance on text-transform). Not all were sentence case (e.g. some were like "Saved Queries"), but don't think that's a deal breaker.

Validated small tooltip style and context menu font choices with Laura.

fyi: @lauralexis 

### Issues Resolved
<!-- List any issues this PR will resolve. -->
<!-- Example: Fixes #1234 -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [X] All tests pass
  - [X] `yarn lint`
  - [X] `yarn test-unit`
- [x] Update [CHANGELOG.md](./../CHANGELOG.md)
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/oui/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
