### PR TITLE
feat: remove Button translations and add inset shadow on active

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,7 @@
 - [Next Theme] Set base font size to 18px ([#1221](https://github.com/opensearch-project/oui/pull/1221))
 - [Next Theme] Revert `font-weight` of OuiButton to normal from semi-bold ([#1222](https://github.com/opensearch-project/oui/pull/1222))
 - Convert shorthand palette colors to full 6-char hex ([#1262](https://github.com/opensearch-project/oui/pull/1262))
-- Remove Button translations and add inset shadow on active ([]())
+- Remove Button translations and add inset shadow on active ([#1285](https://github.com/opensearch-project/oui/pull))
 
 ### 🐛 Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 - [Next Theme] Set base font size to 18px ([#1221](https://github.com/opensearch-project/oui/pull/1221))
 - [Next Theme] Revert `font-weight` of OuiButton to normal from semi-bold ([#1222](https://github.com/opensearch-project/oui/pull/1222))
 - Convert shorthand palette colors to full 6-char hex ([#1262](https://github.com/opensearch-project/oui/pull/1262))
+- Remove Button translations and add inset shadow on active ([]())
 
 ### 🐛 Bug Fixes
 

--- a/src/components/button/_button.scss
+++ b/src/components/button/_button.scss
@@ -107,6 +107,10 @@
           background-color: darken($color, 5%);
           border-color: darken($color, 5%);
         }
+
+        &:active {
+          @include ouiSlightShadowActive(darken($color, 10%), .4);
+        }
       }
     }
 
@@ -126,6 +130,10 @@
       &:focus-within {
         @include ouiSlightShadowHover($shadowColor);
         background-color: transparentize($color, .9);
+      }
+
+      &:active {
+        @include ouiSlightShadowActive($color);
       }
     }
   }

--- a/src/components/button/button_icon/_button_icon.scss
+++ b/src/components/button/button_icon/_button_icon.scss
@@ -105,6 +105,10 @@
           background-color: darken($color, 5%);
           border-color: darken($color, 5%);
         }
+
+        &:active {
+          @include ouiSlightShadowActive(darken($color, 10%), .4);
+        }
       }
     }
 
@@ -124,6 +128,10 @@
       &:focus-within {
         @include ouiSlightShadowHover($shadowColor);
         background-color: transparentize($color, .9);
+      }
+
+      &:active {
+        @include ouiSlightShadowActive($color);
       }
     }
   }

--- a/src/components/split_button/_split_button_control.scss
+++ b/src/components/split_button/_split_button_control.scss
@@ -47,27 +47,6 @@ $splitButtonSeparatorColor: shade($ouiColorPrimary, 50%);
   .ouiSplitButtonControl {
     border: $ouiBorderWidthThick solid $ouiBorderColor;
     border-radius: $ouiBorderRadius;
-
-    // Animate wrapper element only when primary button activated
-    &:has(.ouiSplitButtonControl--primary:hover:not([class*='isDisabled'])) {
-      -webkit-transform: translateY(-1px);
-      transform: translateY(-1px);
-    }
-
-    &:has(.ouiSplitButtonControl--primary:active:not([class*='isDisabled'])) {
-      -webkit-transform: translateY(1px);
-      transform: translateY(1px);
-    }
-
-    &:has(.ouiSplitButtonControl--primary:focus:not([class*='isDisabled'])) {
-      animation: ouiButtonActive $ouiAnimSpeedNormal $ouiAnimSlightBounce;
-    }
-
-    //.ouiSplitButtonControl--primary {
-    //  border-right: $ouiBorderWidthThin solid $splitButtonSeparatorColor;
-    //
-    //}
-
   }
 
   // Create button modifiers based upon the map.

--- a/src/global_styling/mixins/_button.scss
+++ b/src/global_styling/mixins/_button.scss
@@ -26,19 +26,7 @@
 // Adds the focus (and hover) animation for translating up 1px
 @mixin ouiButtonFocus {
   @include ouiCanAnimate {
-    transition: transform $ouiAnimSpeedNormal ease-in-out, background $ouiAnimSpeedNormal ease-in-out;
-
-    &:hover:not([class*='isDisabled']) {
-      transform: translateY(-1px);
-    }
-
-    &:focus {
-      animation: ouiButtonActive $ouiAnimSpeedNormal $ouiAnimSlightBounce;
-    }
-
-    &:active:not([class*='isDisabled']) {
-      transform: translateY(1px);
-    }
+    transition: background $ouiAnimSpeedNormal ease-in-out;
   }
 }
 

--- a/src/global_styling/mixins/_shadow.scss
+++ b/src/global_styling/mixins/_shadow.scss
@@ -93,8 +93,8 @@
     0 2px 2px -1px rgba($color, $opacity);
 }
 
-@mixin ouiSlightShadowActive($color: $ouiShadowColor, $opacity: .3) {
-  @include ouiSlightShadowHover($color, $opacity);
+@mixin ouiSlightShadowActive($color: $ouiShadowColor, $opacity: .15) {
+  box-shadow: inset 1px 2px 8px rgba($color, $opacity);
 }
 
 @mixin ouiOverflowShadow($direction: 'y', $side: 'both') {

--- a/src/themes/oui-next/global_styling/mixins/_button.scss
+++ b/src/themes/oui-next/global_styling/mixins/_button.scss
@@ -26,19 +26,7 @@
 // Adds the focus (and hover) animation for translating up 1px
 @mixin ouiButtonFocus {
   @include ouiCanAnimate {
-    transition: transform $ouiAnimSpeedNormal ease-in-out, background $ouiAnimSpeedNormal ease-in-out;
-
-    &:hover:not([class*='isDisabled']) {
-      transform: translateY(-1px);
-    }
-
-    &:focus {
-      animation: ouiButtonActive $ouiAnimSpeedNormal $ouiAnimSlightBounce;
-    }
-
-    &:active:not([class*='isDisabled']) {
-      transform: translateY(1px);
-    }
+    transition: background $ouiAnimSpeedNormal ease-in-out;
   }
 }
 

--- a/src/themes/oui-next/global_styling/mixins/_shadow.scss
+++ b/src/themes/oui-next/global_styling/mixins/_shadow.scss
@@ -93,8 +93,8 @@
     0 2px 2px -1px rgba($color, $opacity);
 }
 
-@mixin ouiSlightShadowActive($color: $ouiShadowColor, $opacity: .3) {
-  @include ouiSlightShadowHover($color, $opacity);
+@mixin ouiSlightShadowActive($color: $ouiShadowColor, $opacity: .15) {
+  box-shadow: inset 1px 2px 8px rgba($color, $opacity);
 }
 
 @mixin ouiOverflowShadow($direction: 'y', $side: 'both') {


### PR DESCRIPTION
### Description
To avoid buttons physically moving, we've removed the translations on hover/focus and replaced it with an inset shadow (with existing removal of focus/active shadow). We will likely change/refine this behavior in the future, but this removes the weirdness of a physically moving button.

I changed the implementation of ouiSlightShadowActive because there were no active consumers in OUI or OpenSearch Dashboards.

The main downsides of this approach are when background is black and the button is white or a button icon without a border as these cases won't have a super visible change on active.

| Item |  Before (v7dark) | After (v7dark) | Before (v8dark) | After (v8dark) |
| ---- | ---- | ---- | ---- | ---- | 
| Button | ![button v7 before](https://github.com/opensearch-project/oui/assets/1366272/1e52e61b-2b0e-49e0-9a53-556cfbd9825f)| ![button v7 after](https://github.com/opensearch-project/oui/assets/1366272/188299e9-6b26-42b0-90c6-7660180b8033)|![button v8 before](https://github.com/opensearch-project/oui/assets/1366272/bed9247f-da43-4804-9052-b600587d0eca) |![button v8 after](https://github.com/opensearch-project/oui/assets/1366272/424d1cbe-4987-45ca-abd8-c29bd429e901) |
| Empty Button (no change) |![v7 empty before](https://github.com/opensearch-project/oui/assets/1366272/7d8f5385-e86f-4865-92e9-a2e92dee9027) | ![v7 empty after](https://github.com/opensearch-project/oui/assets/1366272/3d6c16f6-14db-4873-a583-117b6076095a)| | |
| Button Icon |![v7 buttonicon before](https://github.com/opensearch-project/oui/assets/1366272/a17b51bf-9b64-4c9c-9ff4-a95d52b3ab77) | ![v7 buttonicon after](https://github.com/opensearch-project/oui/assets/1366272/817adbe2-59fc-4da1-bf54-6ff193c3cd0c)| | |
| Toggle Button |![v7 toggle before](https://github.com/opensearch-project/oui/assets/1366272/8a292fb2-494b-4873-9ef3-1549c882f6d5) | ![v7 toggle after](https://github.com/opensearch-project/oui/assets/1366272/43c38bd0-4780-4a72-ae38-eff5c760da22)| | |
| Button Group (no change) | ![v7 group before](https://github.com/opensearch-project/oui/assets/1366272/f7fcb603-c600-4443-9be3-d07760025801)| ![v7 group after](https://github.com/opensearch-project/oui/assets/1366272/e6051e7c-5a5c-440b-819c-3f4242f390f6)| | |
| Ghost Button | ![v7 ghost before](https://github.com/opensearch-project/oui/assets/1366272/ac4c31f4-377c-48df-9bd8-f53111389923)| ![v7 ghost before](https://github.com/opensearch-project/oui/assets/1366272/94bcfcfb-ade7-4406-83b0-2c34c2b67001)| | |
| Split Button |![v7 split before](https://github.com/opensearch-project/oui/assets/1366272/84675775-847b-487b-a218-3e29ca70e021)|![v7 split after](https://github.com/opensearch-project/oui/assets/1366272/46f1ce14-d903-4491-a7a6-ecf495f885da) | | |

fyi: @lauralexis 

### Issues Resolved
N/A

### Check List
- [ ] New functionality includes testing.
- [X] New functionality has been documented.
- [X] All tests pass
  - [X] `yarn lint`
  - [X] `yarn test-unit`
- [x] Update [CHANGELOG.md](./../CHANGELOG.md)
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/oui/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
