### PR TITLE
feat: make SuperUpdateButton's button secondary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,7 @@
 - [Next Theme] Set base font size to 18px ([#1221](https://github.com/opensearch-project/oui/pull/1221))
 - [Next Theme] Revert `font-weight` of OuiButton to normal from semi-bold ([#1222](https://github.com/opensearch-project/oui/pull/1222))
 - Convert shorthand palette colors to full 6-char hex ([#1262](https://github.com/opensearch-project/oui/pull/1262))
-- Make Super Update Button secondary instead of primary ([]())
+- Make Super Update Button secondary instead of primary ([#1286](https://github.com/opensearch-project/oui/pull/1286))
 
 ### 🐛 Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 - [Next Theme] Set base font size to 18px ([#1221](https://github.com/opensearch-project/oui/pull/1221))
 - [Next Theme] Revert `font-weight` of OuiButton to normal from semi-bold ([#1222](https://github.com/opensearch-project/oui/pull/1222))
 - Convert shorthand palette colors to full 6-char hex ([#1262](https://github.com/opensearch-project/oui/pull/1262))
+- Make Super Update Button secondary instead of primary ([]())
 
 ### 🐛 Bug Fixes
 

--- a/src/components/date_picker/super_date_picker/__snapshots__/super_update_button.test.tsx.snap
+++ b/src/components/date_picker/super_date_picker/__snapshots__/super_update_button.test.tsx.snap
@@ -8,7 +8,6 @@ exports[`OuiSuperUpdateButton is rendered 1`] = `
   <OuiButton
     className="ouiSuperUpdateButton"
     color="primary"
-    fill={true}
     iconType="refresh"
     isDisabled={false}
     isLoading={false}
@@ -41,7 +40,6 @@ exports[`OuiSuperUpdateButton isDisabled 1`] = `
   <OuiButton
     className="ouiSuperUpdateButton"
     color="primary"
-    fill={true}
     iconType="refresh"
     isDisabled={true}
     isLoading={false}
@@ -68,7 +66,6 @@ exports[`OuiSuperUpdateButton isLoading 1`] = `
   <OuiButton
     className="ouiSuperUpdateButton"
     color="success"
-    fill={true}
     iconType="kqlFunction"
     isDisabled={false}
     isLoading={true}
@@ -101,7 +98,6 @@ exports[`OuiSuperUpdateButton needsUpdate 1`] = `
   <OuiButton
     className="ouiSuperUpdateButton"
     color="success"
-    fill={true}
     iconType="kqlFunction"
     isDisabled={false}
     isLoading={false}
@@ -128,7 +124,6 @@ exports[`OuiSuperUpdateButton showTooltip 1`] = `
   <OuiButton
     className="ouiSuperUpdateButton"
     color="primary"
-    fill={true}
     iconType="refresh"
     isDisabled={false}
     isLoading={false}

--- a/src/components/date_picker/super_date_picker/super_update_button.tsx
+++ b/src/components/date_picker/super_date_picker/super_update_button.tsx
@@ -169,7 +169,6 @@ export class OuiSuperUpdateButton extends Component<OuiSuperUpdateButtonProps> {
         <OuiButton
           className={classes}
           color={needsUpdate || isLoading ? 'success' : 'primary'}
-          fill
           iconType={needsUpdate || isLoading ? 'kqlFunction' : 'refresh'}
           textProps={{
             ...restTextProps,


### PR DESCRIPTION
### Description
Makes the Update/Refresh button in SuperUpdateButton secondary instead of primary.

| Before | After |
| ---- | ---- |
| ![image](https://github.com/opensearch-project/oui/assets/1366272/804e6696-d908-4e75-abec-8297d766883f)| ![image](https://github.com/opensearch-project/oui/assets/1366272/03f11965-7316-4f04-8a60-6a8a9891f706) |

### Issues Resolved
N/A

### Check List
- [x] New functionality includes testing.
- [X] New functionality has been documented.
- [x] All tests pass
  - [X] `yarn lint`
  - [x] `yarn test-unit`
- [x] Update [CHANGELOG.md](./../CHANGELOG.md)
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/oui/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
