### PR TITLE
Add Compressed form components, color-picker, and combobox, and small button components and filter-button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@
 ### 📈 Features/Enhancements
 
 - [OuiFilterGroup] Allow popovers to size to content ([#1280](https://github.com/opensearch-project/oui/pull/1280))
+- Add compressed form, color-picker, and combo-box internal components ([#1301](https://github.com/opensearch-project/oui/pull/1301))
+- Add small button and filter-button internal components ([#1301](https://github.com/opensearch-project/oui/pull/1301))
 
 ### 🐛 Bug Fixes
 

--- a/packages/eslint-plugin/rules/href_or_on_click.js
+++ b/packages/eslint-plugin/rules/href_or_on_click.js
@@ -9,7 +9,14 @@
  * GitHub history for details.
  */
 
-const componentNames = ['OuiButton', 'OuiButtonEmpty', 'OuiLink', 'OuiBadge'];
+const componentNames = [
+  'OuiButton',
+  'OuiSmallButton',
+  'OuiButtonEmpty',
+  'OuiSmallButtonEmpty',
+  'OuiLink',
+  'OuiBadge',
+];
 
 module.exports = {
   meta: {

--- a/packages/eslint-plugin/rules/href_or_on_click.test.js
+++ b/packages/eslint-plugin/rules/href_or_on_click.test.js
@@ -59,6 +59,41 @@ ruleTester.run('@opensearch-project/oui/href-or-on-click', rule, {
         )
       `),
     },
+    {
+      code: dedent(`
+        module.export = () => (
+          <OuiSmallButton />
+        )
+      `),
+    },
+    {
+      code: dedent(`
+        module.export = () => (
+          <OuiSmallButton href="/" />
+        )
+      `),
+    },
+    {
+      code: dedent(`
+        module.export = () => (
+          <OuiSmallButton href={'/' + 'home'} />
+        )
+      `),
+    },
+    {
+      code: dedent(`
+        module.export = () => (
+          <OuiSmallButton onClick={executeAction} />
+        )
+      `),
+    },
+    {
+      code: dedent(`
+        module.export = () => (
+          <OuiSmallButton onClick={() => executeAction()} />
+        )
+      `),
+    },
   ],
 
   invalid: [
@@ -99,6 +134,33 @@ ruleTester.run('@opensearch-project/oui/href-or-on-click', rule, {
       errors: [
         {
           message: '<OuiLink> accepts either `href` or `onClick`, not both.',
+        },
+      ],
+    },
+    {
+      code: dedent(`
+        module.export = () => (
+          <OuiSmallButton href="/" onClick={fooBar} />
+        )
+      `),
+
+      errors: [
+        {
+          message: '<OuiSmallButton> accepts either `href` or `onClick`, not both.',
+        },
+      ],
+    },
+    {
+      code: dedent(`
+        module.export = () => (
+          <OuiSmallButtonEmpty href="/" onClick={fooBar} />
+        )
+      `),
+
+      errors: [
+        {
+          message:
+            '<OuiSmallButtonEmpty> accepts either `href` or `onClick`, not both.',
         },
       ],
     },

--- a/src/components/button/button.tsx
+++ b/src/components/button/button.tsx
@@ -314,3 +314,15 @@ export const OuiButton: FunctionComponent<Props> = ({
     />
   );
 };
+
+export type OuiSmallButtonProps = Omit<OuiButtonProps, 'size'>;
+
+// Cannot Omit<Props, 'size'> directly due to Exclude changing optional prop types
+type SmallProps = ExclusiveUnion<
+  Omit<OuiButtonPropsForAnchor, 'size'>,
+  Omit<OuiButtonPropsForButton, 'size'>
+>;
+
+export const OuiSmallButton: FunctionComponent<SmallProps> = (props) => (
+  <OuiButton {...props} size="s" />
+);

--- a/src/components/button/button_empty/button_empty.tsx
+++ b/src/components/button/button_empty/button_empty.tsx
@@ -227,3 +227,14 @@ export const OuiButtonEmpty: FunctionComponent<OuiButtonEmptyProps> = ({
     </button>
   );
 };
+
+// @internal
+export type OuiSmallButtonEmptyProps = ExclusiveUnion<
+  Omit<OuiButtonEmptyPropsForAnchor, 'size'>,
+  Omit<OuiButtonEmptyPropsForButton, 'size'>
+>;
+
+// @internal
+export const OuiSmallButtonEmpty: FunctionComponent<OuiSmallButtonEmptyProps> = (
+  props
+) => <OuiButtonEmpty {...props} size="s" />;

--- a/src/components/button/button_empty/index.ts
+++ b/src/components/button/button_empty/index.ts
@@ -34,4 +34,6 @@ export {
   OuiButtonEmptyColor,
   OuiButtonEmptyProps,
   OuiButtonEmptySizes,
+  OuiSmallButtonEmpty,
+  OuiSmallButtonEmptyProps,
 } from './button_empty';

--- a/src/components/button/button_group/button_group.tsx
+++ b/src/components/button/button_group/button_group.tsx
@@ -211,3 +211,92 @@ export const OuiButtonGroup: FunctionComponent<Props> = ({
     </fieldset>
   );
 };
+
+// @internal
+export type OuiSmallButtonGroupProps = CommonProps & {
+  isDisabled?: boolean;
+  /**
+   * Expands the whole group to the full width of the container.
+   * Each button gets equal widths no matter the content
+   */
+  isFullWidth?: boolean;
+  /**
+   * Hides the label to only show the `iconType` provided by the `option`
+   */
+  isIconOnly?: boolean;
+  /**
+   * A hidden group title (required for accessibility)
+   */
+  legend: string;
+  /**
+   * Compressed styles don't support `ghost` color (Color will be changed to "text")
+   */
+  color?: ButtonColor;
+  /**
+   * Actual type is `'single' | 'multi'`.
+   * Determines how the selection of the group should be handled.
+   * With `'single'` only one option can be selected at a time (similar to radio group).
+   * With `'multi'` multiple options selected (similar to checkbox group).
+   */
+  type?: 'single' | 'multi';
+  /**
+   * An array of #OuiButtonGroupOptionProps
+   */
+  options: OuiButtonGroupOptionProps[];
+} & (
+    | {
+        /**
+         * Default for `type` is single so it can also be excluded
+         */
+        type?: 'single';
+        /**
+         * The `name` attribute for radio inputs;
+         * Defaults to a random string
+         */
+        name?: string;
+        /**
+         * Styles the selected option to look selected (usually with `fill`)
+         * Required by and only used in `type='single'`.
+         */
+        idSelected: string;
+        /**
+         * Single: Returns the `id` of the clicked option and the `value`
+         */
+        onChange: (id: string, value?: any) => void;
+        idToSelectedMap?: never;
+      }
+    | {
+        type: 'multi';
+        /**
+         * A map of `id`s as keys with the selected boolean values.
+         * Required by and only used in `type='multi'`.
+         */
+        idToSelectedMap?: { [id: string]: boolean };
+        /**
+         * Multi: Returns the `id` of the clicked option
+         */
+        onChange: (id: string) => void;
+        idSelected?: never;
+        name?: never;
+      }
+  );
+
+// @internal
+type SmallProps = Omit<
+  HTMLAttributes<HTMLFieldSetElement>,
+  'onChange' | 'color'
+> &
+  OuiSmallButtonGroupProps;
+
+// @internal
+export const OuiSmallButtonGroup: FunctionComponent<SmallProps> = (props) => (
+  <OuiButtonGroup {...props} buttonSize="s" />
+);
+
+// @internal
+export type OuiCompressedButtonGroupProps = OuiSmallButtonGroupProps;
+
+// @internal
+export const OuiCompressedButtonGroup: FunctionComponent<SmallProps> = (
+  props
+) => <OuiButtonGroup {...props} buttonSize="compressed" />;

--- a/src/components/button/button_group/index.ts
+++ b/src/components/button/button_group/index.ts
@@ -32,4 +32,8 @@ export {
   OuiButtonGroup,
   OuiButtonGroupOptionProps,
   OuiButtonGroupProps,
+  OuiSmallButtonGroup,
+  OuiSmallButtonGroupProps,
+  OuiCompressedButtonGroup,
+  OuiCompressedButtonGroupProps,
 } from './button_group';

--- a/src/components/button/button_icon/button_icon.tsx
+++ b/src/components/button/button_icon/button_icon.tsx
@@ -239,3 +239,17 @@ export const OuiButtonIcon: FunctionComponent<Props> = ({
     </button>
   );
 };
+
+// @internal
+export type OuiSmallButtonIconProps = Omit<OuiButtonIconProps, 'size'>;
+
+// @internal
+type SmallProps = ExclusiveUnion<
+  Omit<OuiButtonIconPropsForAnchor, 'size'>,
+  Omit<OuiButtonIconPropsForButton, 'size'>
+>;
+
+// @internal
+export const OuiSmallButtonIcon: FunctionComponent<SmallProps> = (props) => (
+  <OuiButtonIcon {...props} size="s" />
+);

--- a/src/components/button/button_icon/index.ts
+++ b/src/components/button/button_icon/index.ts
@@ -33,4 +33,6 @@ export {
   OuiButtonIconColor,
   OuiButtonIconProps,
   OuiButtonIconPropsForButton,
+  OuiSmallButtonIcon,
+  OuiSmallButtonIconProps,
 } from './button_icon';

--- a/src/components/button/index.ts
+++ b/src/components/button/index.ts
@@ -34,6 +34,8 @@ export {
   ButtonSize,
   OuiButton,
   OuiButtonProps,
+  OuiSmallButton,
+  OuiSmallButtonProps,
 } from './button';
 
 export {
@@ -41,6 +43,8 @@ export {
   OuiButtonEmptyColor,
   OuiButtonEmptyProps,
   OuiButtonEmptySizes,
+  OuiSmallButtonEmpty,
+  OuiSmallButtonEmptyProps,
 } from './button_empty';
 
 export {
@@ -48,10 +52,16 @@ export {
   OuiButtonIconColor,
   OuiButtonIconProps,
   OuiButtonIconPropsForButton,
+  OuiSmallButtonIcon,
+  OuiSmallButtonIconProps,
 } from './button_icon';
 
 export {
   OuiButtonGroup,
   OuiButtonGroupOptionProps,
   OuiButtonGroupProps,
+  OuiSmallButtonGroup,
+  OuiSmallButtonGroupProps,
+  OuiCompressedButtonGroup,
+  OuiCompressedButtonGroupProps,
 } from './button_group';

--- a/src/components/color_picker/color_picker.tsx
+++ b/src/components/color_picker/color_picker.tsx
@@ -695,3 +695,14 @@ export const OuiColorPicker: FunctionComponent<OuiColorPickerProps> = ({
     </OuiPopover>
   );
 };
+
+// @internal
+export type OuiCompressedColorPickerProps = Omit<
+  OuiColorPickerProps,
+  'compressed'
+>;
+
+// @internal
+export const OuiCompressedColorPicker: FunctionComponent<OuiCompressedColorPickerProps> = (
+  props
+) => <OuiColorPicker {...props} compressed />;

--- a/src/components/color_picker/index.ts
+++ b/src/components/color_picker/index.ts
@@ -28,7 +28,12 @@
  * under the License.
  */
 
-export { OuiColorPicker, OuiColorPickerProps } from './color_picker';
+export {
+  OuiColorPicker,
+  OuiColorPickerProps,
+  OuiCompressedColorPicker,
+  OuiCompressedColorPickerProps,
+} from './color_picker';
 export {
   OuiColorPickerSwatch,
   OuiColorPickerSwatchProps,

--- a/src/components/combo_box/combo_box.tsx
+++ b/src/components/combo_box/combo_box.tsx
@@ -1106,3 +1106,17 @@ export class OuiComboBox<T> extends Component<
     );
   }
 }
+
+// @internal
+export type OuiCompressedComboBoxProps<T> = Omit<
+  OuiComboBoxProps<T>,
+  'compressed'
+>;
+
+// @internal
+export class OuiCompressedComboBox<T> extends OuiComboBox<T> {
+  static defaultProps = {
+    ...OuiComboBox.defaultProps,
+    compressed: true,
+  };
+}

--- a/src/components/combo_box/index.ts
+++ b/src/components/combo_box/index.ts
@@ -28,7 +28,13 @@
  * under the License.
  */
 
-export { OuiComboBox, OuiComboBoxProps } from './combo_box';
+export {
+  OuiComboBox,
+  OuiComboBoxProps,
+  OuiCompressedComboBox,
+  OuiCompressedComboBoxProps,
+} from './combo_box';
+
 export * from './combo_box_input';
 export * from './combo_box_options_list';
 export {

--- a/src/components/filter_group/filter_button.tsx
+++ b/src/components/filter_group/filter_button.tsx
@@ -33,7 +33,12 @@ import classNames from 'classnames';
 
 import { OuiI18n } from '../i18n';
 import { OuiNotificationBadge } from '../badge/notification_badge';
-import { OuiButtonEmpty, OuiButtonEmptyProps } from '../button/button_empty';
+
+import {
+  OuiButtonEmpty,
+  OuiButtonEmptyProps,
+  OuiSmallButtonEmptyProps,
+} from '../button/button_empty';
 
 import { useInnerText } from '../inner_text';
 
@@ -168,3 +173,43 @@ export const OuiFilterButton: FunctionComponent<OuiFilterButtonProps> = ({
     </OuiButtonEmpty>
   );
 };
+
+// @internal
+export type OuiSmallFilterButtonProps = OuiSmallButtonEmptyProps & {
+  /**
+   * Bolds the button if true
+   */
+  hasActiveFilters?: boolean;
+  /**
+   * Pass the total number of filters available and it will
+   * add a subdued notification badge showing the number
+   */
+  numFilters?: number;
+  /**
+   * Pass the number of selected filters and it will
+   * add a bright notification badge showing the number
+   */
+  numActiveFilters?: number;
+  /**
+   * Applies a visual state to the button useful when using with a popover.
+   */
+  isSelected?: boolean;
+  /**
+   * Should the button grow to fill its container, best used for dropdown buttons
+   */
+  grow?: boolean;
+  /**
+   * Remove border after button, good for opposite filters
+   */
+  withNext?: boolean;
+  /**
+   * _DEPRECATED: use `withNext`_
+   * Remove border after button, good for opposite filters
+   */
+  noDivider?: boolean;
+};
+
+// @internal
+export const OuiSmallFilterButton: FunctionComponent<OuiSmallFilterButtonProps> = (
+  props
+) => <OuiFilterButton {...props} size="s" />;

--- a/src/components/filter_group/index.ts
+++ b/src/components/filter_group/index.ts
@@ -30,7 +30,12 @@
 
 export { OuiFilterGroup, OuiFilterGroupProps } from './filter_group';
 
-export { OuiFilterButton, OuiFilterButtonProps } from './filter_button';
+export {
+  OuiFilterButton,
+  OuiFilterButtonProps,
+  OuiSmallFilterButton,
+  OuiSmallFilterButtonProps,
+} from './filter_button';
 
 export {
   OuiFilterSelectItem,

--- a/src/components/form/checkbox/checkbox.tsx
+++ b/src/components/form/checkbox/checkbox.tsx
@@ -161,3 +161,14 @@ export class OuiCheckbox extends Component<OuiCheckboxProps> {
     }
   }
 }
+
+// @internal
+export type OuiCompressedCheckboxProps = Omit<OuiCheckboxProps, 'compressed'>;
+
+// @internal
+export class OuiCompressedCheckbox extends OuiCheckbox {
+  static defaultProps = {
+    ...OuiCheckbox.defaultProps,
+    compressed: true,
+  };
+}

--- a/src/components/form/checkbox/checkbox_group.tsx
+++ b/src/components/form/checkbox/checkbox_group.tsx
@@ -121,3 +121,16 @@ export const OuiCheckboxGroup: FunctionComponent<OuiCheckboxGroupProps> = ({
     </div>
   );
 };
+
+// @internal
+export type OuiCompressedCheckboxGroupProps = CommonProps & {
+  options: OuiCheckboxGroupOption[];
+  idToSelectedMap: OuiCheckboxGroupIdToSelectedMap;
+  onChange: (optionId: string) => void;
+  disabled?: boolean;
+} & ExclusiveUnion<AsDivProps, WithLegendProps>;
+
+// @internal
+export const OuiCompressedCheckboxGroup: FunctionComponent<OuiCompressedCheckboxGroupProps> = (
+  props
+) => <OuiCheckboxGroup {...props} compressed />;

--- a/src/components/form/checkbox/index.ts
+++ b/src/components/form/checkbox/index.ts
@@ -28,9 +28,17 @@
  * under the License.
  */
 
-export { OuiCheckbox, OuiCheckboxProps } from './checkbox';
+export {
+  OuiCheckbox,
+  OuiCheckboxProps,
+  OuiCompressedCheckbox,
+  OuiCompressedCheckboxProps,
+} from './checkbox';
+
 export {
   OuiCheckboxGroup,
   OuiCheckboxGroupProps,
   OuiCheckboxGroupOption,
+  OuiCompressedCheckboxGroup,
+  OuiCompressedCheckboxGroupProps,
 } from './checkbox_group';

--- a/src/components/form/field_number/field_number.tsx
+++ b/src/components/form/field_number/field_number.tsx
@@ -149,3 +149,14 @@ export const OuiFieldNumber: FunctionComponent<OuiFieldNumberProps> = ({
     </OuiFormControlLayout>
   );
 };
+
+// @internal
+export type OuiCompressedFieldNumberProps = Omit<
+  OuiFieldNumberProps,
+  'compressed'
+>;
+
+// @internal
+export const OuiCompressedFieldNumber: FunctionComponent<OuiCompressedFieldNumberProps> = (
+  props
+) => <OuiFieldNumber {...props} compressed />;

--- a/src/components/form/field_number/index.ts
+++ b/src/components/form/field_number/index.ts
@@ -28,4 +28,9 @@
  * under the License.
  */
 
-export { OuiFieldNumber, OuiFieldNumberProps } from './field_number';
+export {
+  OuiFieldNumber,
+  OuiFieldNumberProps,
+  OuiCompressedFieldNumber,
+  OuiCompressedFieldNumberProps,
+} from './field_number';

--- a/src/components/form/field_password/field_password.tsx
+++ b/src/components/form/field_password/field_password.tsx
@@ -200,3 +200,14 @@ OuiFieldPassword.defaultProps = {
   isLoading: false,
   compressed: false,
 };
+
+// @internal
+export type OuiCompressedFieldPasswordProps = Omit<
+  OuiFieldPasswordProps,
+  'compressed'
+>;
+
+// @internal
+export const OuiCompressedFieldPassword: FunctionComponent<OuiFieldPasswordProps> = (
+  props
+) => <OuiFieldPassword {...props} compressed />;

--- a/src/components/form/field_password/index.ts
+++ b/src/components/form/field_password/index.ts
@@ -28,4 +28,9 @@
  * under the License.
  */
 
-export { OuiFieldPassword, OuiFieldPasswordProps } from './field_password';
+export {
+  OuiFieldPassword,
+  OuiFieldPasswordProps,
+  OuiCompressedFieldPassword,
+  OuiCompressedFieldPasswordProps,
+} from './field_password';

--- a/src/components/form/field_search/field_search.tsx
+++ b/src/components/form/field_search/field_search.tsx
@@ -291,3 +291,17 @@ export class OuiFieldSearch extends Component<
     );
   }
 }
+
+// @internal
+export type OuiCompressedFieldSearchProps = Omit<
+  OuiFieldSearchProps,
+  'compressed'
+>;
+
+// @internal
+export class OuiCompressedFieldSearch extends OuiFieldSearch {
+  static defaultProps = {
+    ...OuiFieldSearch.defaultProps,
+    compressed: true,
+  };
+}

--- a/src/components/form/field_search/index.ts
+++ b/src/components/form/field_search/index.ts
@@ -28,4 +28,9 @@
  * under the License.
  */
 
-export { OuiFieldSearch, OuiFieldSearchProps } from './field_search';
+export {
+  OuiFieldSearch,
+  OuiFieldSearchProps,
+  OuiCompressedFieldSearch,
+  OuiCompressedFieldSearchProps,
+} from './field_search';

--- a/src/components/form/field_text/field_text.tsx
+++ b/src/components/form/field_text/field_text.tsx
@@ -130,3 +130,11 @@ export const OuiFieldText: FunctionComponent<OuiFieldTextProps> = ({
     </OuiFormControlLayout>
   );
 };
+
+// @internal
+export type OuiCompressedFieldTextProps = Omit<OuiFieldTextProps, 'compressed'>;
+
+// @internal
+export const OuiCompressedFieldText: FunctionComponent<OuiCompressedFieldTextProps> = (
+  props
+) => <OuiFieldText {...props} compressed />;

--- a/src/components/form/field_text/index.ts
+++ b/src/components/form/field_text/index.ts
@@ -28,4 +28,9 @@
  * under the License.
  */
 
-export { OuiFieldText, OuiFieldTextProps } from './field_text';
+export {
+  OuiFieldText,
+  OuiFieldTextProps,
+  OuiCompressedFieldText,
+  OuiCompressedFieldTextProps,
+} from './field_text';

--- a/src/components/form/file_picker/file_picker.tsx
+++ b/src/components/form/file_picker/file_picker.tsx
@@ -263,3 +263,17 @@ export class OuiFilePicker extends Component<OuiFilePickerProps> {
     );
   }
 }
+
+// @internal
+export type OuiCompressedFilePickerProps = Omit<
+  OuiFilePickerProps,
+  'compressed'
+>;
+
+// @internal
+export class OuiCompressedFilePicker extends OuiFilePicker {
+  static defaultProps = {
+    ...OuiFilePicker.defaultProps,
+    compressed: true,
+  };
+}

--- a/src/components/form/file_picker/index.ts
+++ b/src/components/form/file_picker/index.ts
@@ -28,4 +28,9 @@
  * under the License.
  */
 
-export { OuiFilePicker, OuiFilePickerProps } from './file_picker';
+export {
+  OuiFilePicker,
+  OuiFilePickerProps,
+  OuiCompressedFilePicker,
+  OuiCompressedFilePickerProps,
+} from './file_picker';

--- a/src/components/form/form_fieldset/form_legend.tsx
+++ b/src/components/form/form_fieldset/form_legend.tsx
@@ -75,3 +75,14 @@ export const OuiFormLegend: FunctionComponent<OuiFormLegendProps> = ({
     </legend>
   );
 };
+
+// @internal
+export type OuiCompressedFormLegendProps = Omit<
+  OuiFormLegendProps,
+  'compressed'
+>;
+
+// @internal
+export const OuiCompressedFormLegend: FunctionComponent<OuiCompressedFormLegendProps> = (
+  props
+) => <OuiFormLegend {...props} compressed />;

--- a/src/components/form/form_fieldset/index.ts
+++ b/src/components/form/form_fieldset/index.ts
@@ -29,4 +29,9 @@
  */
 
 export { OuiFormFieldset, OuiFormFieldsetProps } from './form_fieldset';
-export { OuiFormLegend, OuiFormLegendProps } from './form_legend';
+export {
+  OuiFormLegend,
+  OuiFormLegendProps,
+  OuiCompressedFormLegend,
+  OuiCompressedFormLegendProps,
+} from './form_legend';

--- a/src/components/form/form_row/form_row.tsx
+++ b/src/components/form/form_row/form_row.tsx
@@ -328,3 +328,17 @@ export class OuiFormRow extends Component<OuiFormRowProps, OuiFormRowState> {
     );
   }
 }
+
+// @internal
+export type OuiCompressedFormRowProps = ExclusiveUnion<
+  Omit<LabelProps, 'display'>,
+  Omit<LegendProps, 'display'>
+>;
+
+// @internal
+export class OuiCompressedFormRow extends OuiFormRow {
+  static defaultProps = {
+    ...OuiFormRow.defaultProps,
+    display: 'rowCompressed',
+  };
+}

--- a/src/components/form/form_row/index.ts
+++ b/src/components/form/form_row/index.ts
@@ -28,4 +28,9 @@
  * under the License.
  */
 
-export { OuiFormRow, OuiFormRowProps } from './form_row';
+export {
+  OuiFormRow,
+  OuiFormRowProps,
+  OuiCompressedFormRow,
+  OuiCompressedFormRowProps,
+} from './form_row';

--- a/src/components/form/radio/index.ts
+++ b/src/components/form/radio/index.ts
@@ -28,9 +28,16 @@
  * under the License.
  */
 
-export { OuiRadio, OuiRadioProps } from './radio';
+export {
+  OuiRadio,
+  OuiRadioProps,
+  OuiCompressedRadio,
+  OuiCompressedRadioProps,
+} from './radio';
 export {
   OuiRadioGroup,
   OuiRadioGroupProps,
   OuiRadioGroupOption,
+  OuiCompressedRadioGroup,
+  OuiCompressedRadioGroupProps,
 } from './radio_group';

--- a/src/components/form/radio/radio.tsx
+++ b/src/components/form/radio/radio.tsx
@@ -120,3 +120,16 @@ export const OuiRadio: FunctionComponent<OuiRadioProps> = ({
     </div>
   );
 };
+
+// @internal
+export type OuiCompressedRadioProps = CommonProps &
+  Omit<HTMLAttributes<HTMLDivElement>, 'onChange' | 'id'> &
+  ExclusiveUnion<
+    ExclusiveUnion<Omit<RadioProps, 'compressed'>, idWithLabel>,
+    withId
+  >;
+
+// @internal
+export const OuiCompressedRadio: FunctionComponent<OuiCompressedRadioProps> = (
+  props
+) => <OuiRadio {...props} compressed />;

--- a/src/components/form/radio/radio_group.tsx
+++ b/src/components/form/radio/radio_group.tsx
@@ -126,3 +126,17 @@ export const OuiRadioGroup: FunctionComponent<OuiRadioGroupProps> = ({
     </div>
   );
 };
+
+// @internal
+export type OuiCompressedRadioGroupProps = CommonProps & {
+  disabled?: boolean;
+  name?: string;
+  options: OuiRadioGroupOption[];
+  idSelected?: string;
+  onChange: OuiRadioGroupChangeCallback;
+} & ExclusiveUnion<AsDivProps, WithLegendProps>;
+
+// @internal
+export const OuiCompressedRadioGroup: FunctionComponent<OuiCompressedRadioGroupProps> = (
+  props
+) => <OuiRadioGroup {...props} compressed />;

--- a/src/components/form/range/dual_range.tsx
+++ b/src/components/form/range/dual_range.tsx
@@ -794,3 +794,14 @@ export class OuiDualRange extends Component<OuiDualRangeProps> {
     return thePopover || theRange;
   }
 }
+
+// @internal
+export type OuiCompressedDualRangeProps = Omit<OuiDualRangeProps, 'compressed'>;
+
+// @internal
+export class OuiCompressedDualRange extends OuiDualRange {
+  static defaultProps = {
+    ...OuiDualRange.defaultProps,
+    compressed: true,
+  };
+}

--- a/src/components/form/range/index.ts
+++ b/src/components/form/range/index.ts
@@ -28,5 +28,16 @@
  * under the License.
  */
 
-export { OuiDualRange, OuiDualRangeProps } from './dual_range';
-export { OuiRange, OuiRangeProps } from './range';
+export {
+  OuiDualRange,
+  OuiDualRangeProps,
+  OuiCompressedDualRange,
+  OuiCompressedDualRangeProps,
+} from './dual_range';
+
+export {
+  OuiRange,
+  OuiRangeProps,
+  OuiCompressedRange,
+  OuiCompressedRangeProps,
+} from './range';

--- a/src/components/form/range/range.tsx
+++ b/src/components/form/range/range.tsx
@@ -357,3 +357,14 @@ export class OuiRange extends Component<OuiRangeProps> {
     return thePopover ? thePopover : theRange;
   }
 }
+
+// @internal
+export type OuiCompressedRangeProps = Omit<OuiRangeProps, 'compressed'>;
+
+// @internal
+export class OuiCompressedRange extends OuiRange {
+  static defaultProps = {
+    ...OuiRange.defaultProps,
+    compressed: true,
+  };
+}

--- a/src/components/form/select/index.ts
+++ b/src/components/form/select/index.ts
@@ -28,4 +28,10 @@
  * under the License.
  */
 
-export { OuiSelect, OuiSelectProps, OuiSelectOption } from './select';
+export {
+  OuiSelect,
+  OuiSelectProps,
+  OuiSelectOption,
+  OuiCompressedSelect,
+  OuiCompressedSelectProps,
+} from './select';

--- a/src/components/form/select/select.tsx
+++ b/src/components/form/select/select.tsx
@@ -178,3 +178,11 @@ export const OuiSelect: FunctionComponent<OuiSelectProps> = ({
     </OuiFormControlLayout>
   );
 };
+
+// @internal
+export type OuiCompressedSelectProps = Omit<OuiSelectProps, 'compressed'>;
+
+// @internal
+export const OuiCompressedSelect: FunctionComponent<OuiCompressedSelectProps> = (
+  props
+) => <OuiSelect {...props} compressed />;

--- a/src/components/form/super_select/index.ts
+++ b/src/components/form/super_select/index.ts
@@ -28,7 +28,13 @@
  * under the License.
  */
 
-export { OuiSuperSelect, OuiSuperSelectProps } from './super_select';
+export {
+  OuiSuperSelect,
+  OuiSuperSelectProps,
+  OuiCompressedSuperSelect,
+  OuiCompressedSuperSelectProps,
+} from './super_select';
+
 export {
   OuiSuperSelectControl,
   OuiSuperSelectControlProps,

--- a/src/components/form/super_select/super_select.tsx
+++ b/src/components/form/super_select/super_select.tsx
@@ -346,3 +346,19 @@ export class OuiSuperSelect<T extends string> extends Component<
     );
   }
 }
+
+// @internal
+export type OuiCompressedSuperSelectProps<T extends string> = Omit<
+  OuiSuperSelectProps<T>,
+  'compressed'
+>;
+
+// @internal
+export class OuiCompressedSuperSelect<T extends string> extends OuiSuperSelect<
+  T
+> {
+  static defaultProps = {
+    ...OuiSuperSelect.defaultProps,
+    compressed: true,
+  };
+}

--- a/src/components/form/switch/index.ts
+++ b/src/components/form/switch/index.ts
@@ -28,4 +28,10 @@
  * under the License.
  */
 
-export { OuiSwitch, OuiSwitchProps, OuiSwitchEvent } from './switch';
+export {
+  OuiSwitch,
+  OuiSwitchProps,
+  OuiSwitchEvent,
+  OuiCompressedSwitch,
+  OuiCompressedSwitchProps,
+} from './switch';

--- a/src/components/form/switch/switch.tsx
+++ b/src/components/form/switch/switch.tsx
@@ -163,3 +163,11 @@ export const OuiSwitch: FunctionComponent<OuiSwitchProps> = ({
     </div>
   );
 };
+
+// @internal
+export type OuiCompressedSwitchProps = Omit<OuiSwitchProps, 'compressed'>;
+
+// @internal
+export const OuiCompressedSwitch: FunctionComponent<OuiCompressedSwitchProps> = (
+  props
+) => <OuiSwitch {...props} compressed />;

--- a/src/components/form/text_area/index.ts
+++ b/src/components/form/text_area/index.ts
@@ -28,4 +28,9 @@
  * under the License.
  */
 
-export { OuiTextArea, OuiTextAreaProps } from './text_area';
+export {
+  OuiTextArea,
+  OuiTextAreaProps,
+  OuiCompressedTextArea,
+  OuiCompressedTextAreaProps,
+} from './text_area';

--- a/src/components/form/text_area/text_area.tsx
+++ b/src/components/form/text_area/text_area.tsx
@@ -105,3 +105,11 @@ export const OuiTextArea: FunctionComponent<OuiTextAreaProps> = ({
     </OuiValidatableControl>
   );
 };
+
+// @internal
+export type OuiCompressedTextAreaProps = Omit<OuiTextAreaProps, 'compressed'>;
+
+// @internal
+export const OuiCompressedTextArea: FunctionComponent<OuiCompressedTextAreaProps> = (
+  props
+) => <OuiTextArea {...props} compressed />;

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -162,6 +162,23 @@ export {
   OuiSwitch,
   OuiTextArea,
   OuiValidatableControl,
+  OuiCompressedCheckbox,
+  OuiCompressedCheckboxGroup,
+  OuiCompressedDualRange,
+  OuiCompressedFieldNumber,
+  OuiCompressedFieldPassword,
+  OuiCompressedFieldSearch,
+  OuiCompressedFieldText,
+  OuiCompressedFilePicker,
+  OuiCompressedFormLegend,
+  OuiCompressedFormRow,
+  OuiCompressedRadio,
+  OuiCompressedRadioGroup,
+  OuiCompressedRange,
+  OuiCompressedSelect,
+  OuiCompressedSuperSelect,
+  OuiCompressedSwitch,
+  OuiCompressedTextArea,
 } from './form';
 
 export {

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -57,6 +57,7 @@ export {
   OuiColorStops,
   OuiHue,
   OuiSaturation,
+  OuiCompressedColorPicker,
 } from './color_picker';
 
 export { OuiComboBox } from './combo_box';

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -33,6 +33,10 @@ export {
   OuiButtonEmpty,
   OuiButtonIcon,
   OuiButtonGroup,
+  OuiSmallButton,
+  OuiSmallButtonEmpty,
+  OuiSmallButtonIcon,
+  OuiSmallButtonGroup,
 } from './button';
 
 export { OuiCallOut } from './call_out';

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -120,6 +120,7 @@ export {
   OuiFilterButton,
   OuiFilterGroup,
   OuiFilterSelectItem,
+  OuiSmallFilterButton,
 } from './filter_group';
 
 export { OuiFacetButton, OuiFacetGroup } from './facet';

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -60,7 +60,7 @@ export {
   OuiCompressedColorPicker,
 } from './color_picker';
 
-export { OuiComboBox } from './combo_box';
+export { OuiComboBox, OuiCompressedComboBox } from './combo_box';
 
 export { OuiComment, OuiCommentList } from './comment_list';
 


### PR DESCRIPTION
### Description

This PR introduces special variants of the necessary components with fixed size or density properties, in order to mitigate potential complexities and conflicts that could arise from attempting to revert size and density modifications directly within the original components, especially as the codebase evolves over time.

#### Long version

Modifications to form elements and buttons without explicit sizing attributes are being implemented in OSD to optimize space utilization and enhance the overall aesthetic appeal. These adjustments involve setting `size="s"` or `compressed={true}` on the elements. However, a comprehensive review of OUI's typography and sizing conventions is scheduled, which could potentially necessitate the reversal of these modifications.

As time progresses, reversal of the thousands of size and density modifications will become increasingly intricate due to the accumulation of neighboring code resulting in conflicts that must be addressed. Furthermore, the pre-existing sizing and density properties will become indistinguishable from the newly implemented modifications, compounding the complexity of the reversal task.

This PR introduces special variants of the necessary components with fixed size or density properties. OSD and plugins will use these variants which are marked `@internal` to indicate that they are not meant for public consumption. This strategy ensures that if a decision is made to revert to the previous sizing and density specifications, the process of identifying and modifying the components will be more straightforward. Instead of having to search through and update individual size and density properties scattered across numerous instances of the original components, the instances of the special variants can be located and replaced more efficiently. If the typography revisit does not necessitate a reversal, transitioning the special variants to utilize the original components with the desired size and density properties would be a straightforward process as well.


### Check List
- [X] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] All tests pass
  - [ ] `yarn lint`
  - [ ] `yarn test-unit`
- [x] Update [CHANGELOG.md](./../CHANGELOG.md)
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/oui/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
