### PR TITLE
fix: Make QuickSelectPopover padding small in SuperDatePicker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 
 - Fix next reset for code blocks and super update button icon ([#1306])(https://github.com/opensearch-project/oui/pull/1306)
 - Fix the appearance of form controls in grouped layouts ([#1311])(https://github.com/opensearch-project/oui/pull/1311)
+- Fix QuickSelectPopover padding in SuperDatePicker ({}())
 
 ### 🚞 Infrastructure
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@
 
 - Fix next reset for code blocks and super update button icon ([#1306])(https://github.com/opensearch-project/oui/pull/1306)
 - Fix the appearance of form controls in grouped layouts ([#1311])(https://github.com/opensearch-project/oui/pull/1311)
-- Fix QuickSelectPopover padding in SuperDatePicker ({}())
+- Fix QuickSelectPopover padding in SuperDatePicker ([#1315](https://github.com/opensearch-project/oui/pull/1315))
 
 ### 🚞 Infrastructure
 

--- a/src/components/date_picker/super_date_picker/quick_select_popover/__snapshots__/quick_select_popover.test.tsx.snap
+++ b/src/components/date_picker/super_date_picker/quick_select_popover/__snapshots__/quick_select_popover.test.tsx.snap
@@ -30,7 +30,7 @@ exports[`OuiQuickSelectPopover is rendered 1`] = `
   hasArrow={true}
   isOpen={false}
   ownFocus={true}
-  panelPaddingSize="m"
+  panelPaddingSize="s"
 >
   <div
     className="ouiQuickSelectPopover__content"
@@ -114,7 +114,7 @@ exports[`OuiQuickSelectPopover isAutoRefreshOnly 1`] = `
   hasArrow={true}
   isOpen={false}
   ownFocus={true}
-  panelPaddingSize="m"
+  panelPaddingSize="s"
 >
   <div
     className="ouiQuickSelectPopover__content"

--- a/src/components/date_picker/super_date_picker/quick_select_popover/quick_select_popover.tsx
+++ b/src/components/date_picker/super_date_picker/quick_select_popover/quick_select_popover.tsx
@@ -196,6 +196,7 @@ export class OuiQuickSelectPopover extends Component<
         button={quickSelectButton}
         isOpen={isOpen}
         closePopover={this.closePopover}
+        panelPaddingSize="s"
         anchorPosition="downLeft"
         anchorClassName="ouiQuickSelectPopover__anchor">
         <div


### PR DESCRIPTION
### Description
This just makes the quickselectpopover in superdatepicker use small padding

| Before | After|
| ---- | ---- |
| <img width="444" alt="image" src="https://github.com/user-attachments/assets/fa72ac5b-4cd0-45b7-bcf6-5f8d56dc3f9c">| <img width="431" alt="image" src="https://github.com/user-attachments/assets/9041f018-f607-4192-b52c-e266d141f9f5">|

### Issues Resolved
N/A

### Check List
- [X] New functionality includes testing.
- [ ] New functionality has been documented.
- [X] All tests pass
  - [X] `yarn lint`
  - [X] `yarn test-unit`
- [X] Update [CHANGELOG.md](./../CHANGELOG.md)
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/oui/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
