### PR TITLE
fix: Fix now button to be secondary in SuperDatePicker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@
 - Fix next reset for code blocks and super update button icon ([#1306])(https://github.com/opensearch-project/oui/pull/1306)
 - Fix the appearance of form controls in grouped layouts ([#1311])(https://github.com/opensearch-project/oui/pull/1311)
 - Fix QuickSelectPopover padding in SuperDatePicker ([#1315](https://github.com/opensearch-project/oui/pull/1315))
-- Fix now button to be secondary in SuperDatePicker ([]())
+- Fix now button to be secondary in SuperDatePicker ([#1320](https://github.com/opensearch-project/oui/pull/1320))
 
 ### 🚞 Infrastructure
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - Fix next reset for code blocks and super update button icon ([#1306])(https://github.com/opensearch-project/oui/pull/1306)
 - Fix the appearance of form controls in grouped layouts ([#1311])(https://github.com/opensearch-project/oui/pull/1311)
 - Fix QuickSelectPopover padding in SuperDatePicker ([#1315](https://github.com/opensearch-project/oui/pull/1315))
+- Fix now button to be secondary in SuperDatePicker ([]())
 
 ### 🚞 Infrastructure
 

--- a/src/components/date_picker/super_date_picker/date_popover/date_popover_content.tsx
+++ b/src/components/date_picker/super_date_picker/date_popover/date_popover_content.tsx
@@ -132,8 +132,7 @@ export const OuiDatePopoverContent: FunctionComponent<OuiDatePopoverContentProps
               onChange('now');
             }}
             fullWidth
-            size="s"
-            fill>
+            size="s">
             Set {position} date and time to now
           </OuiButton>
         </OuiText>


### PR DESCRIPTION
### Description
Makes the now button in SuperDatePicker secondary

Before:
<img width="628" alt="image" src="https://github.com/user-attachments/assets/6c604256-1ea0-4e95-8671-266f2422bbc8">

After:
<img width="643" alt="image" src="https://github.com/user-attachments/assets/9475279c-692c-43c3-9fb2-e0e2b08edd5e">

### Issues Resolved
N/A

### Check List
- [ ] New functionality includes testing.
- [x] New functionality has been documented.
- [X] All tests pass
  - [X] `yarn lint`
  - [X] `yarn test-unit`
- [X] Update [CHANGELOG.md](./../CHANGELOG.md)
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/oui/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
