### PR TITLE
Fixes combobox height with appendees

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 🐛 Bug Fixes
 
+- Fixes combobox height with appendees ([#1338](https://github.com/opensearch-project/oui/pull/1338))
+
 ### 🚞 Infrastructure
 
 ### 📝 Documentation

--- a/src/components/combo_box/_combo_box.scss
+++ b/src/components/combo_box/_combo_box.scss
@@ -165,6 +165,19 @@
     }
   }
 
+  // Overrides the top and bottom padding of 8px with ouiFormControlLayout--group 
+  // when append/prepend is enabled, original top, bottom padding was 1px
+  .ouiFormControlLayout--group {
+    padding-top: 0;
+    padding-bottom: 0;
+  }
+
+  // Overrides line-height of 16px coming from ouiFormControlLayout--group .ouiText
+  .ouiFormControlLayout--group .ouiText {
+    // sass-lint:disable-block no-important
+    line-height: 0 !important;
+  }
+
   // Overrides the ouiFormControlLayout prepend and append height that is 100%
   .ouiFormControlLayout__prepend,
   .ouiFormControlLayout__append {


### PR DESCRIPTION
### Description
Fixes the height of combo box with appended items. Whenever an append flag is added to single select combo box, the element height increases from 40px to 42px or even 43.33px based on the type of the item appended. This PR keeps the height of all combo box variants to 40px

### Issues Resolved

Prior to fix: 
#### Regular combo box
<img width="511" alt="Screenshot 2024-08-08 at 9 49 13 AM" src="https://github.com/user-attachments/assets/50ca1bfd-4ae1-4da5-a2f3-dabe16830a75">

#### Combo box with an append item
<img width="514" alt="Screenshot 2024-08-08 at 9 49 27 AM" src="https://github.com/user-attachments/assets/5a7e7ccb-42dd-48ce-9b14-99a8089f50ad">

#### Combo box with OUIText element as append item
<img width="509" alt="Screenshot 2024-08-08 at 9 49 47 AM" src="https://github.com/user-attachments/assets/ac304244-fb96-41b7-8d70-cb78b1de7ffc">
ed

Post fix all the combo boxes are on same height of 40px (non compressed) and 32px (compressed)

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] All tests pass
  - [ ] `yarn lint`
  - [ ] `yarn test-unit`
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/oui/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
