### PR TITLE
Update styling for empty button and date picker icon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### 🐛 Bug Fixes
 
 - Fixes combobox height with appendees ([#1338](https://github.com/opensearch-project/oui/pull/1338))
+- Update styling for empty button and date picker icon ([#1342](https://github.com/opensearch-project/oui/pull/1342))
 
 ### 🚞 Infrastructure
 

--- a/src/components/button/button_empty/_button_empty.scss
+++ b/src/components/button/button_empty/_button_empty.scss
@@ -96,6 +96,7 @@ $ouiButtonEmptyTypes: (
       // Ghost is unique and ALWAYS sits against a dark background.
       color: $color;
     } @else if ($name == 'text') {
+      line-height: inherit;
       // The default color is lighter than the normal text color, make the it the text color
       color: $ouiTextColor;
     } @else {

--- a/src/components/button/button_empty/_button_empty.scss
+++ b/src/components/button/button_empty/_button_empty.scss
@@ -25,6 +25,7 @@
   animation: none !important; /* 1 */
   transition-timing-function: ease-in; /* 2 */
   transition-duration: $ouiAnimSpeedFast; /* 2 */
+  line-height: inherit;
 
   .ouiButtonEmpty__content {
     padding: 0 $ouiSizeS;
@@ -96,7 +97,6 @@ $ouiButtonEmptyTypes: (
       // Ghost is unique and ALWAYS sits against a dark background.
       color: $color;
     } @else if ($name == 'text') {
-      line-height: inherit;
       // The default color is lighter than the normal text color, make the it the text color
       color: $ouiTextColor;
     } @else {

--- a/src/components/date_picker/super_date_picker/quick_select_popover/_quick_select_popover.scss
+++ b/src/components/date_picker/super_date_picker/quick_select_popover/_quick_select_popover.scss
@@ -23,11 +23,9 @@
 }
 
 // sass-lint:disable no-important
-.ouiFormControlLayout__prepend{
-  .ouiQuickSelectPopover__buttonText {
-    // Override specificity from universal and sibling selectors
-    margin-right: calc($ouiSizeXS/2) !important;
-  }
+.ouiQuickSelectPopover__buttonText {
+  // Override specificity from universal and sibling selectors
+  margin-right: calc($ouiSizeXS/2) !important;
 }
 
 .ouiQuickSelectPopover__anchor {

--- a/src/components/date_picker/super_date_picker/quick_select_popover/_quick_select_popover.scss
+++ b/src/components/date_picker/super_date_picker/quick_select_popover/_quick_select_popover.scss
@@ -25,7 +25,7 @@
 // sass-lint:disable no-important
 .ouiQuickSelectPopover__buttonText {
   // Override specificity from universal and sibling selectors
-  margin-right: calc($ouiSizeXS/2) !important;
+  margin-right: calc($ouiSizeXS / 2) !important;
 }
 
 .ouiQuickSelectPopover__anchor {

--- a/src/components/date_picker/super_date_picker/quick_select_popover/_quick_select_popover.scss
+++ b/src/components/date_picker/super_date_picker/quick_select_popover/_quick_select_popover.scss
@@ -23,9 +23,11 @@
 }
 
 // sass-lint:disable no-important
-.ouiQuickSelectPopover__buttonText {
-  // Override specificity from universal and sibling selectors
-  margin-right: $ouiSizeXS !important;
+.ouiFormControlLayout__prepend{
+  .ouiQuickSelectPopover__buttonText {
+    // Override specificity from universal and sibling selectors
+    margin-right: calc($ouiSizeXS/2) !important;
+  }
 }
 
 .ouiQuickSelectPopover__anchor {


### PR DESCRIPTION
### Description
Update styling for empty button and date picker icon alignments issues: 
```
to the left of the search bar is the save icon. it feels 1px lower than middle and 1px left of center.
```

### Issues Resolved
* Enables button icon to be in right line-height based. 
* Reduces the spacing in between calendar button and pop over icon in super date picker

Before: 
<img width="1195" alt="Screenshot 2024-08-14 at 10 57 40 AM" src="https://github.com/user-attachments/assets/47063d73-916b-4f50-ae7f-97f73b507b1c">
After:
<img width="1213" alt="Screenshot 2024-08-14 at 10 56 39 AM" src="https://github.com/user-attachments/assets/91e55f68-e085-429c-b3f1-5293c94face3">


### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] All tests pass
  - [ ] `yarn lint`
  - [ ] `yarn test-unit`
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/oui/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
