### PR TITLE
Allow controlling the gap between the icon and the content of OuiButton and OuiButtonEmpty (#1367)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@
 
 ### 📈 Features/Enhancements
 
+- Add new icons for workspaces ([#1365](https://github.com/opensearch-project/oui/pull/1365))
+- Add a property to control the gap between an icon and the content of OuiButton and OuiButtonEmpty ([#1367](https://github.com/opensearch-project/oui/pull/1367))
+
 ### 🐛 Bug Fixes
 
 ### 🚞 Infrastructure

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@opensearch-project/oui",
   "description": "OpenSearch UI Component Library",
-  "version": "1.10.0",
+  "version": "1.11.0",
   "license": "Apache-2.0",
   "main": "lib",
   "module": "es",

--- a/src/components/basic_table/__snapshots__/in_memory_table.test.tsx.snap
+++ b/src/components/basic_table/__snapshots__/in_memory_table.test.tsx.snap
@@ -406,6 +406,7 @@ exports[`OuiInMemoryTable behavior pagination 1`] = `
                             >
                               <OuiButtonContent
                                 className="ouiButtonEmpty__content"
+                                iconGap="m"
                                 iconSide="right"
                                 iconSize="s"
                                 iconType="arrowDown"
@@ -576,6 +577,7 @@ exports[`OuiInMemoryTable behavior pagination 1`] = `
                                       >
                                         <OuiButtonContent
                                           className="ouiButtonEmpty__content"
+                                          iconGap="m"
                                           iconSide="left"
                                           iconSize="m"
                                           textProps={
@@ -659,6 +661,7 @@ exports[`OuiInMemoryTable behavior pagination 1`] = `
                                       >
                                         <OuiButtonContent
                                           className="ouiButtonEmpty__content"
+                                          iconGap="m"
                                           iconSide="left"
                                           iconSize="m"
                                           textProps={

--- a/src/components/button/__snapshots__/button.test.tsx.snap
+++ b/src/components/button/__snapshots__/button.test.tsx.snap
@@ -205,6 +205,72 @@ exports[`OuiButton props href secures the rel attribute when the target is _blan
 </a>
 `;
 
+exports[`OuiButton props iconGap m is rendered 1`] = `
+<button
+  class="ouiButton ouiButton--primary"
+  type="button"
+>
+  <span
+    class="ouiButtonContent ouiButton__content"
+  >
+    <span
+      class="ouiButtonContent__icon"
+      color="inherit"
+      data-ouiicon-type="user"
+    />
+    <span
+      class="ouiButton__text"
+    >
+      Content
+    </span>
+  </span>
+</button>
+`;
+
+exports[`OuiButton props iconGap none is rendered 1`] = `
+<button
+  class="ouiButton ouiButton--primary"
+  type="button"
+>
+  <span
+    class="ouiButtonContent ouiButtonContent--noIconGap ouiButton__content"
+  >
+    <span
+      class="ouiButtonContent__icon"
+      color="inherit"
+      data-ouiicon-type="user"
+    />
+    <span
+      class="ouiButton__text"
+    >
+      Content
+    </span>
+  </span>
+</button>
+`;
+
+exports[`OuiButton props iconGap s is rendered 1`] = `
+<button
+  class="ouiButton ouiButton--primary"
+  type="button"
+>
+  <span
+    class="ouiButtonContent ouiButtonContent--smallIconGap ouiButton__content"
+  >
+    <span
+      class="ouiButtonContent__icon"
+      color="inherit"
+      data-ouiicon-type="user"
+    />
+    <span
+      class="ouiButton__text"
+    >
+      Content
+    </span>
+  </span>
+</button>
+`;
+
 exports[`OuiButton props iconSide left is rendered 1`] = `
 <button
   class="ouiButton ouiButton--primary"

--- a/src/components/button/button.test.tsx
+++ b/src/components/button/button.test.tsx
@@ -33,7 +33,7 @@ import { render, mount } from 'enzyme';
 import { requiredProps } from '../../test/required_props';
 
 import { OuiButton, COLORS, SIZES } from './button';
-import { ICON_SIDES } from './button_content';
+import { ICON_GAPS, ICON_SIDES } from './button_content';
 
 describe('OuiButton', () => {
   test('is rendered', () => {
@@ -142,6 +142,20 @@ describe('OuiButton', () => {
         test(`${iconSide} is rendered`, () => {
           const component = render(
             <OuiButton iconType="user" iconSide={iconSide}>
+              Content
+            </OuiButton>
+          );
+
+          expect(component).toMatchSnapshot();
+        });
+      });
+    });
+
+    describe('iconGap', () => {
+      ICON_GAPS.forEach((iconGap) => {
+        test(`${iconGap} is rendered`, () => {
+          const component = render(
+            <OuiButton iconType="user" iconGap={iconGap}>
               Content
             </OuiButton>
           );

--- a/src/components/button/button.tsx
+++ b/src/components/button/button.tsx
@@ -90,7 +90,7 @@ export const SIZES = keysOf(sizeToClassNameMap);
 
 /**
  * Extends OuiButtonContentProps which provides
- * `iconType`, `iconSide`, and `textProps`
+ * `iconType`, `iconSide`, `iconGap`, and `textProps`
  */
 export interface OuiButtonProps extends OuiButtonContentProps, CommonProps {
   children?: ReactNode;
@@ -161,6 +161,7 @@ const OuiButtonDisplay = forwardRef<HTMLElement, OuiButtonDisplayProps>(
       children,
       className,
       iconType,
+      iconGap = 'm',
       iconSide = 'left',
       color = 'primary',
       size = 'm',
@@ -210,6 +211,7 @@ const OuiButtonDisplay = forwardRef<HTMLElement, OuiButtonDisplayProps>(
         isLoading={isLoading}
         iconType={iconType}
         iconSide={iconSide}
+        iconGap={iconGap}
         textProps={{ ...textProps, className: textClassNames }}
         {...contentProps}
         // className has to come last to override contentProps.className

--- a/src/components/button/button_content.tsx
+++ b/src/components/button/button_content.tsx
@@ -35,6 +35,7 @@ import { OuiLoadingSpinner } from '../loading';
 import { OuiIcon, IconType } from '../icon';
 
 export type ButtonContentIconSide = 'left' | 'right';
+export type ButtonContentIconGap = 's' | 'm' | 'none';
 
 const iconSideToClassNameMap: {
   [side in ButtonContentIconSide]: string | null;
@@ -43,7 +44,17 @@ const iconSideToClassNameMap: {
   right: 'ouiButtonContent--iconRight',
 };
 
+const iconGapToClassNameMap: {
+  [gap in ButtonContentIconGap]: string | null;
+} = {
+  m: null,
+  s: 'ouiButtonContent--smallIconGap',
+  none: 'ouiButtonContent--noIconGap',
+};
+
 export const ICON_SIDES = keysOf(iconSideToClassNameMap);
+
+export const ICON_GAPS = keysOf(iconGapToClassNameMap);
 
 export type OuiButtonContentType = HTMLAttributes<HTMLSpanElement>;
 
@@ -70,6 +81,10 @@ export interface OuiButtonContentProps extends CommonProps {
       'data-text'?: string;
     };
   iconSize?: 's' | 'm';
+  /**
+   * The gap between the icon and the content
+   */
+  iconGap?: ButtonContentIconGap;
 }
 
 export const OuiButtonContent: FunctionComponent<
@@ -80,6 +95,7 @@ export const OuiButtonContent: FunctionComponent<
   isLoading = false,
   iconType,
   iconSize = 'm',
+  iconGap = 'm',
   iconSide = 'left',
   ...contentProps
 }) => {
@@ -105,6 +121,7 @@ export const OuiButtonContent: FunctionComponent<
   const contentClassNames = classNames(
     'ouiButtonContent',
     iconSide ? iconSideToClassNameMap[iconSide] : null,
+    iconGap ? iconGapToClassNameMap[iconGap] : null,
     contentProps && contentProps.className
   );
 

--- a/src/components/button/button_empty/__snapshots__/button_empty.test.tsx.snap
+++ b/src/components/button/button_empty/__snapshots__/button_empty.test.tsx.snap
@@ -190,6 +190,72 @@ exports[`OuiButtonEmpty props href secures the rel attribute when the target is 
 </a>
 `;
 
+exports[`OuiButtonEmpty props iconGap m is rendered 1`] = `
+<button
+  class="ouiButtonEmpty ouiButtonEmpty--primary"
+  type="button"
+>
+  <span
+    class="ouiButtonContent ouiButtonEmpty__content"
+  >
+    <span
+      class="ouiButtonContent__icon"
+      color="inherit"
+      data-ouiicon-type="user"
+    />
+    <span
+      class="ouiButtonEmpty__text"
+    >
+      Content
+    </span>
+  </span>
+</button>
+`;
+
+exports[`OuiButtonEmpty props iconGap none is rendered 1`] = `
+<button
+  class="ouiButtonEmpty ouiButtonEmpty--primary"
+  type="button"
+>
+  <span
+    class="ouiButtonContent ouiButtonContent--noIconGap ouiButtonEmpty__content"
+  >
+    <span
+      class="ouiButtonContent__icon"
+      color="inherit"
+      data-ouiicon-type="user"
+    />
+    <span
+      class="ouiButtonEmpty__text"
+    >
+      Content
+    </span>
+  </span>
+</button>
+`;
+
+exports[`OuiButtonEmpty props iconGap s is rendered 1`] = `
+<button
+  class="ouiButtonEmpty ouiButtonEmpty--primary"
+  type="button"
+>
+  <span
+    class="ouiButtonContent ouiButtonContent--smallIconGap ouiButtonEmpty__content"
+  >
+    <span
+      class="ouiButtonContent__icon"
+      color="inherit"
+      data-ouiicon-type="user"
+    />
+    <span
+      class="ouiButtonEmpty__text"
+    >
+      Content
+    </span>
+  </span>
+</button>
+`;
+
 exports[`OuiButtonEmpty props iconSide left is rendered 1`] = `
 <button
   class="ouiButtonEmpty ouiButtonEmpty--primary"

--- a/src/components/button/button_empty/button_empty.test.tsx
+++ b/src/components/button/button_empty/button_empty.test.tsx
@@ -33,7 +33,7 @@ import { render, mount } from 'enzyme';
 import { requiredProps } from '../../../test/required_props';
 
 import { OuiButtonEmpty, COLORS, SIZES, FLUSH_TYPES } from './button_empty';
-import { ICON_SIDES } from '../button_content';
+import { ICON_GAPS, ICON_SIDES } from '../button_content';
 
 describe('OuiButtonEmpty', () => {
   test('is rendered', () => {
@@ -120,6 +120,20 @@ describe('OuiButtonEmpty', () => {
         test(`${iconSide} is rendered`, () => {
           const component = render(
             <OuiButtonEmpty iconType="user" iconSide={iconSide}>
+              Content
+            </OuiButtonEmpty>
+          );
+
+          expect(component).toMatchSnapshot();
+        });
+      });
+    });
+
+    describe('iconGap', () => {
+      ICON_GAPS.forEach((iconGap) => {
+        test(`${iconGap} is rendered`, () => {
+          const component = render(
+            <OuiButtonEmpty iconType="user" iconGap={iconGap}>
               Content
             </OuiButtonEmpty>
           );

--- a/src/components/button/button_empty/button_empty.tsx
+++ b/src/components/button/button_empty/button_empty.tsx
@@ -85,7 +85,7 @@ export const FLUSH_TYPES = keysOf(flushTypeToClassNameMap);
 
 /**
  * Extends OuiButtonContentProps which provides
- * `iconType`, `iconSide`, and `textProps`
+ * `iconType`, `iconSide`, `iconGap`, and `textProps`
  */
 export interface CommonOuiButtonEmptyProps
   extends OuiButtonContentProps,
@@ -136,6 +136,7 @@ export const OuiButtonEmpty: FunctionComponent<OuiButtonEmptyProps> = ({
   children,
   className,
   iconType,
+  iconGap = 'm',
   iconSide = 'left',
   color = 'primary',
   size,
@@ -189,6 +190,7 @@ export const OuiButtonEmpty: FunctionComponent<OuiButtonEmptyProps> = ({
       iconType={iconType}
       iconSide={iconSide}
       iconSize={iconSize}
+      iconGap={iconGap}
       textProps={{ ...textProps, className: textClassNames }}
       {...contentProps}
       // className has to come last to override contentProps.className

--- a/src/components/control_bar/__snapshots__/control_bar.test.tsx.snap
+++ b/src/components/control_bar/__snapshots__/control_bar.test.tsx.snap
@@ -350,6 +350,7 @@ exports[`OuiControlBar props leftOffset is rendered 1`] = `
                 >
                   <OuiButtonContent
                     className="ouiButton__content"
+                    iconGap="m"
                     iconSide="left"
                     textProps={
                       Object {
@@ -690,6 +691,7 @@ exports[`OuiControlBar props maxHeight is rendered 1`] = `
                 >
                   <OuiButtonContent
                     className="ouiButton__content"
+                    iconGap="m"
                     iconSide="left"
                     textProps={
                       Object {
@@ -1029,6 +1031,7 @@ exports[`OuiControlBar props mobile is rendered 1`] = `
                 >
                   <OuiButtonContent
                     className="ouiButton__content"
+                    iconGap="m"
                     iconSide="left"
                     textProps={
                       Object {
@@ -1272,6 +1275,7 @@ exports[`OuiControlBar props position is rendered 1`] = `
             >
               <OuiButtonContent
                 className="ouiButton__content"
+                iconGap="m"
                 iconSide="left"
                 textProps={
                   Object {
@@ -1596,6 +1600,7 @@ exports[`OuiControlBar props rightOffset is rendered 1`] = `
                 >
                   <OuiButtonContent
                     className="ouiButton__content"
+                    iconGap="m"
                     iconSide="left"
                     textProps={
                       Object {
@@ -1940,6 +1945,7 @@ exports[`OuiControlBar props showContent is rendered 1`] = `
                 >
                   <OuiButtonContent
                     className="ouiButton__content"
+                    iconGap="m"
                     iconSide="left"
                     textProps={
                       Object {
@@ -2284,6 +2290,7 @@ exports[`OuiControlBar props size is rendered 1`] = `
                 >
                   <OuiButtonContent
                     className="ouiButton__content"
+                    iconGap="m"
                     iconSide="left"
                     textProps={
                       Object {

--- a/src/components/split_button/__snapshots__/split_button.test.tsx.snap
+++ b/src/components/split_button/__snapshots__/split_button.test.tsx.snap
@@ -143,6 +143,7 @@ exports[`OuiSplitButton onClick events selection list is opened on drop-down but
                   >
                     <OuiButtonContent
                       className="ouiButton__content"
+                      iconGap="m"
                       iconSide="left"
                       textProps={
                         Object {
@@ -1218,6 +1219,7 @@ exports[`OuiSplitButton options rendering option with href renders link 1`] = `
                   >
                     <OuiButtonContent
                       className="ouiButton__content"
+                      iconGap="m"
                       iconSide="left"
                       textProps={
                         Object {
@@ -2074,6 +2076,7 @@ exports[`OuiSplitButton options rendering options are rendered when select is op
                   >
                     <OuiButtonContent
                       className="ouiButton__content"
+                      iconGap="m"
                       iconSide="left"
                       textProps={
                         Object {
@@ -3085,6 +3088,7 @@ exports[`OuiSplitButton options rendering selectedItem 0 is rendered 1`] = `
                   >
                     <OuiButtonContent
                       className="ouiButton__content"
+                      iconGap="m"
                       iconSide="left"
                       textProps={
                         Object {
@@ -4167,6 +4171,7 @@ exports[`OuiSplitButton options rendering selectedItem last is rendered 1`] = `
                   >
                     <OuiButtonContent
                       className="ouiButton__content"
+                      iconGap="m"
                       iconSide="left"
                       textProps={
                         Object {

--- a/src/global_styling/mixins/_button.scss
+++ b/src/global_styling/mixins/_button.scss
@@ -76,6 +76,16 @@
       margin-inline-start: 0; // 1, 2
       margin-inline-end: $ouiSizeS; // 1, 2
     }
+
+    &.ouiButtonContent--smallIconGap > * + * {
+      margin-inline-start: 0; // 1, 2
+      margin-inline-end: $ouiSizeXXS; // 1, 2
+    }
+
+    &.ouiButtonContent--noIconGap > * + * {
+      margin-inline-start: 0; // 1, 2
+      margin-inline-end: 0; // 1, 2
+    }
   } @else {
     display: flex;
     justify-content: center;
@@ -83,6 +93,14 @@
 
     > * + * {
       margin-inline-start: $ouiSizeS; // 1
+    }
+
+    &.ouiButtonContent--smallIconGap > * + * {
+      margin-inline-start: $ouiSizeXXS; // 1
+    }
+
+    &.ouiButtonContent--noIconGap > * + * {
+      margin-inline-start: 0; // 1
     }
   }
 }

--- a/src/global_styling/variables/_size.scss
+++ b/src/global_styling/variables/_size.scss
@@ -11,6 +11,7 @@
 
 $ouiSize:     16px !default;
 
+$ouiSizeXXS:   $ouiSize * .125 !default;
 $ouiSizeXS:   $ouiSize * .25 !default;
 $ouiSizeS:    $ouiSize * .5 !default;
 $ouiSizeM:    $ouiSize * .75 !default;

--- a/src/themes/oui-next/global_styling/mixins/_button.scss
+++ b/src/themes/oui-next/global_styling/mixins/_button.scss
@@ -77,6 +77,16 @@
       margin-inline-start: 0; // 1, 2
       margin-inline-end: $ouiSizeS; // 1, 2
     }
+
+    &.ouiButtonContent--smallIconGap > * + * {
+      margin-inline-start: 0; // 1, 2
+      margin-inline-end: $ouiSizeXXS;
+    }
+
+    &.ouiButtonContent--noIconGap > * + * {
+      margin-inline-start: 0; // 1, 2
+      margin-inline-end: 0;
+    }
   } @else {
     display: flex;
     justify-content: center;
@@ -84,6 +94,14 @@
 
     > * + * {
       margin-inline-start: $ouiSizeS; // 1
+    }
+
+    &.ouiButtonContent--smallIconGap > * + * {
+      margin-inline-start: $ouiSizeXXS; // 1
+    }
+
+    &.ouiButtonContent--noIconGap > * + * {
+      margin-inline-start: 0; // 1
     }
   }
 }

--- a/src/themes/oui-next/global_styling/variables/_size.scss
+++ b/src/themes/oui-next/global_styling/variables/_size.scss
@@ -11,6 +11,7 @@
 
 $ouiSize:     16px !default;
 
+$ouiSizeXXS:   $ouiSize * .125 !default;
 $ouiSizeXS:   $ouiSize * .25 !default;
 $ouiSizeS:    $ouiSize * .5 !default;
 $ouiSizeM:    $ouiSize * .75 !default;

--- a/src/themes/v9/global_styling/mixins/_button.scss
+++ b/src/themes/v9/global_styling/mixins/_button.scss
@@ -77,6 +77,16 @@
       margin-inline-start: 0; // 1, 2
       margin-inline-end: $ouiSizeS; // 1, 2
     }
+
+    &.ouiButtonContent--smallIconGap > * + * {
+      margin-inline-start: 0; // 1, 2
+      margin-inline-end: $ouiSizeXXS; // 1, 2
+    }
+
+    &.ouiButtonContent--noIconGap > * + * {
+      margin-inline-start: 0; // 1, 2
+      margin-inline-end: 0; // 1, 2
+    }
   } @else {
     display: flex;
     justify-content: center;
@@ -84,6 +94,14 @@
 
     > * + * {
       margin-inline-start: $ouiSizeS; // 1
+    }
+
+    &.ouiButtonContent--smallIconGap > * + * {
+      margin-inline-start: $ouiSizeXXS; // 1
+    }
+
+    &.ouiButtonContent--noIconGap > * + * {
+      margin-inline-start: 0; // 1
     }
   }
 }

--- a/src/themes/v9/global_styling/variables/_size.scss
+++ b/src/themes/v9/global_styling/variables/_size.scss
@@ -11,6 +11,7 @@
 
 $ouiSize:     16px !default;
 
+$ouiSizeXXS:   $ouiSize * .125 !default;
 $ouiSizeXS:   $ouiSize * .25 !default;
 $ouiSizeS:    $ouiSize * .5 !default;
 $ouiSizeM:    $ouiSize * .75 !default;


### PR DESCRIPTION
cherry picked from commit 7bdea7afd9874e3c1b5ad75e5beb62763dcc7fe7 from #1367

Also:
* Bumped package version to the next release

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] All tests pass
  - [ ] `yarn lint`
  - [ ] `yarn test-unit`
- [X] Update [CHANGELOG.md](./../CHANGELOG.md)
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/oui/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
