### PR TITLE
Expand definition of `$ouiBreakpoints` to include `xxl` and `xxxl`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### 📈 Features/Enhancements
 
 - Add `compressed` to OuiDatePicker ([#1380](https://github.com/opensearch-project/oui/pull/1380))
+- Expand the definitions of `$ouiBreakpoints` to include `xxl` and `xxxl` ([#1387](https://github.com/opensearch-project/oui/pull/1387))
 
 ### 🐛 Bug Fixes
 

--- a/src/global_styling/variables/_responsive.scss
+++ b/src/global_styling/variables/_responsive.scss
@@ -14,7 +14,9 @@ $ouiBreakpoints: (
   's':  575px,
   'm':  768px,
   'l':  992px,
-  'xl': 1200px
+  'xl': 1200px,
+  'xxl': 1680px,
+  'xxxl': 1920px
 ) !default;
 
 $ouiBreakpointKeys: map-keys($ouiBreakpoints);

--- a/src/themes/oui-next/global_styling/variables/_responsive.scss
+++ b/src/themes/oui-next/global_styling/variables/_responsive.scss
@@ -14,7 +14,9 @@ $ouiBreakpoints: (
   's':  575px,
   'm':  768px,
   'l':  992px,
-  'xl': 1200px
+  'xl': 1200px,
+  'xxl': 1680px,
+  'xxxl': 1920px
 ) !default;
 
 $ouiBreakpointKeys: map-keys($ouiBreakpoints);

--- a/src/themes/v9/global_styling/variables/_responsive.scss
+++ b/src/themes/v9/global_styling/variables/_responsive.scss
@@ -14,7 +14,9 @@ $ouiBreakpoints: (
   's':  575px,
   'm':  768px,
   'l':  992px,
-  'xl': 1200px
+  'xl': 1200px,
+  'xxl': 1680px,
+  'xxxl': 1920px
 ) !default;
 
 $ouiBreakpointKeys: map-keys($ouiBreakpoints);


### PR DESCRIPTION
### Description
Expand definition of `$ouiBreakpoints` to include `xxl` and `xxxl`

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] All tests pass
  - [ ] `yarn lint`
  - [ ] `yarn test-unit`
- [X] Update [CHANGELOG.md](./../CHANGELOG.md)
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/oui/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
