### PR TITLE
Make the space between search bar and table rows match the compressed state of the search box

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Add `compressed` to OuiDatePicker ([#1380](https://github.com/opensearch-project/oui/pull/1380))
 - Expand the definitions of `$ouiBreakpoints` to include `xxl` and `xxxl` ([#1387](https://github.com/opensearch-project/oui/pull/1387))
 - Remove scaling of heading elements ([#1389](https://github.com/opensearch-project/oui/pull/1389))
+- Make the space between search bar and table rows match the compressed state of the search box ([#1391](https://github.com/opensearch-project/oui/pull/1391))
 
 ### 🐛 Bug Fixes
 

--- a/src-docs/src/views/tables/in_memory/in_memory_search.js
+++ b/src-docs/src/views/tables/in_memory/in_memory_search.js
@@ -50,6 +50,8 @@ export const Table = () => {
   const [incremental, setIncremental] = useState(false);
   const [filters, setFilters] = useState(false);
   const [contentBetween, setContentBetween] = useState(false);
+  const [compressed, setCompressed] = useState(false);
+  const [compressedSearch, setCompressedSearch] = useState(false);
 
   const columns = [
     {
@@ -95,6 +97,7 @@ export const Table = () => {
       incremental: incremental,
       schema: true,
     },
+    compressed: compressedSearch,
     filters: !filters
       ? undefined
       : [
@@ -142,12 +145,27 @@ export const Table = () => {
             onChange={() => setContentBetween(!contentBetween)}
           />
         </OuiFlexItem>
+        <OuiFlexItem grow={false}>
+          <OuiSwitch
+            label="Compressed table"
+            checked={compressed}
+            onChange={() => setCompressed(!compressed)}
+          />
+        </OuiFlexItem>
+        <OuiFlexItem grow={false}>
+          <OuiSwitch
+            label="Compressed search"
+            checked={compressedSearch}
+            onChange={() => setCompressedSearch(!compressedSearch)}
+          />
+        </OuiFlexItem>
       </OuiFlexGroup>
       <OuiSpacer size="l" />
       <OuiInMemoryTable
         items={store.users}
         columns={columns}
         search={search}
+        compressed={compressed}
         pagination={true}
         sorting={true}
         childrenBetween={

--- a/src/components/basic_table/in_memory_table.tsx
+++ b/src/components/basic_table/in_memory_table.tsx
@@ -520,7 +520,7 @@ export class OuiInMemoryTable<T> extends Component<
       return (
         <>
           <OuiSearchBar onChange={this.onQueryChange} {...searchBarProps} />
-          <OuiSpacer size="l" />
+          <OuiSpacer size={searchBarProps.compressed ? 'm' : 'l'} />
         </>
       );
     }


### PR DESCRIPTION
Make the space between search bar and table rows match the compressed state of the search box

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] All tests pass
  - [ ] `yarn lint`
  - [ ] `yarn test-unit`
- [X] Update [CHANGELOG.md](./../CHANGELOG.md)
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/oui/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
