### PR TITLE
Move Iskander, Andrey, and Sergey to the Emeritus list

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-*   @AMoo-Miki @rednaksi91 @bandinib-amzn @ashwin-pc @joshuarrrr @andreymyssak @SergeyMyssak @virajsanghvi
+*   @AMoo-Miki @bandinib-amzn @ashwin-pc @joshuarrrr @virajsanghvi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@
 
 ### 🛡 Security
 
+- [CVE-2024-39338] Bumps `axios` from 1.6.2 to 1.7.4 ([#1357](https://github.com/opensearch-project/oui/pull/1357))
+- [CVE-2024-42459][CVE-2024-42460][CVE-2024-42461] Bumps `elliptic` from 6.5.4 to 6.5.7 ([#1358](https://github.com/opensearch-project/oui/pull/1358))
+
 ### 📈 Features/Enhancements
 
 - Add `compressed` to OuiDatePicker ([#1380](https://github.com/opensearch-project/oui/pull/1380))
@@ -27,6 +30,8 @@
 - Add a playground for OuiDatePicker ([#1380](https://github.com/opensearch-project/oui/pull/1380))
 
 ### 🛠 Maintenance
+
+- Move Iskander, Andrey, and Sergey to the Emeritus list ([#1394](https://github.com/opensearch-project/oui/pull/1394))
 
 ### 🪛 Refactoring
 

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -7,12 +7,9 @@ This document contains a list of maintainers in this repo. See [opensearch-proje
 | Maintainer               | GitHub ID                                         | Affiliation |
 |--------------------------|---------------------------------------------------|-------------|
 | Miki Barahmand           | [AMoo-Miki](https://github.com/AMoo-Miki)         | Amazon      |
-| Iskander Rakhmanberdiyev | [rednaksi91](https://github.com/rednaksi91)       | Amazon      |
 | Bandini                  | [bandinib-amzn](https://github.com/bandinib-amzn) | Amazon      |
 | Ashwin P Chandran        | [ashwin-pc](https://github.com/ashwin-pc)         | Amazon      |
 | Josh Romero              | [joshuarrrr](https://github.com/joshuarrrr)       | Amazon      |
-| Andrey Myssak            | [andreymyssak](https://github.com/andreymyssak)   | Contributor |
-| Sergey Myssak            | [SergeyMyssak](https://github.com/SergeyMyssak)   | Contributor |
 | Viraj Sanghvi            | [virajsanghvi](https://github.com/virajsanghvi)   | Amazon      |
 
 
@@ -23,3 +20,6 @@ This document contains a list of maintainers in this repo. See [opensearch-proje
 | Matt Provost             | [BSFishy](https://github.com/BSFishy)             | Contributor |
 | Kroosh                   | [KrooshalUX](https://github.com/KrooshalUX)       | Contributor |
 | Sean Neumann             | [seanneumann](https://github.com/seanneumann)     | Contributor |
+| Iskander Rakhmanberdiyev | [rednaksi91](https://github.com/rednaksi91)       | Amazon      |
+| Andrey Myssak            | [andreymyssak](https://github.com/andreymyssak)   | Contributor |
+| Sergey Myssak            | [SergeyMyssak](https://github.com/SergeyMyssak)   | Contributor |


### PR DESCRIPTION
### Description
Move Iskander, Andrey, and Sergey to the Emeritus list

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] All tests pass
  - [ ] `yarn lint`
  - [ ] `yarn test-unit`
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/oui/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
