### PR TITLE
fix: update v9 light primary color

### DIFF
--- a/src/themes/v9/global_styling/variables/_colors.scss
+++ b/src/themes/v9/global_styling/variables/_colors.scss
@@ -17,7 +17,7 @@ $ouiColorGhost: #FFFFFF !default;
 $ouiColorInk: #131313 !default;
 
 // Core
-$ouiColorPrimary: #003B5C !default;
+$ouiColorPrimary: #1D70C0 !default;
 $ouiColorSecondary: #199863 !default;
 $ouiColorAccent: #B92FC5 !default;
 
@@ -52,7 +52,7 @@ $ouiColorAccentText: #B92FC5 !default;
 $ouiColorWarningText: #C48600 !default;
 $ouiColorDangerText: #C84133 !default;
 $ouiColorDisabledText: #AFAFAF !default;
-$ouiColorSuccessText: #0D6453 !default;
+$ouiColorSuccessText: #117F6A !default;
 $ouiLinkColor: $ouiColorPrimaryText !default;
 
 // Visualization colors

--- a/src/themes/v9/v9_colors_dark.scss
+++ b/src/themes/v9/v9_colors_dark.scss
@@ -47,7 +47,7 @@ $ouiTextSubduedColor: #A0A9B5;
 $ouiColorDisabled: #AFAFAF;
 
 // Contrasty text variants
-$ouiColorPrimaryText: #005EB8;
+$ouiColorPrimaryText: $ouiColorPrimary;
 $ouiColorSecondaryText: #117F6A;
 $ouiColorAccentText: #B92FC5;
 $ouiColorWarningText: #C48600;


### PR DESCRIPTION
### Description
Just updates primary action color of v9 light theme, and fixing success color to match spreadsheet

### Issues Resolved
N/A

### Changelog
- skip

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [X] All tests pass
  - [X] `yarn lint`
  - [X] `yarn test-unit`
- [X] Update [CHANGELOG.md](./../CHANGELOG.md)
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/oui/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
