### PR TITLE
Upgrade build-lib version in release pipeline to accomodate new changes

### DIFF
--- a/jenkins/release.JenkinsFile
+++ b/jenkins/release.JenkinsFile
@@ -1,4 +1,4 @@
-lib = library(identifier: 'jenkins@3.0.0', retriever: modernSCM([
+lib = library(identifier: 'jenkins@6.9.0', retriever: modernSCM([
     $class: 'GitSCMSource',
     remote: 'https://github.com/opensearch-project/opensearch-build-libraries.git',
 ]))


### PR DESCRIPTION
### Description
This change uses the GitHub tag used to release an artifact to tag the release on npmjs.org as well. As of now everything is mark latest as default which is not right. `beta` should be tagged as beta and same goes for other tags such as `rc`, `alpha`, etc. 
See https://github.com/opensearch-project/opensearch-build-libraries/releases/tag/6.9.0

This version parses the github tag and accordingly uses it in while publishing to npmjs.org

### Issues Resolved
<!-- List any issues this PR will resolve. -->
<!-- Example: Fixes #1234 -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] All tests pass
  - [ ] `yarn lint`
  - [ ] `yarn test-unit`
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/oui/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
