### PR TITLE
Temporary fix for Chrome's problem with rendering mask images

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,37 @@
 
 ### Deprecations
 
+
+### 🛡 Security
+
+
+### 📈 Features/Enhancements
+
+
+### 🐛 Bug Fixes
+
+-  Add Temporary fix for Chrome's problem with rendering mask images ([#1414](https://github.com/opensearch-project/oui/pull/1414))
+
+### 🚞 Infrastructure
+
+
+### 📝 Documentation
+
+
+### 🛠 Maintenance
+
+
+### 🪛 Refactoring
+
+
+### 🔩 Tests
+
+## [`1.13.0`](https://github.com/opensearch-project/oui/tree/1.13)
+
+### Deprecations
+
 - Deprecate `aria-label` and `data-test-subj` of OuiSearchBar which have never been consumed despite being defined ([#1381](https://github.com/opensearch-project/oui/pull/1381))
 - Deprecate the unexported `OuiBreadcrumbsSimplified` ([#1401](https://github.com/opensearch-project/oui/pull/1401))
-
 
 ### 🛡 Security
 
@@ -19,6 +47,8 @@
 - Expand the definitions of `$ouiBreakpoints` to include `xxl` and `xxxl` ([#1387](https://github.com/opensearch-project/oui/pull/1387))
 - Remove scaling of heading elements ([#1389](https://github.com/opensearch-project/oui/pull/1389))
 - Make the space between search bar and table rows match the compressed state of the search box ([#1391](https://github.com/opensearch-project/oui/pull/1391))
+- Update primary color for the v9 light theme ([#1398](https://github.com/opensearch-project/oui/pull/1398))
+- Update colors for the v9 theme ([#1402](https://github.com/opensearch-project/oui/pull/1402))
 - Add CSS breakpoints to OuiBreakpointSize ([#1401](https://github.com/opensearch-project/oui/pull/1401))
 - Allow limiting the allowed breakpoints when calling `getBreakpoint()` ([#1401](https://github.com/opensearch-project/oui/pull/1401))
 - Adjust number of responsive breadcrumbs shown per breakpoint ([#1401](https://github.com/opensearch-project/oui/pull/1401))
@@ -34,8 +64,6 @@
 - Display the last breadcrumb in a nested breadcrumb as a normal breadcrumb ([#1401](https://github.com/opensearch-project/oui/pull/1401))
 - Limit allowed breakpoints to those provided by the `responsive` prop of Oui*Breadcrumbs ([#1401](https://github.com/opensearch-project/oui/pull/1401))
 
-### 🚞 Infrastructure
-
 ### 📝 Documentation
 
 - Add a playground for OuiDatePicker ([#1380](https://github.com/opensearch-project/oui/pull/1380))
@@ -48,8 +76,6 @@
 ### 🪛 Refactoring
 
 - Refactor OuiSimplifiedBreadcrumbs into its own folder ([#1401](https://github.com/opensearch-project/oui/pull/1401))
-
-### 🔩 Tests
 
 
 ## [`1.12.0`](https://github.com/opensearch-project/oui/tree/1.12)

--- a/src/global_styling/mixins/_shadow.scss
+++ b/src/global_styling/mixins/_shadow.scss
@@ -120,8 +120,10 @@
 
   @if ($direction == 'y') {
     mask-image: linear-gradient(to bottom, #{$gradient});
+    contain: paint;
   } @else if ($direction == 'x') {
     mask-image: linear-gradient(to right, #{$gradient});
+    contain: paint;
   } @else {
     @warn "ouiOverflowShadow() expects direction to be 'y' or 'x' but got '#{$direction}'";
   }

--- a/src/themes/oui-next/global_styling/mixins/_shadow.scss
+++ b/src/themes/oui-next/global_styling/mixins/_shadow.scss
@@ -120,8 +120,10 @@
 
   @if ($direction == 'y') {
     mask-image: linear-gradient(to bottom, #{$gradient});
+    contain: paint;
   } @else if ($direction == 'x') {
     mask-image: linear-gradient(to right, #{$gradient});
+    contain: paint;
   } @else {
     @warn "ouiOverflowShadow() expects direction to be 'y' or 'x' but got '#{$direction}'";
   }

--- a/src/themes/v9/global_styling/mixins/_shadow.scss
+++ b/src/themes/v9/global_styling/mixins/_shadow.scss
@@ -120,8 +120,10 @@
 
   @if ($direction == 'y') {
     mask-image: linear-gradient(to bottom, #{$gradient});
+    contain: paint;
   } @else if ($direction == 'x') {
     mask-image: linear-gradient(to right, #{$gradient});
+    contain: paint;
   } @else {
     @warn "ouiOverflowShadow() expects direction to be 'y' or 'x' but got '#{$direction}'";
   }


### PR DESCRIPTION
### Description
Temporary fix for Chrome's problem with rendering mask images.

OUI provides the mask-image  which Chrome 129 fails to render correctly.
It is not known if or when Chrome will fix this. Since almost all of these classes
are applied to elements with scrollbars where their content contained, containing the
paint is a safe solution.

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] All tests pass
  - [ ] `yarn lint`
  - [ ] `yarn test-unit`
- [X] Update [CHANGELOG.md](./../CHANGELOG.md)
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/oui/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
