### PR TITLE
fix: Update components to respect new breakpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,35 @@
 
 ### Deprecations
 
+
+### 🛡 Security
+
+
+### 📈 Features/Enhancements
+
+
+### 🐛 Bug Fixes
+- Update components to respect new breakpoints
+
+### 🚞 Infrastructure
+
+
+### 📝 Documentation
+
+
+### 🛠 Maintenance
+
+
+### 🪛 Refactoring
+
+
+### 🔩 Tests
+
+
+## [`1.13.0`](https://github.com/opensearch-project/oui/tree/1.13)
+
+### Deprecations
+
 - Deprecate `aria-label` and `data-test-subj` of OuiSearchBar which have never been consumed despite being defined ([#1381](https://github.com/opensearch-project/oui/pull/1381))
 - Deprecate the unexported `OuiBreadcrumbsSimplified` ([#1401](https://github.com/opensearch-project/oui/pull/1401))
 

--- a/i18ntokens.json
+++ b/i18ntokens.json
@@ -234,40 +234,40 @@
     "filepath": "src/components/bottom_bar/bottom_bar.tsx"
   },
   {
+    "token": "ouiBreadcrumbsSimplified.collapsedBadge.ariaLabel",
+    "defString": "Show collapsed breadcrumbs",
+    "highlighting": "string",
+    "loc": {
+      "start": {
+        "line": 79,
+        "column": 6,
+        "index": 2234
+      },
+      "end": {
+        "line": 81,
+        "column": 45,
+        "index": 2354
+      }
+    },
+    "filepath": "src/components/breadcrumbs/breadcrumbs_simplified.tsx"
+  },
+  {
     "token": "ouiBreadcrumbs.collapsedBadge.ariaLabel",
     "defString": "Show collapsed breadcrumbs",
     "highlighting": "string",
     "loc": {
       "start": {
-        "line": 157,
+        "line": 147,
         "column": 6,
-        "index": 4951
+        "index": 4396
       },
       "end": {
-        "line": 159,
+        "line": 149,
         "column": 45,
-        "index": 5061
+        "index": 4506
       }
     },
     "filepath": "src/components/breadcrumbs/breadcrumbs.tsx"
-  },
-  {
-    "token": "ouiSimplifiedBreadcrumbs.collapsedBadge.ariaLabel",
-    "defString": "Show collapsed breadcrumbs",
-    "highlighting": "string",
-    "loc": {
-      "start": {
-        "line": 128,
-        "column": 6,
-        "index": 4196
-      },
-      "end": {
-        "line": 130,
-        "column": 45,
-        "index": 4316
-      }
-    },
-    "filepath": "src/components/breadcrumbs/simplified_breadcrumbs/simplified_breadcrumbs.tsx"
   },
   {
     "token": "ouiCardSelect.selected",

--- a/i18ntokens.json
+++ b/i18ntokens.json
@@ -234,40 +234,40 @@
     "filepath": "src/components/bottom_bar/bottom_bar.tsx"
   },
   {
-    "token": "ouiBreadcrumbsSimplified.collapsedBadge.ariaLabel",
-    "defString": "Show collapsed breadcrumbs",
-    "highlighting": "string",
-    "loc": {
-      "start": {
-        "line": 79,
-        "column": 6,
-        "index": 2234
-      },
-      "end": {
-        "line": 81,
-        "column": 45,
-        "index": 2354
-      }
-    },
-    "filepath": "src/components/breadcrumbs/breadcrumbs_simplified.tsx"
-  },
-  {
     "token": "ouiBreadcrumbs.collapsedBadge.ariaLabel",
     "defString": "Show collapsed breadcrumbs",
     "highlighting": "string",
     "loc": {
       "start": {
-        "line": 147,
+        "line": 157,
         "column": 6,
-        "index": 4396
+        "index": 4951
       },
       "end": {
-        "line": 149,
+        "line": 159,
         "column": 45,
-        "index": 4506
+        "index": 5061
       }
     },
     "filepath": "src/components/breadcrumbs/breadcrumbs.tsx"
+  },
+  {
+    "token": "ouiSimplifiedBreadcrumbs.collapsedBadge.ariaLabel",
+    "defString": "Show collapsed breadcrumbs",
+    "highlighting": "string",
+    "loc": {
+      "start": {
+        "line": 128,
+        "column": 6,
+        "index": 4196
+      },
+      "end": {
+        "line": 130,
+        "column": 45,
+        "index": 4316
+      }
+    },
+    "filepath": "src/components/breadcrumbs/simplified_breadcrumbs/simplified_breadcrumbs.tsx"
   },
   {
     "token": "ouiCardSelect.selected",

--- a/src-docs/src/views/guidelines/colors/_color_section.scss
+++ b/src-docs/src/views/guidelines/colors/_color_section.scss
@@ -9,7 +9,7 @@
  * GitHub history for details.
  */
 
-@include ouiBreakpoint('m', 'l', 'xl') {
+@include ouiBreakpoint('m', 'l', 'xl', 'xxl', 'xxxl') {
   .guideColorsPage__stickySlider {
     position: sticky;
     top: $ouiHeaderHeightCompensation;

--- a/src/components/header/header_links/header_links.test.tsx
+++ b/src/components/header/header_links/header_links.test.tsx
@@ -55,7 +55,7 @@ describe('OuiHeaderLinks', () => {
     test('is rendered', () => {
       const component = render(
         <OuiHeaderLinks
-          popoverBreakpoints={['xs', 's', 'm', 'l', 'xl']}
+          popoverBreakpoints={['xs', 's', 'm', 'l', 'xl', 'xxl', 'xxxl']}
           popoverButtonProps={{
             iconType: 'bolt',
             className: 'customButtonClass',

--- a/src/components/page/page_header/_page_header_content.scss
+++ b/src/components/page/page_header/_page_header_content.scss
@@ -13,7 +13,7 @@
   width: 100%;
 }
 
-@include ouiBreakpoint('m', 'l', 'xl') {
+@include ouiBreakpoint('m', 'l', 'xl', 'xxl', 'xxxl') {
   .ouiPageHeaderContent__rightSideItems {
     flex-direction: row-reverse;
   }

--- a/src/components/page/page_side_bar/_page_side_bar.scss
+++ b/src/components/page/page_side_bar/_page_side_bar.scss
@@ -30,7 +30,7 @@
   }
 }
 
-@include ouiBreakpoint('m', 'l', 'xl') {
+@include ouiBreakpoint('m', 'l', 'xl', 'xxl', 'xxxl') {
   .ouiPageSideBar--sticky {
     @include ouiScrollBar;
     overflow-y: auto;

--- a/src/components/page/page_template.tsx
+++ b/src/components/page/page_template.tsx
@@ -135,7 +135,7 @@ export const OuiPageTemplate: FunctionComponent<OuiPageTemplateProps> = ({
    * Full height ~madness~ logic
    */
   const canFullHeight =
-    useIsWithinBreakpoints(['m', 'l', 'xl']) &&
+    useIsWithinBreakpoints(['m', 'l', 'xl', 'xxl', 'xxxl']) &&
     (template === 'default' || template === 'empty');
   const fullHeightClass = { 'oui-fullHeight': fullHeight && canFullHeight };
   const yScrollClass = { 'oui-yScroll': fullHeight && canFullHeight };

--- a/src/components/search_bar/_search_bar.scss
+++ b/src/components/search_bar/_search_bar.scss
@@ -13,7 +13,7 @@
   min-width: calc($ouiFormMaxWidth / 2);
 }
 
-@include ouiBreakpoint('m', 'l', 'xl') {
+@include ouiBreakpoint('m', 'l', 'xl', 'xxl', 'xxxl') {
   .ouiSearchBar__filtersHolder {
     // Helps with flex-wrapping
     max-width: calc(100% - #{$ouiSize});

--- a/src/components/table/_responsive.scss
+++ b/src/components/table/_responsive.scss
@@ -21,7 +21,7 @@
   }
 }
 
-@include ouiBreakpoint('m', 'l', 'xl') {
+@include ouiBreakpoint('m', 'l', 'xl', 'xxl', 'xxxl') {
   .ouiTableRowCell--hideForDesktop { // must come last to override any special cases
     // sass-lint:disable-block no-important
     display: none !important;

--- a/src/components/table/_table.scss
+++ b/src/components/table/_table.scss
@@ -33,7 +33,7 @@
 }
 
 // Compressed styles not for mobile
-@include ouiBreakpoint('m', 'l', 'xl') {
+@include ouiBreakpoint('m', 'l', 'xl', 'xxl', 'xxxl') {
   .ouiTable--compressed {
     .ouiTableCellContent {
       @include ouiFontSizeXS;

--- a/src/global_styling/mixins/_header.scss
+++ b/src/global_styling/mixins/_header.scss
@@ -22,7 +22,7 @@
       height: calc(100% - #{$headerHeight});
     }
 
-    @include ouiBreakpoint('m', 'l', 'xl') {
+    @include ouiBreakpoint('m', 'l', 'xl', 'xxl', 'xxxl') {
       .ouiPageSideBar--sticky {
         max-height: calc(100vh - #{$headerHeight});
         top: #{$headerHeight};
@@ -47,7 +47,7 @@
       height: calc(100% - #{$headerHeight});
     }
 
-    @include euiBreakpoint('m', 'l', 'xl') {
+    @include euiBreakpoint('m', 'l', 'xl', 'xxl', 'xxxl') {
       .euiPageSideBar--sticky {
         max-height: calc(100vh - #{$headerHeight});
         top: #{$headerHeight};

--- a/src/themes/oui-next/global_styling/mixins/_header.scss
+++ b/src/themes/oui-next/global_styling/mixins/_header.scss
@@ -22,7 +22,7 @@
       height: calc(100% - #{$headerHeight});
     }
 
-    @include ouiBreakpoint('m', 'l', 'xl') {
+    @include ouiBreakpoint('m', 'l', 'xl', 'xxl', 'xxxl') {
       .ouiPageSideBar--sticky {
         max-height: calc(100vh - #{$headerHeight});
         top: #{$headerHeight};
@@ -47,7 +47,7 @@
       height: calc(100% - #{$headerHeight});
     }
 
-    @include euiBreakpoint('m', 'l', 'xl') {
+    @include euiBreakpoint('m', 'l', 'xl', 'xxl', 'xxxl') {
       .euiPageSideBar--sticky {
         max-height: calc(100vh - #{$headerHeight});
         top: #{$headerHeight};

--- a/src/themes/v9/global_styling/mixins/_header.scss
+++ b/src/themes/v9/global_styling/mixins/_header.scss
@@ -22,7 +22,7 @@
       height: calc(100% - #{$headerHeight});
     }
 
-    @include ouiBreakpoint('m', 'l', 'xl') {
+    @include ouiBreakpoint('m', 'l', 'xl', 'xxl', 'xxxl') {
       .ouiPageSideBar--sticky {
         max-height: calc(100vh - #{$headerHeight});
         top: #{$headerHeight};
@@ -47,7 +47,7 @@
       height: calc(100% - #{$headerHeight});
     }
 
-    @include euiBreakpoint('m', 'l', 'xl') {
+    @include euiBreakpoint('m', 'l', 'xl', 'xxl', 'xxxl') {
       .euiPageSideBar--sticky {
         max-height: calc(100vh - #{$headerHeight});
         top: #{$headerHeight};


### PR DESCRIPTION
### Description

When we [added new breakpoints](https://github.com/opensearch-project/oui/commit/b8a9daa3edc9e6af0b4b07ef5b6a19a5b4410cd3), we didn't update components to utilize them, leading to some bugs. This just treats new breakpoints like xl out of an abundance of caution.

### Issues Resolved
N/A

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] All tests pass
  - [ ] `yarn lint`
  - [ ] `yarn test-unit`
- [X] Update [CHANGELOG.md](./../CHANGELOG.md)
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/oui/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
