### PR TITLE
Additional updates to v9 theme

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,11 @@
 
 
 ### 📈 Features/Enhancements
-
+- Additional borderRadius sizes on Panels ([#1417](https://github.com/opensearch-project/oui/pull/1417))
+- Configuration of borderRadius on Cards ([#1417](https://github.com/opensearch-project/oui/pull/1417))
 
 ### 🐛 Bug Fixes
-- Update components to respect new breakpoints
+- Update components to respect new breakpoints ([#1416])(https://github.com/opensearch-project/oui/pull/1416)
 
 ### 🚞 Infrastructure
 
@@ -24,7 +25,9 @@
 
 
 ### 🪛 Refactoring
-
+- Make Side Nav variables themeable ([#1417](https://github.com/opensearch-project/oui/pull/1417))
+- Make Links use font-weight `$ouiFontWeightSemiBold` (no change for existing themes) ([#1417](https://github.com/opensearch-project/oui/pull/1417))
+- Enable themes to define background colors for Buttons ([#1417](https://github.com/opensearch-project/oui/pull/1417))
 
 ### 🔩 Tests
 

--- a/i18ntokens.json
+++ b/i18ntokens.json
@@ -234,40 +234,40 @@
     "filepath": "src/components/bottom_bar/bottom_bar.tsx"
   },
   {
-    "token": "ouiBreadcrumbsSimplified.collapsedBadge.ariaLabel",
-    "defString": "Show collapsed breadcrumbs",
-    "highlighting": "string",
-    "loc": {
-      "start": {
-        "line": 79,
-        "column": 6,
-        "index": 2234
-      },
-      "end": {
-        "line": 81,
-        "column": 45,
-        "index": 2354
-      }
-    },
-    "filepath": "src/components/breadcrumbs/breadcrumbs_simplified.tsx"
-  },
-  {
     "token": "ouiBreadcrumbs.collapsedBadge.ariaLabel",
     "defString": "Show collapsed breadcrumbs",
     "highlighting": "string",
     "loc": {
       "start": {
-        "line": 147,
+        "line": 157,
         "column": 6,
-        "index": 4396
+        "index": 4951
       },
       "end": {
-        "line": 149,
+        "line": 159,
         "column": 45,
-        "index": 4506
+        "index": 5061
       }
     },
     "filepath": "src/components/breadcrumbs/breadcrumbs.tsx"
+  },
+  {
+    "token": "ouiSimplifiedBreadcrumbs.collapsedBadge.ariaLabel",
+    "defString": "Show collapsed breadcrumbs",
+    "highlighting": "string",
+    "loc": {
+      "start": {
+        "line": 128,
+        "column": 6,
+        "index": 4196
+      },
+      "end": {
+        "line": 130,
+        "column": 45,
+        "index": 4316
+      }
+    },
+    "filepath": "src/components/breadcrumbs/simplified_breadcrumbs/simplified_breadcrumbs.tsx"
   },
   {
     "token": "ouiCardSelect.selected",

--- a/src-docs/src/views/card/card_example.js
+++ b/src-docs/src/views/card/card_example.js
@@ -421,7 +421,8 @@ onClick={handleClick}
           </p>
           <p>
             For non-interactive cards, reduce or eliminate the padding as needed
-            to suit your layout with the prop <OuiCode>paddingSize</OuiCode>.
+            to suit your layout with the prop <OuiCode>paddingSize</OuiCode>, or
+            adjust border radius with <OuiCode>borderRadius</OuiCode>.
           </p>
         </Fragment>
       ),

--- a/src-docs/src/views/panel/panel_color.js
+++ b/src-docs/src/views/panel/panel_color.js
@@ -24,5 +24,19 @@ export default () => (
     <OuiPanel color="transparent" hasBorder={false}>
       <p>I am a transparent box simply for padding</p>
     </OuiPanel>
+
+    <OuiSpacer />
+
+    {['m', 'l', 'xl'].map((borderRadius) => (
+      <>
+        <OuiPanel color="subdued" borderRadius={borderRadius}>
+          <p>
+            I am shaded box with{' '}
+            <code>borderRadius=&quot;{borderRadius}&quot;</code>
+          </p>
+        </OuiPanel>
+        <OuiSpacer />
+      </>
+    ))}
   </div>
 );

--- a/src-docs/src/views/panel/panel_example.js
+++ b/src-docs/src/views/panel/panel_example.js
@@ -71,6 +71,12 @@ const panelColorSnippet = [
   `<OuiPanel color="transparent" hasBorder={false}>
   <!-- Transparent panel -->
 </OuiPanel>`,
+  ...['m', 'l', 'xl'].map(
+    (borderRadius) =>
+      `<OuiPanel color="subdued" borderRadius="${borderRadius}">
+  <!-- Panel with gray background and ${borderRadius} corners -->
+</OuiPanel>`
+  ),
 ];
 
 const panelGrowSnippet = `<OuiPanel grow={false}>
@@ -198,7 +204,8 @@ export const PanelExample = {
             and provide an additional helpful aesthetic to your container in
             context. Be mindful to use color sparingly. You can also remove the
             rounded corners depending on the placement of your panel with{' '}
-            <OuiCode language="tsx">{'borderRadius="none"'}</OuiCode>
+            <OuiCode language="tsx">{'borderRadius="none"'}</OuiCode> or the
+            border radius size.
           </p>
           <p>
             Passing <OuiCode language="ts">{'color="transparent"'}</OuiCode> can

--- a/src/components/button/_button.scss
+++ b/src/components/button/_button.scss
@@ -20,6 +20,7 @@
   }
 
   border-radius: $ouiButtonBorderRadius;
+  background-color: $ouiButtonBackgroundColor;
   min-width: $ouiButtonMinWidth;
 
   .ouiButton__content {
@@ -83,6 +84,7 @@
     @if ($name == 'ghost') {
       // Ghost is unique and ALWAYS sits against a dark background.
       color: $color;
+      background-color: transparent;
     } @else if ($name == 'text') {
       // The default color is lighter than the normal text color, make the it the text color
       color: $ouiTextColor;

--- a/src/components/button/button_group/_button_group.scss
+++ b/src/components/button/button_group/_button_group.scss
@@ -32,6 +32,7 @@
     @include ouiSlightShadow;
   }
   border-radius: $ouiButtonBorderRadius + 1px; // Simply for the box-shadow
+  background-color: $ouiButtonBackgroundColor;
   max-width: 100%;
   display: flex;
   overflow: hidden;

--- a/src/components/card/card.tsx
+++ b/src/components/card/card.tsx
@@ -180,6 +180,10 @@ export type OuiCardProps = Omit<CommonProps, 'aria-label'> &
      * Use a border style of card instead of shadow
      */
     hasBorder?: OuiPanelProps['hasBorder'];
+    /**
+     * Customize card border radius
+     */
+    borderRadius?: OuiPanelProps['borderRadius'];
   } & (
     | {
         // description becomes optional when children is present
@@ -216,6 +220,7 @@ export const OuiCard: FunctionComponent<OuiCardProps> = ({
   selectable,
   display,
   paddingSize,
+  borderRadius,
   ...rest
 }) => {
   const isHrefValid = !href || validateHref(href);
@@ -405,6 +410,7 @@ export const OuiCard: FunctionComponent<OuiCardProps> = ({
       hasShadow={isDisabled || display ? false : true}
       hasBorder={display ? false : undefined}
       paddingSize={paddingSize}
+      borderRadius={borderRadius}
       {...rest}>
       {optionalCardTop}
 

--- a/src/components/form/form_control_layout/_form_control_layout.scss
+++ b/src/components/form/form_control_layout/_form_control_layout.scss
@@ -178,7 +178,7 @@
 
   &.ouiFormControlLayout--compressed {
     @include ouiFormControlDefaultShadow($borderOnly: true);
-    border-radius: calc($ouiBorderRadius / 2);
+    border-radius: $ouiFormControlCompressedBorderRadius;
     overflow: hidden; // Keeps backgrounds inside border radius
 
     // Padding

--- a/src/components/link/_mixins.scss
+++ b/src/components/link/_mixins.scss
@@ -11,7 +11,7 @@
 
 @mixin ouiLink {
   text-align: left;
-  font-weight: 600;
+  font-weight: $ouiFontWeightSemiBold;
 
   &:hover {
     text-decoration: underline;

--- a/src/components/panel/__snapshots__/panel.test.tsx.snap
+++ b/src/components/panel/__snapshots__/panel.test.tsx.snap
@@ -8,6 +8,12 @@ exports[`OuiPanel is rendered 1`] = `
 />
 `;
 
+exports[`OuiPanel props borderRadius l is rendered 1`] = `
+<div
+  class="ouiPanel ouiPanel--paddingMedium ouiPanel--borderRadiusLarge ouiPanel--plain ouiPanel--hasShadow"
+/>
+`;
+
 exports[`OuiPanel props borderRadius m is rendered 1`] = `
 <div
   class="ouiPanel ouiPanel--paddingMedium ouiPanel--borderRadiusMedium ouiPanel--plain ouiPanel--hasShadow"
@@ -17,6 +23,12 @@ exports[`OuiPanel props borderRadius m is rendered 1`] = `
 exports[`OuiPanel props borderRadius none is rendered 1`] = `
 <div
   class="ouiPanel ouiPanel--paddingMedium ouiPanel--borderRadiusNone ouiPanel--plain ouiPanel--hasShadow"
+/>
+`;
+
+exports[`OuiPanel props borderRadius xl is rendered 1`] = `
+<div
+  class="ouiPanel ouiPanel--paddingMedium ouiPanel--borderRadiusXLarge ouiPanel--plain ouiPanel--hasShadow"
 />
 `;
 

--- a/src/components/panel/panel.tsx
+++ b/src/components/panel/panel.tsx
@@ -57,6 +57,8 @@ export const SIZES = keysOf(paddingSizeToClassNameMap);
 const borderRadiusToClassNameMap = {
   none: 'ouiPanel--borderRadiusNone',
   m: 'ouiPanel--borderRadiusMedium',
+  l: 'ouiPanel--borderRadiusLarge',
+  xl: 'ouiPanel--borderRadiusXLarge',
 };
 
 export const BORDER_RADII = keysOf(borderRadiusToClassNameMap);

--- a/src/components/side_nav/_index.scss
+++ b/src/components/side_nav/_index.scss
@@ -9,7 +9,6 @@
  * GitHub history for details.
  */
 
-@import 'variables';
 @import 'mixins';
 
 @import 'side_nav';

--- a/src/components/split_button/_split_button_control.scss
+++ b/src/components/split_button/_split_button_control.scss
@@ -24,6 +24,10 @@ $splitButtonSeparatorColor: shade($ouiColorPrimary, 50%);
     border-bottom-right-radius: 0px;
     border-bottom-left-radius: 0px;
 
+    &:not(.ouiButton--fill) {
+      background: transparent;
+    }
+
     &:hover,
     &:active,
     &:focus {
@@ -36,6 +40,10 @@ $splitButtonSeparatorColor: shade($ouiColorPrimary, 50%);
     border-width: 0px;
     border-radius: 0px;
 
+    &:not(.ouiButtonIcon--fill) {
+      background: transparent;
+    }
+
     &:hover,
     &:active,
     &:focus {
@@ -47,6 +55,10 @@ $splitButtonSeparatorColor: shade($ouiColorPrimary, 50%);
   .ouiSplitButtonControl {
     border: $ouiBorderWidthThick solid $ouiBorderColor;
     border-radius: $ouiButtonBorderRadius;
+
+    &:not(.ouiButton) {
+      background: $ouiButtonBackgroundColor;
+    }
   }
 
   // Create button modifiers based upon the map.

--- a/src/global_styling/variables/_buttons.scss
+++ b/src/global_styling/variables/_buttons.scss
@@ -19,6 +19,7 @@ $ouiButtonColorDisabledText: makeDisabledContrastColor($ouiButtonColorDisabled) 
 $ouiButtonColorGhostDisabled: lightOrDarkTheme($ouiColorDarkShade, $ouiColorLightShade) !default;
 
 $ouiButtonBorderRadius: $ouiBorderRadius !default;
+$ouiButtonBackgroundColor: transparent;
 
 // Modifier naming and colors.
 $ouiButtonTypes: (
@@ -42,5 +43,6 @@ $euiButtonColorDisabled: $ouiButtonColorDisabled;
 $euiButtonColorDisabledText: $ouiButtonColorDisabledText;
 $euiButtonColorGhostDisabled: $ouiButtonColorGhostDisabled;
 $euiButtonBorderRadius: $ouiButtonBorderRadius;
+$euiButtonBackgroundColor: $ouiButtonBackgroundColor;
 $euiButtonTypes: $ouiButtonTypes;
 /* End of Aliases */

--- a/src/global_styling/variables/_index.scss
+++ b/src/global_styling/variables/_index.scss
@@ -35,3 +35,4 @@
 @import 'panel';
 @import 'tool_tip';
 @import 'collapsible_nav';
+@import 'side_nav';

--- a/src/global_styling/variables/_panel.scss
+++ b/src/global_styling/variables/_panel.scss
@@ -18,6 +18,8 @@ $ouiPanelPaddingModifiers: (
 $ouiPanelBorderRadiusModifiers: (
   'borderRadiusNone': 0,
   'borderRadiusMedium': $ouiBorderRadius,
+  'borderRadiusLarge': $ouiBorderRadius * 2,
+  'borderRadiusXLarge': $ouiBorderRadius * 4,
 ) !default;
 
 $ouiPanelBackgroundColorModifiers: (

--- a/src/global_styling/variables/_side_nav.scss
+++ b/src/global_styling/variables/_side_nav.scss
@@ -9,7 +9,7 @@
  * GitHub history for details.
  */
 
-$ouiSideNavEmphasizedBackgroundColor: transparentize($ouiColorLightShade, .7);
+$ouiSideNavEmphasizedBackgroundColor: transparentize($ouiColorLightShade, .7) !default;
 
 // Simulates the transparent backround on top of the page background to get an opaque color
 // in order to get the right contrast for text
@@ -20,10 +20,10 @@ $ouiSideNavEmphasizedBackgroundColor: transparentize($ouiColorLightShade, .7);
 }
 
 // Ensure all the possible text color have proper contrast when "emphasized"
-$ouiSideNavRootTextcolor: ouiSideNavEmphasizedContrast($ouiTitleColor);
-$ouiSideNavBranchTextcolor: ouiSideNavEmphasizedContrast($ouiTextSubduedColor);
-$ouiSideNavSelectedTextcolor: ouiSideNavEmphasizedContrast($ouiColorPrimary);
-$ouiSideNavDisabledTextcolor: ouiSideNavEmphasizedContrast($ouiButtonColorDisabledText, $ouiContrastRatioDisabled);
+$ouiSideNavRootTextcolor: ouiSideNavEmphasizedContrast($ouiTitleColor) !default;
+$ouiSideNavBranchTextcolor: ouiSideNavEmphasizedContrast($ouiTextSubduedColor) !default;
+$ouiSideNavSelectedTextcolor: ouiSideNavEmphasizedContrast($ouiColorPrimary) !default;
+$ouiSideNavDisabledTextcolor: ouiSideNavEmphasizedContrast($ouiButtonColorDisabledText, $ouiContrastRatioDisabled) !default;
 
 
 /* OUI -> EUI Aliases */

--- a/src/themes/oui-next/global_styling/variables/_buttons.scss
+++ b/src/themes/oui-next/global_styling/variables/_buttons.scss
@@ -19,6 +19,7 @@ $ouiButtonColorDisabledText: makeDisabledContrastColor($ouiButtonColorDisabled) 
 $ouiButtonColorGhostDisabled: lightOrDarkTheme($ouiColorDarkShade, $ouiColorLightShade) !default;
 
 $ouiButtonBorderRadius: $ouiBorderRadius !default;
+$ouiButtonBackgroundColor: transparent;
 
 // Modifier naming and colors.
 $ouiButtonTypes: (
@@ -42,5 +43,6 @@ $euiButtonColorDisabled: $ouiButtonColorDisabled;
 $euiButtonColorDisabledText: $ouiButtonColorDisabledText;
 $euiButtonColorGhostDisabled: $ouiButtonColorGhostDisabled;
 $euiButtonBorderRadius: $ouiButtonBorderRadius;
+$euiButtonBackgroundColor: $ouiButtonBackgroundColor;
 $euiButtonTypes: $ouiButtonTypes;
 /* End of Aliases */

--- a/src/themes/oui-next/global_styling/variables/_index.scss
+++ b/src/themes/oui-next/global_styling/variables/_index.scss
@@ -35,3 +35,4 @@
 @import 'panel';
 @import 'tool_tip';
 @import 'collapsible_nav';
+@import 'side_nav';

--- a/src/themes/oui-next/global_styling/variables/_panel.scss
+++ b/src/themes/oui-next/global_styling/variables/_panel.scss
@@ -18,6 +18,8 @@ $ouiPanelPaddingModifiers: (
 $ouiPanelBorderRadiusModifiers: (
   'borderRadiusNone': 0,
   'borderRadiusMedium': $ouiBorderRadius,
+  'borderRadiusLarge': $ouiBorderRadius * 2,
+  'borderRadiusXLarge': $ouiBorderRadius * 4,
 ) !default;
 
 $ouiPanelBackgroundColorModifiers: (

--- a/src/themes/oui-next/global_styling/variables/_side_nav.scss
+++ b/src/themes/oui-next/global_styling/variables/_side_nav.scss
@@ -1,0 +1,36 @@
+/*!
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+$ouiSideNavEmphasizedBackgroundColor: transparentize($ouiColorLightShade, .7) !default;
+
+// Simulates the transparent backround on top of the page background to get an opaque color
+// in order to get the right contrast for text
+@function ouiSideNavEmphasizedContrast($textColor, $ratio: $ouiContrastRatioText) {
+  $backgroundColorSimulated: mix($ouiPageBackgroundColor, $ouiColorLightShade, 70%);
+  $color: makeHighContrastColor($textColor, $backgroundColorSimulated, $ratio);
+  @return $color;
+}
+
+// Ensure all the possible text color have proper contrast when "emphasized"
+$ouiSideNavRootTextcolor: ouiSideNavEmphasizedContrast($ouiTitleColor) !default;
+$ouiSideNavBranchTextcolor: ouiSideNavEmphasizedContrast($ouiTextSubduedColor) !default;
+$ouiSideNavSelectedTextcolor: ouiSideNavEmphasizedContrast($ouiColorPrimary) !default;
+$ouiSideNavDisabledTextcolor: ouiSideNavEmphasizedContrast($ouiButtonColorDisabledText, $ouiContrastRatioDisabled) !default;
+
+
+/* OUI -> EUI Aliases */
+$euiSideNavEmphasizedBackgroundColor: $ouiSideNavEmphasizedBackgroundColor;
+$euiSideNavRootTextcolor: $ouiSideNavRootTextcolor;
+$euiSideNavBranchTextcolor: $ouiSideNavBranchTextcolor;
+$euiSideNavSelectedTextcolor: $ouiSideNavSelectedTextcolor;
+$euiSideNavDisabledTextcolor: $ouiSideNavDisabledTextcolor;
+@function euiSideNavEmphasizedContrast($textColor, $ratio: $ouiContrastRatioText) { @return ouiSideNavEmphasizedContrast($textColor, $ratio); }
+/* End of Aliases */

--- a/src/themes/v9/global_styling/variables/_buttons.scss
+++ b/src/themes/v9/global_styling/variables/_buttons.scss
@@ -14,13 +14,14 @@ $ouiButtonHeightSmall: $ouiSizeXL !default;
 $ouiButtonHeightXSmall: $ouiSizeL !default;
 
 // sass-lint:disable no-color-literals
-$ouiButtonColorDisabled: lightOrDarkTheme($ouiColorMediumShade, $ouiColorLightShade) !default;
+$ouiButtonColorDisabled: lightOrDarkTheme(#AFAFAF, $ouiColorLightShade) !default;
 // Only increase the contrast of background color to text to 2.0 for disabled
 $ouiButtonColorDisabledText: lightOrDarkTheme(#8E8E8E, #585858) !default;
 // sass-lint:disable no-color-literals
 $ouiButtonColorGhostDisabled: lightOrDarkTheme(#585858, #353535) !default;
 
-$ouiButtonBorderRadius: 0 !default;
+$ouiButtonBorderRadius: $ouiBorderRadius !default;
+$ouiButtonBackgroundColor: $ouiColorEmptyShade;
 
 // Modifier naming and colors.
 $ouiButtonTypes: (
@@ -44,5 +45,6 @@ $euiButtonColorDisabled: $ouiButtonColorDisabled;
 $euiButtonColorDisabledText: $ouiButtonColorDisabledText;
 $euiButtonColorGhostDisabled: $ouiButtonColorGhostDisabled;
 $euiButtonBorderRadius: $ouiButtonBorderRadius;
+$euiButtonBackgroundColor: $ouiButtonBackgroundColor;
 $euiButtonTypes: $ouiButtonTypes;
 /* End of Aliases */

--- a/src/themes/v9/global_styling/variables/_colors.scss
+++ b/src/themes/v9/global_styling/variables/_colors.scss
@@ -13,46 +13,46 @@
 @import '../functions/index';
 
 // These colors stay the same no matter the theme
-$ouiColorGhost: #FFFFFF !default;
-$ouiColorInk: #131313 !default;
+$ouiColorGhost: #F7F4F2 !default;
+$ouiColorInk: #262626 !default;
 
 // Core
 $ouiColorPrimary: #0974BE !default;
-$ouiColorSecondary: #0F7F6B !default;
-$ouiColorAccent: #9E4DC0 !default;
+$ouiColorSecondary: #107F6B !default;
+$ouiColorAccent: #7F389D !default;
 
 // Status
 $ouiColorSuccess: $ouiColorSecondary !default;
-$ouiColorWarning: #E4A330 !default;
+$ouiColorWarning: #FFC460 !default;
 $ouiColorDanger: #C84233 !default;
 
 // Grays
 $ouiColorEmptyShade: #FFFFFF !default;
-$ouiColorLightestShade: #E5E5E5 !default;
-$ouiColorLightShade: #CDCDCD !default;
-$ouiColorMediumShade: #AFAFAF !default;
+$ouiColorLightestShade: #F7F4F2 !default;
+$ouiColorLightShade: #EBE4DF !default;
+$ouiColorMediumShade: #C1AC9C !default;
 $ouiColorDarkShade: #585858 !default;
-$ouiColorDarkestShade: #2A2A2A !default;
+$ouiColorDarkestShade: #262626 !default;
 $ouiColorFullShade: #131313 !default;
 
 // Backgrounds
-$ouiPageBackgroundColor: #F9F9F9 !default;
+$ouiPageBackgroundColor: #F3EFEC !default;
 $ouiColorHighlight: #FFF3E1 !default;
 
 // Every color below must be based mathematically on the set above and in a particular order.
-$ouiTextColor: $ouiColorFullShade !default;
-$ouiTitleColor: $ouiColorFullShade !default;
-$ouiTextSubduedColor: #707070 !default;
-$ouiColorDisabled: #CDCDCD !default;
+$ouiTextColor: $ouiColorDarkestShade !default;
+$ouiTitleColor: shade($ouiTextColor, 50%) !default;
+$ouiTextSubduedColor: makeHighContrastColor($ouiColorMediumShade) !default;
+$ouiColorDisabled: tint($ouiTextColor, 70%) !default;
 
 // Contrasty text variants
-$ouiColorPrimaryText: $ouiColorPrimary !default;
-$ouiColorSecondaryText: $ouiColorSecondary !default;
-$ouiColorAccentText: $ouiColorAccent !default;
-$ouiColorWarningText: #91691F !default;
-$ouiColorDangerText: $ouiColorDanger !default;
-$ouiColorDisabledText: #8E8E8E !default;
-$ouiColorSuccessText: $ouiColorSuccess !default;
+$ouiColorPrimaryText: makeHighContrastColor($ouiColorPrimary) !default;
+$ouiColorSecondaryText: makeHighContrastColor($ouiColorSecondary) !default;
+$ouiColorAccentText: makeHighContrastColor($ouiColorAccent) !default;
+$ouiColorWarningText: makeHighContrastColor($ouiColorWarning) !default;
+$ouiColorDangerText: makeHighContrastColor($ouiColorDanger) !default;
+$ouiColorDisabledText: makeDisabledContrastColor($ouiColorDisabled) !default;
+$ouiColorSuccessText: $ouiColorSecondaryText !default;
 $ouiLinkColor: $ouiColorPrimaryText !default;
 
 // Visualization colors

--- a/src/themes/v9/global_styling/variables/_form.scss
+++ b/src/themes/v9/global_styling/variables/_form.scss
@@ -16,7 +16,7 @@ $ouiFormControlCompressedHeight: $ouiSizeXL !default;
 $ouiFormControlPadding: $ouiSizeM !default;
 $ouiFormControlCompressedPadding: $ouiSizeS !default;
 $ouiFormControlBorderRadius: 0 !default;
-$ouiFormControlCompressedBorderRadius: $ouiBorderRadiusSmall !default;
+$ouiFormControlCompressedBorderRadius: 2px !default;
 
 $ouiRadioSize: $ouiSize !default;
 $ouiCheckBoxSize: $ouiSize !default;

--- a/src/themes/v9/global_styling/variables/_index.scss
+++ b/src/themes/v9/global_styling/variables/_index.scss
@@ -35,3 +35,4 @@
 @import 'panel';
 @import 'tool_tip';
 @import 'collapsible_nav';
+@import 'side_nav';

--- a/src/themes/v9/global_styling/variables/_panel.scss
+++ b/src/themes/v9/global_styling/variables/_panel.scss
@@ -18,6 +18,8 @@ $ouiPanelPaddingModifiers: (
 $ouiPanelBorderRadiusModifiers: (
   'borderRadiusNone': 0,
   'borderRadiusMedium': $ouiBorderRadius,
+  'borderRadiusLarge': $ouiBorderRadius * 2,
+  'borderRadiusXLarge': $ouiBorderRadius * 4,
 ) !default;
 
 $ouiPanelBackgroundColorModifiers: (

--- a/src/themes/v9/global_styling/variables/_side_nav.scss
+++ b/src/themes/v9/global_styling/variables/_side_nav.scss
@@ -1,0 +1,36 @@
+/*!
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+$ouiSideNavEmphasizedBackgroundColor: rgba(9, 116, 190, .1) !default;
+
+// Simulates the transparent backround on top of the page background to get an opaque color
+// in order to get the right contrast for text
+@function ouiSideNavEmphasizedContrast($textColor, $ratio: $ouiContrastRatioText) {
+  $backgroundColorSimulated: mix($ouiPageBackgroundColor, $ouiColorLightShade, 70%);
+  $color: makeHighContrastColor($textColor, $backgroundColorSimulated, $ratio);
+  @return $color;
+}
+
+// Ensure all the possible text color have proper contrast when "emphasized"
+$ouiSideNavRootTextcolor: ouiSideNavEmphasizedContrast($ouiTitleColor) !default;
+$ouiSideNavBranchTextcolor: ouiSideNavEmphasizedContrast($ouiTextSubduedColor) !default;
+$ouiSideNavSelectedTextcolor: ouiSideNavEmphasizedContrast($ouiColorPrimary) !default;
+$ouiSideNavDisabledTextcolor: ouiSideNavEmphasizedContrast($ouiButtonColorDisabledText, $ouiContrastRatioDisabled) !default;
+
+
+/* OUI -> EUI Aliases */
+$euiSideNavEmphasizedBackgroundColor: $ouiSideNavEmphasizedBackgroundColor;
+$euiSideNavRootTextcolor: $ouiSideNavRootTextcolor;
+$euiSideNavBranchTextcolor: $ouiSideNavBranchTextcolor;
+$euiSideNavSelectedTextcolor: $ouiSideNavSelectedTextcolor;
+$euiSideNavDisabledTextcolor: $ouiSideNavDisabledTextcolor;
+@function euiSideNavEmphasizedContrast($textColor, $ratio: $ouiContrastRatioText) { @return ouiSideNavEmphasizedContrast($textColor, $ratio); }
+/* End of Aliases */

--- a/src/themes/v9/global_styling/variables/_typography.scss
+++ b/src/themes/v9/global_styling/variables/_typography.scss
@@ -65,11 +65,11 @@ $ouiLineHeight:     1.5 !default;
 $ouiBodyLineHeight: 1 !default;
 
 // Font weights
-$ouiFontWeightLight:        200 !default;
-$ouiFontWeightRegular:      300 !default;
-$ouiFontWeightMedium:       400 !default;
+$ouiFontWeightLight:        400 !default;
+$ouiFontWeightRegular:      400 !default;
+$ouiFontWeightMedium:       500 !default;
 $ouiFontWeightSemiBold:     500 !default;
-$ouiFontWeightBold:         600 !default;
+$ouiFontWeightBold:         500 !default;
 $ouiCodeFontWeightRegular:  400 !default;
 $ouiCodeFontWeightBold:     700 !default;
 
@@ -77,25 +77,25 @@ $ouiCodeFontWeightBold:     700 !default;
 // Lists all the properties per OuiTitle size that then gets looped through to create the selectors.
 // The map allows for tokenization and easier customization per theme, otherwise you'd have to override the selectors themselves
 $ouiTitles: (
-  // h4: 12px / 15px / 400
+  // h6: 14px / 17px / 500
   'xxxs': (
-    'font-size': $ouiFontSizeXS,
-    'line-height': lineHeightFromBaseline(2.1429),
+    'font-size': $ouiFontSizeS,
+    'line-height': lineHeightFromBaseline(2.4286),
     'font-weight': $ouiFontWeightMedium,
   ),
-  // h4: 12px / 15px / 400
+  // h5: 14px / 17px / 500
   'xxs': (
-    'font-size': $ouiFontSizeXS,
-    'line-height': lineHeightFromBaseline(2.1429),
+    'font-size': $ouiFontSizeS,
+    'line-height': lineHeightFromBaseline(2.4286),
     'font-weight': $ouiFontWeightMedium,
   ),
-  // h4: 14px / 17px / 400
+  // h4: 16px / 19px / 500
   'xs': (
-    'font-size': $ouiFontSize,
-    'line-height': lineHeightFromBaseline(2.8286),
+    'font-size': $ouiFontSizeM,
+    'line-height': lineHeightFromBaseline(2.7143),
     'font-weight': $ouiFontWeightMedium,
   ),
-  // h3: 18px / 22px / 400
+  // h3: 18px / 22px / 500
   's': (
     'font-size': $ouiFontSizeL,
     'line-height': lineHeightFromBaseline(3.1429),
@@ -105,13 +105,13 @@ $ouiTitles: (
   'm': (
     'font-size': $ouiFontSizeXL,
     'line-height': lineHeightFromBaseline(4.1429),
-    'font-weight': $ouiFontWeightLight,
+    'font-weight': $ouiFontWeightRegular,
   ),
   // h1: 28px / 34px / 400
   'l': (
     'font-size': $ouiFontSizeXXL,
     'line-height': lineHeightFromBaseline(4.857),
-    'font-weight': $ouiFontWeightLight,
+    'font-weight': $ouiFontWeightRegular,
   ),
 ) !default;
 


### PR DESCRIPTION
### Description

Updates to v9 theme - dark theme colors still to be updated.

New:
- Additional borderRadius sizes on Panels (might be used in osd)
- Configuration of borderRadius on Cards (might be used in osd)
- Make Side Nav variables themeable
- Make Links use font-weight `$ouiFontWeightSemiBold` (no change for existing themes)
- Make input group radius match input radius using variable

V9 updates:
- Make buttons (except icon button) have a background color (old themes use transparent)
  - UX was okay with some instances of icon buttons next to regular buttons with mixed backgrounds
- Switch back to buttons having 4px radius
- Using 0 border radius for inputs
- Update light theme colors
- Make Links use a lower font-weight
- Adjust typography size + weight

Screenshots (v7 should have no changes below)

| Item | Before (v9) | After (v9) | Before (v7) | After (v7) |
| ---- | ---- | ---- | ---- | ---- | 
| V9 Colors |![image](https://github.com/user-attachments/assets/2113cffb-35bd-47f0-bf50-a6a2824a8bd6)|![image](https://github.com/user-attachments/assets/fcbf5b96-7216-4d09-9041-a3e569e2d441)| | |
| V9 Typography|![image](https://github.com/user-attachments/assets/82c2b710-39b7-42b8-942c-563080403662)|![image](https://github.com/user-attachments/assets/bc185f95-cb81-46c7-b74a-9972c6fd3648)| | |
| EuiLink |![image](https://github.com/user-attachments/assets/028939ae-0393-4d80-81d3-8bc9ad645974)|![image](https://github.com/user-attachments/assets/0c9b8daf-a972-4901-9e51-c344d58c30d6)|![image](https://github.com/user-attachments/assets/f6442ca9-5baa-40c5-9d90-e2fe1081d771)|![image](https://github.com/user-attachments/assets/9e16e493-7ddf-404a-9e73-62f8d6a60c68)|
| Panel borderRadius | |![image](https://github.com/user-attachments/assets/224abfe6-7784-4de4-9fe9-84af92508fe0)| | |
| Card borderRadius | |![image](https://github.com/user-attachments/assets/1c79789c-63fb-4c2f-a9f3-a8d088baaff5)|  | |
| Side nav selected item |![image](https://github.com/user-attachments/assets/6e0c2271-1aa7-4923-ab8f-7e08cd02284a)|![image](https://github.com/user-attachments/assets/f84ce3a2-7474-4012-bf97-326127d20771)| | |
| Input border radius |![image](https://github.com/user-attachments/assets/bc3274b6-cf3e-41bd-85e9-126482c16885)|![image](https://github.com/user-attachments/assets/d9f2cf1d-b9af-477a-97c4-d3635a86a745)| | |
|Buttons|![image](https://github.com/user-attachments/assets/97459a3e-dc0f-4d12-8ea7-bdf70b94cf55)|![image](https://github.com/user-attachments/assets/2777b63b-3498-4994-8349-d70583270055)|![image](https://github.com/user-attachments/assets/b9dd99ea-0392-4bc5-bc87-71f97b7bab9e)|![image](https://github.com/user-attachments/assets/4164e222-8cb4-437e-aa5d-87f2672ac320)|
|Ghost Buttons|![image](https://github.com/user-attachments/assets/bf4fc595-f602-40f3-a4ba-d9ceead36000)|![image](https://github.com/user-attachments/assets/11fe3026-940f-4b8f-b6f2-759d5c657093)|![image](https://github.com/user-attachments/assets/e50a2c83-c85e-4c51-a6e7-b3b280ecd173)|![image](https://github.com/user-attachments/assets/c62ac1c2-3901-4cfa-89c8-d9dfabaf0ec7)|
|Split Buttons|![image](https://github.com/user-attachments/assets/62e8850e-cf4c-4e00-af53-64da19058e89)|![image](https://github.com/user-attachments/assets/c6ba23a0-5f79-43a7-99bc-a58773643fe6)|![image](https://github.com/user-attachments/assets/ff67de9e-7c7b-43d0-9bd9-0a711d8a5751)|![image](https://github.com/user-attachments/assets/bd255026-e1c2-4e56-a681-6521db57e4ec)|

### Issues Resolved
N/A

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] All tests pass
  - [ ] `yarn lint`
  - [ ] `yarn test-unit`
- [X] Update [CHANGELOG.md](./../CHANGELOG.md)
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/oui/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
