### PR TITLE
Update sidenav and tooltip colors in v9 theme

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ### 📈 Features/Enhancements
 - Update filter icon ([#1435](https://github.com/opensearch-project/oui/pull/1435))
+- Update v9 colors for side nav and tooltip ([#])(https://github.com/opensearch-project/oui/pull/)
 
 ### 🐛 Bug Fixes
 

--- a/src/themes/v9/global_styling/variables/_side_nav.scss
+++ b/src/themes/v9/global_styling/variables/_side_nav.scss
@@ -10,7 +10,7 @@
  */
 
 // Value not currently consumed by Side nav component
-$ouiSideNavBackgroundColor: lightOrDarkTheme(#EBE4DF, #001C28) !default; // sass-lint:disable-line no-color-literals
+$ouiSideNavBackgroundColor: lightOrDarkTheme(#EFE9E5, #001C28) !default; // sass-lint:disable-line no-color-literals
 
 $ouiSideNavEmphasizedBackgroundColor: transparentize($ouiColorPrimary, .8) !default;
 

--- a/src/themes/v9/global_styling/variables/_tool_tip.scss
+++ b/src/themes/v9/global_styling/variables/_tool_tip.scss
@@ -9,7 +9,7 @@
  * GitHub history for details.
  */
 
-$ouiTooltipBackgroundColor: $ouiColorDarkestShade !default;
+$ouiTooltipBackgroundColor: lightOrDarkTheme($ouiColorDarkestShade, #293847) !default; // sass-lint:disable-line no-color-literals
 
 $ouiTooltipAnimations: (
   top: ouiToolTipTop,


### PR DESCRIPTION
### Description
Just minor updates to v9 theme to update sidenav bg color in light mode and fix tooltip bg in dark mode (to previous value until its defined)

### Issues Resolved
N/A

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] All tests pass
  - [ ] `yarn lint`
  - [ ] `yarn test-unit`
- [X] Update [CHANGELOG.md](./../CHANGELOG.md)
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/oui/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
