### PR TITLE
Update colors for v9 theme light

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ### 📈 Features/Enhancements
 - Add sparkleFilled icon ([#1452](https://github.com/opensearch-project/oui/pull/1452))
+- Update colors v9 theme ([#1460](https://github.com/opensearch-project/oui/pull/1460))
 
 ### 🐛 Bug Fixes
 
@@ -27,6 +28,7 @@
 
 
 ### 🔩 Tests
+
 
 ## [`1.17.0`](https://github.com/opensearch-project/oui/tree/1.17)
 

--- a/src/themes/v9/global_styling/variables/_buttons.scss
+++ b/src/themes/v9/global_styling/variables/_buttons.scss
@@ -13,11 +13,10 @@ $ouiButtonHeight: $ouiSizeXXL !default;
 $ouiButtonHeightSmall: $ouiSizeXL !default;
 $ouiButtonHeightXSmall: $ouiSizeL !default;
 
-// sass-lint:disable no-color-literals
-$ouiButtonColorDisabled: lightOrDarkTheme(#D7D9DD, $ouiColorLightShade) !default;
+
+$ouiButtonColorDisabled: tintOrShade($ouiTextColor, 70%, 70%) !default;
 // Only increase the contrast of background color to text to 2.0 for disabled
-$ouiButtonColorDisabledText: lightOrDarkTheme($ouiColorDarkShade, #7F878F) !default;
-// sass-lint:disable no-color-literals
+$ouiButtonColorDisabledText: makeDisabledContrastColor($ouiButtonColorDisabled) !default;
 $ouiButtonColorGhostDisabled: lightOrDarkTheme($ouiColorDarkShade, $ouiColorLightShade) !default;
 
 $ouiButtonBorderRadius: $ouiBorderRadius !default;

--- a/src/themes/v9/global_styling/variables/_colors.scss
+++ b/src/themes/v9/global_styling/variables/_colors.scss
@@ -28,21 +28,21 @@ $ouiColorDanger: #C43D35 !default;
 
 // Grays
 $ouiColorEmptyShade: #FCFEFF !default;
-$ouiColorLightestShade: #EAECEE !default;
-$ouiColorLightShade: #D7D9DD !default;
-$ouiColorMediumShade: #A8ADB3 !default;
-$ouiColorDarkShade: #5F6872 !default;
-$ouiColorDarkestShade: #18212A !default;
-$ouiColorFullShade: #02020E !default;
+$ouiColorLightestShade: #E3E5E8 !default;
+$ouiColorLightShade: #D6D9DD !default;
+$ouiColorMediumShade: #ADB4BA !default;
+$ouiColorDarkShade: #5A6875 !default;
+$ouiColorDarkestShade: #2A3947 !default;
+$ouiColorFullShade: #0A1219 !default;
 
 // Backgrounds
 $ouiPageBackgroundColor: #F0F2F4 !default;
 $ouiColorHighlight: #FFE1B0 !default;
 
 // Every color below must be based mathematically on the set above and in a particular order.
-$ouiTextColor: #2A3947 !default;
-$ouiTitleColor: #1A2631 !default;
-$ouiTextSubduedColor: #676E75 !default;
+$ouiTextColor: $ouiColorDarkestShade !default;
+$ouiTitleColor: shade($ouiTextColor, 50%) !default;
+$ouiTextSubduedColor: makeHighContrastColor($ouiColorMediumShade) !default;
 $ouiColorDisabled: tint($ouiTextColor, 70%) !default;
 
 // Contrasty text variants
@@ -133,7 +133,7 @@ $ouiColorChartLines: shade($ouiColorLightestShade, 3%) !default;
 $ouiColorChartBand: $ouiColorLightestShade !default;
 
 // Code
-$ouiCodeBlockBackgroundColor: $ouiColorLightShade !default;
+$ouiCodeBlockBackgroundColor: $ouiColorLightestShade !default;
 $ouiCodeBlockColor: makeHighContrastColor($ouiTextColor, $ouiCodeBlockBackgroundColor) !default;
 $ouiCodeBlockSelectedBackgroundColor: inherit !default;
 $ouiCodeBlockCommentColor: makeHighContrastColor($ouiTextSubduedColor, $ouiCodeBlockBackgroundColor) !default;

--- a/src/themes/v9/global_styling/variables/_form.scss
+++ b/src/themes/v9/global_styling/variables/_form.scss
@@ -50,12 +50,12 @@ $ouiSwitchColors: (
 ) !default;
 
 // Coloring
-$ouiFormBackgroundColor: $ouiColorEmptyShade !default;
-$ouiFormBackgroundDisabledColor: $ouiColorLightestShade !default;
-$ouiFormBackgroundReadOnlyColor: $ouiColorEmptyShade !default;
+$ouiFormBackgroundColor: tintOrShade($ouiColorLightestShade, 60%, 40%) !default;
+$ouiFormBackgroundDisabledColor: darken($ouiColorLightestShade, 2%) !default;
+$ouiFormBackgroundReadOnlyColor: transparentize(lightOrDarkTheme($ouiColorLightShade, $ouiColorInk), .95) !default;
 $ouiFormBorderOpaqueColor: shadeOrTint(desaturate(adjust-hue($ouiColorPrimary, 22), 22.95), 26%, 100%) !default;
-$ouiFormBorderColor: lightOrDarkTheme(transparentize($ouiFormBorderOpaqueColor, .9), $ouiColorLightShade) !default;
-$ouiFormBorderDisabledColor: lightOrDarkTheme(transparentize($ouiFormBorderOpaqueColor, .9), $ouiColorLightestShade) !default;
+$ouiFormBorderColor: transparentize($ouiFormBorderOpaqueColor, .9) !default;
+$ouiFormBorderDisabledColor: transparentize($ouiFormBorderOpaqueColor, .9) !default;
 $ouiFormCustomControlDisabledIconColor: shadeOrTint($ouiColorMediumShade, 38%, 48.5%) !default; // exact 508c foreground for $ouiColorLightShade
 $ouiFormCustomControlBorderColor: shadeOrTint($ouiColorLightestShade, 18%, 30%) !default;
 $ouiFormControlDisabledColor: $ouiColorMediumShade !default;

--- a/src/themes/v9/global_styling/variables/_panel.scss
+++ b/src/themes/v9/global_styling/variables/_panel.scss
@@ -25,7 +25,7 @@ $ouiPanelBorderRadiusModifiers: (
 $ouiPanelBackgroundColorModifiers: (
   'transparent': transparent,
   'plain': $ouiColorEmptyShade,
-  'subdued': $ouiColorLightestShade,
+  'subdued': $ouiPageBackgroundColor,
   'accent':  tintOrShade($ouiColorAccent, 90%, 70%),
   'primary': tintOrShade($ouiColorPrimary, 90%, 70%),
   'success': tintOrShade($ouiColorSuccess, 90%, 70%),

--- a/src/themes/v9/global_styling/variables/_shadows.scss
+++ b/src/themes/v9/global_styling/variables/_shadows.scss
@@ -11,8 +11,8 @@
 
 // Shadows
 // Transparency only affects the use of variable this outside of the shadow mixins (borders)
-$ouiShadowColor: #ADB2B8 !default;
-$ouiShadowColorLarge: $ouiShadowColor !default;
+$ouiShadowColor: $ouiColorMediumShade !default;
+$ouiShadowColorLarge: shade(saturate($ouiColorMediumShade, 25%), 50%) !default;
 
 
 /* OUI -> EUI Aliases */

--- a/src/themes/v9/global_styling/variables/_tool_tip.scss
+++ b/src/themes/v9/global_styling/variables/_tool_tip.scss
@@ -9,7 +9,7 @@
  * GitHub history for details.
  */
 
-$ouiTooltipBackgroundColor: lightOrDarkTheme($ouiColorDarkestShade, $ouiColorLightestShade) !default; // sass-lint:disable-line no-color-literals
+$ouiTooltipBackgroundColor: lightOrDarkTheme($ouiColorDarkestShade, $ouiColorLightestShade) !default;
 
 $ouiTooltipAnimations: (
   top: ouiToolTipTop,


### PR DESCRIPTION
### Description
This is an update to v9 theme colors for light mode (some have impact on dark mode) made by design.

Some changes:

Colors: 
<img width="621" alt="image" src="https://github.com/user-attachments/assets/2c0ada72-04fb-4114-987a-04a508a7c7d9">

Disabled button colors:
<img width="514" alt="image" src="https://github.com/user-attachments/assets/b1ca760e-5518-4cc4-ac4d-f9e8eb2785a2">
<img width="504" alt="image" src="https://github.com/user-attachments/assets/98888385-9098-41f1-8c57-294f74ba9723">

Text Colors:
<img width="494" alt="image" src="https://github.com/user-attachments/assets/735bed28-ef31-46ed-8214-7c15fde260fa">

Form border/background colors:
<img width="290" alt="image" src="https://github.com/user-attachments/assets/ec1e4c2e-23b6-4177-b702-7070e5d42c4e">
<img width="322" alt="image" src="https://github.com/user-attachments/assets/27fc22f4-8a29-4259-8d3a-b9e9a59a486c">

Panel subdued background: 
<img width="986" alt="image" src="https://github.com/user-attachments/assets/172c6df5-b81e-4969-89a7-2eb8891f9f6a">

Tooltip background:
<img width="287" alt="image" src="https://github.com/user-attachments/assets/9bfc2c68-b219-477b-ac5e-a89363d4e177">
<img width="289" alt="image" src="https://github.com/user-attachments/assets/78e8e623-5957-416a-bf94-2071603826fd">


### Issues Resolved
N/A

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] All tests pass
  - [ ] `yarn lint`
  - [ ] `yarn test-unit`
- [X] Update [CHANGELOG.md](./../CHANGELOG.md)
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/oui/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
