### PR TITLE
Fix changelog from 1.18 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,8 @@
 
 ### Deprecations
 
-### 🛡 Security
-- Update cross-spawn to address CVE ([#1469](https://github.com/opensearch-project/oui/pull/1469))
-- Update webpack and webpack-dev-server to address CVEs ([#1473](https://github.com/opensearch-project/oui/pull/1473))
 
-## [`1.18.0`](https://github.com/opensearch-project/oui/tree/1.18)
+### 🛡 Security
 
 
 ### 📈 Features/Enhancements
@@ -21,7 +18,6 @@
 
 
 ### 📝 Documentation
- - Refactor OUI Documentation homepage layout ([#1472](https://github.com/opensearch-project/oui/pull/1472))
 
 
 ### 🛠 Maintenance
@@ -31,11 +27,24 @@
 
 
 ### 🔩 Tests
+ 
+
+## [`1.19.0`](https://github.com/opensearch-project/oui/tree/1.19)
+
+### 🛡 Security
+- Update cross-spawn to address CVE ([#1469](https://github.com/opensearch-project/oui/pull/1469))
+- Update webpack and webpack-dev-server to address CVEs ([#1473](https://github.com/opensearch-project/oui/pull/1473))
+
+### 📈 Features/Enhancements
+- Add vertical oriented button group ([#755](https://github.com/opensearch-project/oui/pull/755))
+
+### 📝 Documentation
+ - Refactor OUI Documentation homepage layout ([#1472](https://github.com/opensearch-project/oui/pull/1472))
+
 
 ## [`1.18.0`](https://github.com/opensearch-project/oui/tree/1.18)
 
 ### 📈 Features/Enhancements
-- Add vertical oriented button group ([#755](https://github.com/opensearch-project/oui/pull/755))
 - Add sparkleFilled icon ([#1452](https://github.com/opensearch-project/oui/pull/1452))
 - Update colors v9 theme ([#1460](https://github.com/opensearch-project/oui/pull/1460))
 


### PR DESCRIPTION
### Description
Vertical button groups wasn't backported to 1.x so wasn't actually in 1.18, and there was an incorrect duplicated 1.18 header. This corrects both and updates for 1.19.

### Issues Resolved
N/A

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] All tests pass
  - [ ] `yarn lint`
  - [ ] `yarn test-unit`
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/oui/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
