### PR TITLE
fix EmptyButton text line-height

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 
 ### 🐛 Bug Fixes
+- fix button line-height inherit causes text cut off ([#1490](https://github.com/opensearch-project/oui/pull/1490))
 
 
 ### 🚞 Infrastructure

--- a/src/components/button/button_empty/_button_empty.scss
+++ b/src/components/button/button_empty/_button_empty.scss
@@ -25,13 +25,13 @@
   animation: none !important; /* 1 */
   transition-timing-function: ease-in; /* 2 */
   transition-duration: $ouiAnimSpeedFast; /* 2 */
-  line-height: inherit;
 
   .ouiButtonEmpty__content {
     padding: 0 $ouiSizeS;
   }
 
   .ouiButtonEmpty__text {
+    display: flex;
     text-overflow: ellipsis;
     overflow: hidden;
   }


### PR DESCRIPTION
Removed `line-height: inherit` introduced by #1342 and use `display: flex` to fix the original issue. I believe the button `line-height` should not `inherit` as it will inherit the line-height of its parent which may result in unexpected behavior, see issue and comments in #1486 

With this commit, it also fixed the issue described in #1486

### Description
#### Before
<img width="618" alt="image" src="https://github.com/user-attachments/assets/441b35e3-5f94-4729-b774-e65f355091bf" />

<img width="653" alt="image" src="https://github.com/user-attachments/assets/471d983d-3164-45d8-83c3-ea9aaa532596" />


#### After
<img width="490" alt="image" src="https://github.com/user-attachments/assets/2e528c4f-8d30-497c-bf15-a6d179f469f0" />

<img width="645" alt="image" src="https://github.com/user-attachments/assets/9171f661-ba95-4a00-9dac-89547471cab0" />


<!-- Describe what this change achieves -->

### Issues Resolved
<!-- List any issues this PR will resolve. -->
<!-- Example: Fixes #1234 -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] All tests pass
  - [ ] `yarn lint`
  - [ ] `yarn test-unit`
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/oui/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
