### PR TITLE
Update maintainer alias from @d-rowe to @d-buckner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-*   @AMoo-Miki @bandinib-amzn @ashwin-pc @joshuarrrr @virajsanghvi @ruanyl @d-rowe
+*   @AMoo-Miki @bandinib-amzn @ashwin-pc @joshuarrrr @virajsanghvi @ruanyl @d-buckner

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 
 ### 🛠 Maintenance
 - Add @ruanyl and @d-rowe as maintainers ([#1485])(https://github.com/opensearch-project/oui/pull/1485)
+- Update maintainer alias from @d-rowe to @d-buckner ([#])(https://github.com/opensearch-project/oui/pull/) 
 
 
 ### 🪛 Refactoring

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@
 
 ### 🛠 Maintenance
 - Add @ruanyl and @d-rowe as maintainers ([#1485])(https://github.com/opensearch-project/oui/pull/1485)
-- Update maintainer alias from @d-rowe to @d-buckner ([#])(https://github.com/opensearch-project/oui/pull/) 
+- Update maintainer alias from @d-rowe to @d-buckner ([#1492])(https://github.com/opensearch-project/oui/pull/1492) 
 
 
 ### 🪛 Refactoring

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -12,7 +12,7 @@ This document contains a list of maintainers in this repo. See [opensearch-proje
 | Josh Romero              | [joshuarrrr](https://github.com/joshuarrrr)       | Amazon      |
 | Viraj Sanghvi            | [virajsanghvi](https://github.com/virajsanghvi)   | Amazon      |
 | Yulong Ruan              | [ruanyl](https://github.com/ruanyl)               | Amazon      |
-| Daniel Rowe              | [d-rowe](https://github.com/d-rowe)               | Amazon      |
+| Daniel Rowe              | [d-buckner](https://github.com/d-buckner)         | Amazon      |
 
 
 ## Emeritus


### PR DESCRIPTION
### Description
Update maintainer alias from @d-rowe to @d-buckner

### Issues Resolved
N/A

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] All tests pass
  - [ ] `yarn lint`
  - [ ] `yarn test-unit`
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/oui/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
