### PR TITLE
Add support for caching tab content in dom

### DIFF
--- a/src/components/tabs/tabbed_content/__snapshots__/tabbed_content.test.tsx.snap
+++ b/src/components/tabs/tabbed_content/__snapshots__/tabbed_content.test.tsx.snap
@@ -53,6 +53,7 @@ exports[`OuiTabbedContent behavior when selected tab state isn't controlled by t
 exports[`OuiTabbedContent behavior when uncontrolled, the selected tab should update if it receives new content 1`] = `
 <OuiTabbedContent
   autoFocus="initial"
+  cacheContent={false}
   tabs={
     Array [
       Object {

--- a/src/components/tabs/tabbed_content/tabbed_content.test.tsx
+++ b/src/components/tabs/tabbed_content/tabbed_content.test.tsx
@@ -115,6 +115,15 @@ describe('OuiTabbedContent', () => {
         });
       });
     });
+
+    describe('cacheContent', () => {
+      test('content of all tabs should appear on dom', () => {
+        const component = render(
+          <OuiTabbedContent cacheContent={true} tabs={tabs} />
+        );
+        expect(component.find('div[role="tabpanel"]').length).toBe(2);
+      });
+    });
   });
 
   describe('behavior', () => {

--- a/src/components/tabs/tabbed_content/tabbed_content.tsx
+++ b/src/components/tabs/tabbed_content/tabbed_content.tsx
@@ -84,14 +84,19 @@ export type OuiTabbedContentProps = CommonProps &
      * The name property (a node) is also required to display to the user.
      */
     tabs: OuiTabbedContentTab[];
+    /**
+     * Use this prop to control if tab content of unselected tab will stay in dom.
+     */
+    cacheContent?: boolean;
   };
 
 export class OuiTabbedContent extends Component<
   OuiTabbedContentProps,
   OuiTabbedContentState
 > {
-  static defaultProps = {
+  static defaultProps: Partial<OuiTabbedContentProps> = {
     autoFocus: 'initial',
+    cacheContent: false,
   };
 
   private readonly rootId = htmlIdGenerator()();
@@ -193,6 +198,7 @@ export class OuiTabbedContent extends Component<
       size,
       tabs,
       autoFocus,
+      cacheContent,
       ...rest
     } = this.props;
 
@@ -233,12 +239,30 @@ export class OuiTabbedContent extends Component<
           })}
         </OuiTabs>
 
-        <div
-          role="tabpanel"
-          id={`${this.rootId}`}
-          aria-labelledby={selectedTabId}>
-          {selectedTabContent}
-        </div>
+        {!cacheContent && (
+          <div
+            role="tabpanel"
+            id={`${this.rootId}`}
+            aria-labelledby={selectedTabId}>
+            {selectedTabContent}
+          </div>
+        )}
+
+        {cacheContent &&
+          tabs.map((tab: OuiTabbedContentTab) => {
+            const { id, content } = tab;
+
+            return (
+              <div
+                key={id}
+                role="tabpanel"
+                id={id}
+                aria-labelledby={id}
+                style={{ display: id === selectedTabId ? 'block' : 'none' }}>
+                {content}
+              </div>
+            );
+          })}
       </div>
     );
   }


### PR DESCRIPTION
### Description
<!-- Describe what this change achieves -->

Introduce a prop for `TabbedContent` to support caching tab content in dom tree

video:


https://github.com/user-attachments/assets/c8dc41df-c884-4c4c-bd3c-64c36515f8a8


### Issues Resolved
<!-- List any issues this PR will resolve. -->
<!-- Example: Fixes #1234 -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] All tests pass
  - [ ] `yarn lint`
  - [ ] `yarn test-unit`
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/oui/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
