### PR TITLE
Enable navigating grid headers by tab-key

### DIFF
--- a/src/components/datagrid/data_grid_body.tsx
+++ b/src/components/datagrid/data_grid_body.tsx
@@ -668,7 +668,6 @@ export const OuiDataGridBody: FunctionComponent<OuiDataGridBodyProps> = (
           element.getAttribute('role') !== 'gridcell' &&
           !element.dataset['ouigrid-tab-managed']
         ) {
-          element.setAttribute('tabIndex', '-1');
           element.setAttribute('data-datagrid-interactable', 'true');
         }
       }

--- a/src/components/datagrid/data_grid_header_cell.tsx
+++ b/src/components/datagrid/data_grid_header_cell.tsx
@@ -167,7 +167,6 @@ export const OuiDataGridHeaderCell: FunctionComponent<OuiDataGridHeaderCellProps
       for (let i = 0; i < tababbles.length; i++) {
         const element = tababbles[i];
         element.setAttribute('data-ouigrid-tab-managed', 'true');
-        element.setAttribute('tabIndex', '-1');
       }
     }
   }, []);


### PR DESCRIPTION
### Description

Make grid headers navigable via tab keys

### Issues Resolved
Resolves: #1501 

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] All tests pass
  - [ ] `yarn lint`
  - [ ] `yarn test-unit`
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/oui/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
