### PR TITLE
Fix dev server configuration after webpack-dev-server upgrade in 1.19

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 ### 🐛 Bug Fixes
 - fix button line-height inherit causes text cut off ([#1490](https://github.com/opensearch-project/oui/pull/1490))
 - Add OpenSearch logo to page title ([#1532](https://github.com/opensearch-project/oui/pull/1532))
+- Fix dev server configuration after webpack-dev-server upgrade in 1.19 ([#1567](https://github.com/opensearch-project/oui/pull/1567)) 
 
 
 ### 🚞 Infrastructure

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "*.scss"
   ],
   "scripts": {
-    "start": "cross-env BABEL_MODULES=false webpack-dev-server --hot --config=src-docs/webpack.config.js",
+    "start": "cross-env WEBPACK_DEV_SERVER=true BABEL_MODULES=false webpack-dev-server --hot --config=src-docs/dev.webpack.config.js",
     "test-docker": "node ./scripts/test-docker.js",
     "sync-docs": "node ./scripts/docs-sync.js",
     "build-docs": "cross-env BABEL_MODULES=false cross-env NODE_ENV=production NODE_OPTIONS=--max-old-space-size=4096 webpack --config=src-docs/webpack.config.js",
@@ -30,7 +30,7 @@
     "test-unit": "cross-env NODE_ENV=test jest --config ./scripts/jest/config.json",
     "test-a11y": "node ./scripts/a11y-testing",
     "test-staged": "node scripts/test-staged.js",
-    "start-test-server": "BABEL_MODULES=false NODE_ENV=puppeteer NODE_OPTIONS=--max-old-space-size=4096 webpack-dev-server --config src-docs/webpack.config.js --port 9999",
+    "start-test-server": "WEBPACK_DEV_SERVER=true BABEL_MODULES=false NODE_ENV=puppeteer NODE_OPTIONS=--max-old-space-size=4096 webpack-dev-server --config src-docs/dev.webpack.config.js --port 9999",
     "yo-component": "yo ./generator-oui/app/component.js",
     "start-test-server-and-a11y-test": "cross-env WAIT_ON_TIMEOUT=600000 start-server-and-test start-test-server http-get://localhost:9999 test-a11y",
     "yo-doc": "yo ./generator-oui/app/documentation.js",
@@ -177,7 +177,6 @@
     "cross-env": "^7.0.3",
     "css-loader": "5.0.0",
     "cssnano": "^4.1.11",
-    "deasync": "^0.1.28",
     "dedent": "^0.7.0",
     "dts-generator": "^3.0.0",
     "enzyme": "^3.11.0",

--- a/src-docs/dev.webpack.config.js
+++ b/src-docs/dev.webpack.config.js
@@ -1,0 +1,21 @@
+// Copyright OpenSearch Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+// This file is a wrapper for webpack.config.js that supports async/await solely to
+// support retrieving an availble port.
+module.exports = async function () {
+  const getPort = require('get-port');
+  const port = await getPort({
+    port: getPort.makeRange(8030, 8130),
+    host: '0.0.0.0',
+  });
+
+  const webpackConfig = require('./webpack.config.js');
+  return {
+    ...webpackConfig,
+    devServer: {
+      ...webpackConfig.devServer,
+      port,
+    },
+  };
+};

--- a/src/components/search_bar/search_bar.tsx
+++ b/src/components/search_bar/search_bar.tsx
@@ -33,11 +33,12 @@ import { isString } from '../../services/predicate';
 import { OuiFlexGroup, OuiFlexItem } from '../flex';
 import { OuiSearchBox, SchemaType } from './search_box';
 import { OuiSearchFilters, SearchFilterConfig } from './search_filters';
-import { Query } from './query/query';
+import { Query, Query as QueryForExport } from './query/query';
 import { CommonProps } from '../common';
 import { OuiFieldSearchProps } from '../form/field_search';
 
-export { Query, Ast } from './query';
+export { Ast } from './query';
+export { QueryForExport as Query }; // Explicity export and import due to webpack/babel re-export issue
 
 export type QueryType = Query | string;
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -6262,14 +6262,6 @@ dateformat@^4.5.0:
   resolved "https://registry.yarnpkg.com/dateformat/-/dateformat-4.6.3.tgz#556fa6497e5217fedb78821424f8a1c22fa3f4b5"
   integrity sha512-2P0p0pFGzHS5EMnhdxQi7aJN+iMheud0UhG4dlE1DLAlvL8JHjJJTX/CSm4JXwV0Ka5nGk3zC5mcb5bUQUxxMA==
 
-deasync@^0.1.28:
-  version "0.1.28"
-  resolved "https://registry.yarnpkg.com/deasync/-/deasync-0.1.28.tgz#9b447b79b3f822432f0ab6a8614c0062808b5ad2"
-  integrity sha512-QqLF6inIDwiATrfROIyQtwOQxjZuek13WRYZ7donU5wJPLoP67MnYxA6QtqdvdBy2mMqv5m3UefBVdJjvevOYg==
-  dependencies:
-    bindings "^1.5.0"
-    node-addon-api "^1.7.1"
-
 debug@2.6.9, debug@^2.2.0, debug@^2.3.3, debug@^2.6.9:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
@@ -10744,7 +10736,7 @@ json-stringify-nice@^1.1.4:
 json-stringify-safe@^5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz#1296a2d58fd45f19a0f6ce01d65701e2c735b6eb"
-  integrity sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=
+  integrity sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==
 
 json5@^1.0.1:
   version "1.0.2"
@@ -11972,11 +11964,6 @@ no-case@^3.0.4:
   dependencies:
     lower-case "^2.0.2"
     tslib "^2.0.3"
-
-node-addon-api@^1.7.1:
-  version "1.7.1"
-  resolved "https://registry.yarnpkg.com/node-addon-api/-/node-addon-api-1.7.1.tgz#cf813cd69bb8d9100f6bdca6755fc268f54ac492"
-  integrity sha512-2+DuKodWvwRTrCfKOeR24KIc5unKjOh8mz17NCzVnHWfjAdDqbfbjqh7gUT+BkXBRQM52+xCHciKWonJ3CbJMQ==
 
 node-emoji@^1.10.0:
   version "1.10.0"
@@ -16045,7 +16032,7 @@ supports-color@^2.0.0:
 supports-color@^3.1.2:
   version "3.2.3"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-3.2.3.tgz#65ac0504b3954171d8a64946b2ae3cbb8a5f54f6"
-  integrity sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=
+  integrity sha512-Jds2VIYDrlp5ui7t8abHN2bjAu4LV/q4N2KivFPpGH0lrka0BMq/33AmECUXlKPcHigkNaqfXRENFju+rlcy+A==
   dependencies:
     has-flag "^1.0.0"
 


### PR DESCRIPTION
### Description
https://github.com/opensearch-project/oui/pull/1473 upgraded versions of webpack-cli and webpack-dev-server. After these changes, runtime errors from ResizeObservable bubbled up to the dev server overlay causing a loop and error for certain components. This doesn't impact the production build, and this code is already out in 1.19. 

The MV upgrade of webpack-cli removed a WEBPACK_DEV_SERVER env variable, which enables us to not show runtime errors in the overlay (fixing the issue above), but also pointed out that the dev server config wasn't updated (which I did here). 

I had to drop deasync because it caused an infinite loop (unclear why this changed behavior). Other sync libraries to get ports had other issues (cves, unnecessary dependencies) and using async/await in the same file failed because eslint doesn't support async webpack config functions. I went with just wrapping this config with an async/await function in a separate file just for dev server as it seemed simplest.

Also, Query in search bar started causing an issue as its getting re-exported. Not completely clear why, but I think its because of webpack version mismatches, and I'd rather spend time upgrade webpack than fixing this, so just put in a work around.

### Issues Resolved
N/A

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] All tests pass
  - [ ] `yarn lint`
  - [ ] `yarn test-unit`
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/oui/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
