### PR TITLE
Update TypeScript to 4.7.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@
 - Add @angle943, @Maosaic, and @ruchidh as maintainers ([#1553](https://github.com/opensearch-project/oui/pull/1553))
 - Bump http-proxy-middleware from 2.0.7 to 2.0.9 ([#1551](https://github.com/opensearch-project/oui/pull/1551))
 - Moving @bandinib-amzn and @joshuarrrr to emeritus ([#1558](https://github.com/opensearch-project/oui/pull/1558))
+- Update TypeScript to 4.7.4 ([#1586](https://github.com/opensearch-project/oui/pull/1586))
 
 
 ### 🪛 Refactoring

--- a/package.json
+++ b/package.json
@@ -238,7 +238,7 @@
     "start-server-and-test": "^2.0.0",
     "style-loader": "^2.0.0",
     "terser-webpack-plugin": "^4.1.0",
-    "typescript": "4.6.4",
+    "typescript": "4.7.4",
     "url-loader": "^4.1.0",
     "webpack": "npm:@amoo-miki/webpack@4.46.0-rc.2",
     "webpack-cli": "^4.10.0",

--- a/src/components/basic_table/basic_table.tsx
+++ b/src/components/basic_table/basic_table.tsx
@@ -664,9 +664,9 @@ export class OuiBasicTable<T = any> extends Component<
 
       items.push({
         name: column.name,
-        key: `_data_s_${
+        key: `_data_s_${String(
           (column as OuiTableFieldDataColumnType<T>).field
-        }_${index}`,
+        )}_${index}`,
         onSort: this.resolveColumnOnSort(column),
         isSorted: !!sortDirection,
         isSortAscending: sortDirection
@@ -898,13 +898,13 @@ export class OuiBasicTable<T = any> extends Component<
       }
       headers.push(
         <OuiTableHeaderCell
-          key={`_data_h_${field}_${index}`}
+          key={`_data_h_${String(field)}_${index}`}
           align={columnAlign}
           width={width}
           isMobileHeader={isMobileHeader}
           hideForMobile={hideForMobile}
           mobileOptions={mobileOptions}
-          data-test-subj={`tableHeaderCell_${field}_${index}`}
+          data-test-subj={`tableHeaderCell_${String(field)}_${index}`}
           description={description}
           {...sorting}>
           {name}
@@ -946,7 +946,7 @@ export class OuiBasicTable<T = any> extends Component<
       if (footer) {
         footers.push(
           <OuiTableFooterCell
-            key={`footer_${field}_${footers.length - 1}`}
+            key={`footer_${String(field)}_${footers.length - 1}`}
             align={align}>
             {footer}
           </OuiTableFooterCell>
@@ -1264,7 +1264,7 @@ export class OuiBasicTable<T = any> extends Component<
   ) {
     const { field, render, dataType } = column;
 
-    const key = `_data_column_${field}_${itemId}_${columnIndex}`;
+    const key = `_data_column_${String(field)}_${itemId}_${columnIndex}`;
     const contentRenderer = render || this.getRendererForDataType(dataType);
     const value = get(item, field as string);
     const content = contentRenderer(value, item);

--- a/src/components/page/page_template.tsx
+++ b/src/components/page/page_template.tsx
@@ -410,7 +410,7 @@ export const OuiPageTemplate: FunctionComponent<OuiPageTemplateProps> = ({
           paddingSize={paddingSize}
           position={canFullHeight && fullHeight ? 'static' : 'sticky'}
           // Using uknown here because of the possible conflict with overriding props and position `sticky`
-          {...(bottomBarProps as unknown)}>
+          {...(bottomBarProps as Record<string, any>)}>
           {/* Wrapping the contents with OuiPageContentBody allows us to match the restrictWidth to keep the contents aligned */}
           <OuiPageContentBody
             paddingSize={'none'}

--- a/src/components/search_bar/query/date_format.ts
+++ b/src/components/search_bar/query/date_format.ts
@@ -43,9 +43,12 @@ export interface OuiMoment extends Moment {
   __oui_format?: string;
 }
 
+export type GranularityEsType = 'd' | 'w' | 'M' | 'y';
+export type GranularityJsType = 'day' | 'week' | 'month' | 'year';
+
 export interface GranularityType {
-  es: 'd' | 'w' | 'M' | 'y';
-  js: 'day' | 'week' | 'month' | 'year';
+  es: GranularityEsType;
+  js: GranularityJsType;
   isSame: (d1: Moment, d2: Moment) => boolean;
   start: (date: Moment) => Moment;
   startOfNext: (date: Moment) => Moment;
@@ -61,36 +64,36 @@ interface GranularitiesType {
 
 export const Granularity: GranularitiesType = Object.freeze({
   DAY: {
-    es: 'd',
-    js: 'day',
-    isSame: (d1, d2) => d1.isSame(d2, 'day'),
-    start: (date) => date.startOf('day'),
-    startOfNext: (date) => date.add(1, 'days').startOf('day'),
-    iso8601: (date) => date.format('YYYY-MM-DD'),
+    es: 'd' as GranularityEsType,
+    js: 'day' as GranularityJsType,
+    isSame: (d1: Moment, d2: Moment) => d1.isSame(d2, 'day'),
+    start: (date: Moment) => date.startOf('day'),
+    startOfNext: (date: Moment) => date.add(1, 'days').startOf('day'),
+    iso8601: (date: Moment) => date.format('YYYY-MM-DD'),
   },
   WEEK: {
-    es: 'w',
-    js: 'week',
-    isSame: (d1, d2) => d1.isSame(d2, 'week'),
-    start: (date) => date.startOf('week'),
-    startOfNext: (date) => date.add(1, 'weeks').startOf('week'),
-    iso8601: (date) => date.format('YYYY-MM-DD'),
+    es: 'w' as GranularityEsType,
+    js: 'week' as GranularityJsType,
+    isSame: (d1: Moment, d2: Moment) => d1.isSame(d2, 'week'),
+    start: (date: Moment) => date.startOf('week'),
+    startOfNext: (date: Moment) => date.add(1, 'weeks').startOf('week'),
+    iso8601: (date: Moment) => date.format('YYYY-MM-DD'),
   },
   MONTH: {
-    es: 'M',
-    js: 'month',
-    isSame: (d1, d2) => d1.isSame(d2, 'month'),
-    start: (date) => date.startOf('month'),
-    startOfNext: (date) => date.add(1, 'months').startOf('month'),
-    iso8601: (date) => date.format('YYYY-MM'),
+    es: 'M' as GranularityEsType,
+    js: 'month' as GranularityJsType,
+    isSame: (d1: Moment, d2: Moment) => d1.isSame(d2, 'month'),
+    start: (date: Moment) => date.startOf('month'),
+    startOfNext: (date: Moment) => date.add(1, 'months').startOf('month'),
+    iso8601: (date: Moment) => date.format('YYYY-MM'),
   },
   YEAR: {
-    es: 'y',
-    js: 'year',
-    isSame: (d1, d2) => d1.isSame(d2, 'year'),
-    start: (date) => date.startOf('year'),
-    startOfNext: (date) => date.add(1, 'years').startOf('year'),
-    iso8601: (date) => date.format('YYYY'),
+    es: 'y' as GranularityEsType,
+    js: 'year' as GranularityJsType,
+    isSame: (d1: Moment, d2: Moment) => d1.isSame(d2, 'year'),
+    start: (date: Moment) => date.startOf('year'),
+    startOfNext: (date: Moment) => date.add(1, 'years').startOf('year'),
+    iso8601: (date: Moment) => date.format('YYYY'),
   },
 });
 

--- a/src/utils/prop_types/is.ts
+++ b/src/utils/prop_types/is.ts
@@ -35,7 +35,9 @@ export const is = <T>(expectedValue: any) => {
     const compName = componentName || 'ANONYMOUS';
     const value = props[propName];
     if (value !== expectedValue) {
-      return new Error(`[${propName}] property in [${compName}] component is expected to equal [${expectedValue}] but
+      return new Error(`[${String(
+        propName
+      )}] property in [${compName}] component is expected to equal [${expectedValue}] but
          [${value}] was provided instead.`);
     }
     return null;
@@ -50,7 +52,9 @@ export const is = <T>(expectedValue: any) => {
     const value = props[propName];
     if (isNil(value)) {
       return new Error(
-        `[${propName}] property in [${compName}] component is required but seems to be missing`
+        `[${String(
+          propName
+        )}] property in [${compName}] component is required but seems to be missing`
       );
     }
     return validator(props, propName, componentName);

--- a/yarn.lock
+++ b/yarn.lock
@@ -16889,10 +16889,10 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript@4.6.4:
-  version "4.6.4"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.6.4.tgz#caa78bbc3a59e6a5c510d35703f6a09877ce45e9"
-  integrity sha512-9ia/jWHIEbo49HfjrLGfKbZSuWo9iTMwXO+Ca3pRsSpbsMbc7/IU8NKdCZVRRBafVPGnoJeFL76ZOAA84I9fEg==
+typescript@4.7.4:
+  version "4.7.4"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.7.4.tgz#1a88596d1cf47d59507a1bcdfb5b9dfe4d488235"
+  integrity sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==
 
 unbox-primitive@^1.0.2:
   version "1.0.2"


### PR DESCRIPTION
### Description
Updates TypeScript to 4.7.4

I think this will unblock refractor version update (https://github.com/opensearch-project/oui/pull/1574) due to package.json exports support. Worst case otherwise is just more strict typing.

### Issues Resolved
N/A

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] All tests pass
  - [ ] `yarn lint`
  - [ ] `yarn test-unit`
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/oui/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
