### PR TITLE
Fix: Correct text cut-off in pagination buttons (#1486)

### DIFF
--- a/src/components/button/button_empty/_button_empty.scss
+++ b/src/components/button/button_empty/_button_empty.scss
@@ -11,7 +11,7 @@
 
 /**
  * 1. We don't want any of the animations that come inherited from the mixin.
- *    These should act like normal links instead.
+ * These should act like normal links instead.
  * 2. Change the easing, quickness to not bounce so lighter backgrounds don't flash
  */
 .ouiButtonEmpty {
@@ -34,6 +34,7 @@
     display: flex;
     text-overflow: ellipsis;
     overflow: hidden;
+    padding: 1px 0; /* Fix for issue #1486 */
   }
 
   &.ouiButtonEmpty--small {


### PR DESCRIPTION
**Title:** Fix: Correct text cut-off in pagination buttons

**Description:**

This pull request addresses the bug where the text in the pagination buttons was being cut off at the bottom.

**Details of the fix:**

I have added padding: 1px 0; to the .ouiButtonEmpty__text class in _button_empty.scss to provide a small amount of vertical space, which prevents the text from being cropped.

**Closes Issue:** Fixes #1486

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/oui/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
