### PR TITLE
Update Popover to capture click event outside to dismiss Popover

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ### 📈 Features/Enhancements
 
 ### 🐛 Bug Fixes
+- Update Popover to capture click event outside to dismiss Popover
 
 ### 🚞 Infrastructure
 
@@ -17,7 +18,7 @@
 
 ### 🛠 Maintenance
 - Update code base to work in react 16 and 18 ([#1628](https://github.com/opensearch-project/oui/pull/1628))
-- Setup devserver and tests to run in react 18 ([#1630](https://github.com/opensearch-project/oui/pull/1630)) 
+- Setup devserver and tests to run in react 18 ([#1630](https://github.com/opensearch-project/oui/pull/1630))
 - Update tests failing against react 18 to react-testing-library ([#1632](https://github.com/opensearch-project/oui/pull/1632))
 
 ### 🪛 Refactoring
@@ -56,8 +57,8 @@
 ### 🐛 Bug Fixes
 - fix button line-height inherit causes text cut off ([#1490](https://github.com/opensearch-project/oui/pull/1490))
 - Add OpenSearch logo to page title ([#1532](https://github.com/opensearch-project/oui/pull/1532))
-- Fix dev server configuration after webpack-dev-server upgrade in 1.19 ([#1567](https://github.com/opensearch-project/oui/pull/1567)) 
-- Fix DataGrid numeric cell content shifting on hover ([#1644](https://github.com/opensearch-project/oui/pull/1644)) 
+- Fix dev server configuration after webpack-dev-server upgrade in 1.19 ([#1567](https://github.com/opensearch-project/oui/pull/1567))
+- Fix DataGrid numeric cell content shifting on hover ([#1644](https://github.com/opensearch-project/oui/pull/1644))
 
 ### 🚞 Infrastructure
 - update actions/upload-artifact and actions/download-artifact to v4([#1491](https://github.com/opensearch-project/oui/pull/1491))


### PR DESCRIPTION
### Description
<!-- Describe what this change achieves -->

Existing Popover component use `react-focus-on` to detect click/focus event outside the component. However, it can't not capture the click event from `monaco-editor` input. This PR add a event listener that capture click event and close the Popover when a event is captured.

### Issues Resolved
<!-- List any issues this PR will resolve. -->
<!-- Example: Fixes #1234 -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] All tests pass
  - [ ] `yarn lint`
  - [ ] `yarn test-unit`
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/oui/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
