### PR TITLE
Support reset styles being overridden by layers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@
 
 ### 🪛 Refactoring
 
+- Support reset styles being overridden by layers ([#1664](https://github.com/opensearch-project/oui/pull/1664))
+
 ### 🔩 Tests
 
 

--- a/src/global_styling/reset/_index.scss
+++ b/src/global_styling/reset/_index.scss
@@ -9,6 +9,8 @@
  * GitHub history for details.
  */
 
-@import 'reset';
-@import 'hacks';
-@import 'scrollbar';
+@layer theme {
+  @import 'reset';
+  @import 'hacks';
+  @import 'scrollbar';
+}

--- a/src/themes/oui-next/global_styling/reset/_index.scss
+++ b/src/themes/oui-next/global_styling/reset/_index.scss
@@ -9,6 +9,8 @@
  * GitHub history for details.
  */
 
-@import 'reset';
-@import 'hacks';
-@import 'scrollbar';
+@layer theme {
+  @import 'reset';
+  @import 'hacks';
+  @import 'scrollbar';
+}

--- a/src/themes/v9/global_styling/reset/_index.scss
+++ b/src/themes/v9/global_styling/reset/_index.scss
@@ -9,6 +9,8 @@
  * GitHub history for details.
  */
 
-@import 'reset';
-@import 'hacks';
-@import 'scrollbar';
+@layer theme {
+  @import 'reset';
+  @import 'hacks';
+  @import 'scrollbar';
+}


### PR DESCRIPTION
### Description
Support reset styles being overridden by layers

This allows reset styles to be overridden by other design systems that support cascading layers, helping for an eventual mibration. It should have no impact on current styles as it immediately overrides browser defaults and is overridden by oui styles.

Failing test is due to another recent change that hasn't been updated in osd yet.

### Issues Resolved
N/A

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] All tests pass
  - [ ] `yarn lint`
  - [ ] `yarn test-unit`
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/oui/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
