### PR TITLE
Scopes preset.css custom css to avoid conflicts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,15 +1,15 @@
 # OUI
 
-## [`2.0.0-alpha.1`](https://github.com/opensearch-project/oui/tree/main)
+## [`2.0.0-alpha.2`](https://github.com/opensearch-project/oui/tree/main)
 
 ### Deprecations
 
 ### 🛡 Security
 
 ### 📈 Features/Enhancements
-- Initial 2.x shadcn-based alpha-release ([#1666](https://github.com/opensearch-project/oui/pull/1666))
 
 ### 🐛 Bug Fixes
+- Scope preset.css custom css to avoid conflicts ([#1673](https://github.com/opensearch-project/oui/pull/1673))
 
 ### 🚞 Infrastructure
 
@@ -20,6 +20,12 @@
 ### 🪛 Refactoring
 
 ### 🔩 Tests
+
+
+## [`2.0.0-alpha.1`](https://github.com/opensearch-project/oui/tree/main)
+
+### 📈 Features/Enhancements
+- Initial 2.x shadcn-based alpha-release ([#1666](https://github.com/opensearch-project/oui/pull/1666))
 
 
 ## [`1.22.1`](https://github.com/opensearch-project/oui/tree/1.22.1)

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@opensearch-project/oui",
   "description": "OpenSearch UI Component Library",
-  "version": "2.0.0-alpha.1",
+  "version": "2.0.0-alpha.2",
   "license": "Apache-2.0",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/scripts/scope-css.ts
+++ b/scripts/scope-css.ts
@@ -50,8 +50,26 @@ function scopeCSS(): void {
     htmlResetStyles = htmlResetMatch[1].trim();
   }
 
-  // Remove the first @layer base section from the original CSS
-  const cssWithoutFirstLayerBase = css.replace(layerBaseRegex, '');
+  // Process scoped styles in-place by replacing marker pairs with @scope blocks
+  let processedCSS = css;
+
+  // Find all scoped styles marker pairs and process them
+  const scopeMarkerRegex =
+    /\.__oui-scoped-styles-start\s*\{[^}]*\}([\s\S]*?)\.__oui-scoped-styles-end\s*\{[^}]*\}/g;
+
+  processedCSS = processedCSS.replace(scopeMarkerRegex, (match, content) => {
+    // Extract the content between markers and wrap it in @scope
+    const trimmedContent = content.trim();
+    if (trimmedContent) {
+      return `@scope (.oui2) to (.oui2-end) {
+${trimmedContent.replace(/^/gm, '  ')}
+}`;
+    }
+    return '';
+  });
+
+  // Remove the first @layer base section from the processed CSS
+  const cssWithoutFirstLayerBase = processedCSS.replace(layerBaseRegex, '');
 
   // Create scoped CSS
   const scopedCSS = `/* OUI2 Library - Scoped CSS */

--- a/src/styles/preset.css
+++ b/src/styles/preset.css
@@ -127,6 +127,9 @@
   --color-severity-critical: var(--oui-severity-critical);
 }
 
+/* This allows scope-css.ts to scope these styles without tailwind stripping during build */
+.__oui-scoped-styles-start { display: none; }
+
 @layer base {
   * {
     @apply oui:border-border oui:outline-ring/50;
@@ -134,6 +137,11 @@
 
   body {
     @apply oui:bg-background oui:text-foreground;
+  }
+
+  /* Apply on .oui2 hierarchies as body style won't get picked up */
+  .oui2 {
+    @apply oui:text-foreground;
   }
 }
 
@@ -175,3 +183,5 @@
 [data-sonner-toaster] button {
   margin-left: auto !important;
 }
+
+.__oui-scoped-styles-end { display: none; }


### PR DESCRIPTION
### Description
Scopes preset.css custom css to avoid conflicts - some styles were overriding osd styles because they were not properly scoped. This just makes sure they only apply where we want them. Did have to introduce a hacky css selector to identify relative positions to scope (comments didn't seem to get preserved in the same place)

### Issues Resolved
N/A

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] All tests pass
  - [ ] `yarn lint`
  - [ ] `yarn test-unit`
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/oui/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
