### PR TITLE
Use theme layer for unset css + provide .oui2-body utility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### 🐛 Bug Fixes
 - Scope preset.css custom css to avoid conflicts ([#1673](https://github.com/opensearch-project/oui/pull/1673))
+- Use theme layer for unset css + provide .oui2-body utility ([#1674](https://github.com/opensearch-project/oui/pull/1674))
 
 ### 🚞 Infrastructure
 

--- a/src/styles/preset.css
+++ b/src/styles/preset.css
@@ -143,6 +143,11 @@
   .oui2 {
     @apply oui:text-foreground;
   }
+
+  /* Utility class to get oui background as otherwise only on body */
+  .oui2-body {
+    @apply oui:bg-background;
+  }
 }
 
 /* Sonner Toast Styling */

--- a/src/styles/unset-oui1.css
+++ b/src/styles/unset-oui1.css
@@ -6,7 +6,7 @@
  * In @layer theme so applied before shadcn reset css in @layer base
  */
 
-@layer base {
+@layer theme {
   /* Unset box-sizing reset */
   *, *:before, *:after {
     box-sizing: unset;

--- a/wiki/consuming.md
+++ b/wiki/consuming.md
@@ -65,6 +65,22 @@ import '@opensearch-project/oui/style.scoped.css';
 </div>
 ```
 
+#### Important considerations for scoped styles
+
+When using scoped styles, there are some important limitations to be aware of:
+
+**HTML and body styles**: Some expected styles that would normally apply to `html` and `body` elements may not be presented when using scoped styles. This happens because if `.oui2` is used on a descendant element, the scoped styles cannot affect parent elements like `html` or `body`. For the most consistent behavior, consider placing `.oui2` as high up in your DOM tree as possible.
+
+**Background colors**: Since `body` styles are scoped and won't apply unless `.oui2` is placed directly on the `<body>` element, you should use the `.oui2-body` class on your root container to get the expected background color:
+
+```jsx
+<div className="oui2 oui2-body">
+  {/* Your OUI components here */}
+  <Button>Click me</Button>
+<div className="oui2-end"></div>
+</div>
+```
+
 The library supports both light and dark themes through CSS custom properties and the `dark` class.
 
 ### Customizing with CSS custom properties


### PR DESCRIPTION
### Description
Use theme layer for unset css + provide .oui2-body utility

This uses theme layer for unset css because OUI 1.x uses theme layer for its reset css + using theme allows later base layer styles to override despite lower specificity (desired behavior).

### Issues Resolved
Before: 
<img width="3582" height="1688" alt="image" src="https://github.com/user-attachments/assets/3012c042-7338-46fc-8310-30f4df515594" />

After:
<img width="3594" height="1794" alt="image" src="https://github.com/user-attachments/assets/a93c64fe-d44d-451d-ac3a-a704cfb8a4d3" />

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] All tests pass
  - [ ] `yarn lint`
  - [ ] `yarn test-unit`
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/oui/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
