### PR TITLE
Centralize icons and enable custom icons

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -209,5 +209,12 @@ module.exports = {
         '@typescript-eslint/no-var-requires': 'off', // not enforcing ES6-style import statements
       },
     },
+    {
+      // Disable formatting rules for generated custom icon files
+      files: ['src/components/custom/icons/custom/*.{ts,tsx}', '!src/components/custom/icons/custom/index.ts'],
+      rules: {
+        'prettier/prettier': 'off', // Generated files don't need to follow prettier formatting
+      },
+    },
   ],
 };

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,27 @@
 # OUI
 
-## [`2.0.0-alpha.2`](https://github.com/opensearch-project/oui/tree/main)
+## [`2.0.0-alpha.3`](https://github.com/opensearch-project/oui/tree/main)
 
 ### Deprecations
+
+### 🛡 Security
+
+### 📈 Features/Enhancements
+
+### 🐛 Bug Fixes
+
+### 🚞 Infrastructure
+
+### 📝 Documentation
+
+### 🛠 Maintenance
+
+### 🪛 Refactoring
+- Centralize icons and enable custom icons ([#1684](https://github.com/opensearch-project/oui/pull/1684))
+
+### 🔩 Tests
+
+## [`2.0.0-alpha.2`](https://github.com/opensearch-project/oui/tree/main)
 
 ### 🛡 Security
 - Upgrade storybook to 9.1.17 for CVE ([#1681](https://github.com/opensearch-project/oui/pull/1681))
@@ -21,16 +40,8 @@
 - Match OUI1 V9 colors ([#1682](https://github.com/opensearch-project/oui/pull/1682))
 - Use small rounded corners on buttons ([#1682](https://github.com/opensearch-project/oui/pull/1682))
 
-### 🚞 Infrastructure
-
 ### 📝 Documentation
 - Update documentation for 2.x ([#1676](https://github.com/opensearch-project/oui/pull/1676))
-
-### 🛠 Maintenance
-
-### 🪛 Refactoring
-
-### 🔩 Tests
 
 
 ## [`2.0.0-alpha.1`](https://github.com/opensearch-project/oui/tree/main)

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@opensearch-project/oui",
   "description": "OpenSearch UI Component Library",
-  "version": "2.0.0-alpha.2",
+  "version": "2.0.0-alpha.3",
   "license": "Apache-2.0",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -32,7 +32,10 @@
   ],
   "scripts": {
     "build": "yarn run build:lib && yarn run build:storybook",
-    "build:lib": "tsc --project tsconfig.build.json && tsc-alias && npx @tailwindcss/cli -i src/styles/preset.css -o dist/style.css && npx tsx scripts/scope-css.ts",
+    "build:icons": "npx tsx scripts/generate-icons.ts",
+    "build:ts": "tsc --project tsconfig.build.json && tsc-alias",
+    "build:css": "npx @tailwindcss/cli -i src/styles/preset.css -o dist/style.css && npx tsx scripts/scope-css.ts",
+    "build:lib": "yarn run build:icons && yarn run build:ts && yarn run build:css",
     "build:storybook": "storybook build -o ./docs",
     "build-docs": "yarn run build:storybook",
     "clean": "rm -rf build node_modules dist lib docs",

--- a/scripts/generate-icons.ts
+++ b/scripts/generate-icons.ts
@@ -1,0 +1,191 @@
+#!/usr/bin/env tsx
+
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+  readFileSync,
+  writeFileSync,
+  existsSync,
+  mkdirSync,
+  readdirSync,
+} from 'fs';
+import { join, resolve, parse } from 'path';
+import { fileURLToPath } from 'url';
+import { dirname } from 'path';
+
+// Get the project root directory
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const projectRoot = resolve(__dirname, '..');
+
+/**
+ * Converts kebab-case filename to PascalCase component name with Icon suffix
+ * app-discover -> AppDiscoverIcon
+ */
+function getComponentName(filename: string): string {
+  const baseName = parse(filename).name;
+  const pascalCase = baseName
+    .split('-')
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+    .join('');
+  return `${pascalCase}Icon`;
+}
+
+/**
+ * Converts SVG content to React component code
+ */
+function svgToReact(svgContent: string, componentName: string): string {
+  // Remove comments and XML declaration
+  let cleanedSvg = svgContent
+    .replace(/<!--[\s\S]*?-->/g, '')
+    .replace(/<\?xml[^>]*\?>/g, '')
+    .trim();
+
+  // Convert class to className
+  cleanedSvg = cleanedSvg.replace(/class=/g, 'className=');
+
+  // Extract the inner content of the SVG
+  const svgMatch = cleanedSvg.match(/<svg[^>]*>([\s\S]*)<\/svg>/);
+  if (!svgMatch) {
+    throw new Error(`Invalid SVG content for ${componentName}`);
+  }
+
+  // Extract viewBox from the original SVG
+  const viewBoxMatch = cleanedSvg.match(/viewBox="([^"]*)"/);
+  const viewBox = viewBoxMatch ? viewBoxMatch[1] : '0 0 24 24';
+
+  // Clean up the inner content and properly indent it
+  const innerContent = svgMatch[1]
+    .trim()
+    .split('\n')
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0)
+    .map((line) => `        ${line}`)
+    .join('\n');
+
+  return `/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as React from 'react';
+import { BaseIcon, type IconProps } from '../base-icon';
+
+/**
+ * ${componentName} - Custom SVG icon component
+ * Generated from SVG file
+ */
+export const ${componentName} = React.forwardRef<SVGSVGElement, IconProps>(
+  (props, ref) => {
+    return (
+      <BaseIcon ref={ref} viewBox="${viewBox}" {...props}>
+${innerContent}
+      </BaseIcon>
+    );
+  }
+);
+
+${componentName}.displayName = '${componentName}';
+`;
+}
+
+/**
+ * Generates the custom icons barrel export
+ */
+function generateCustomBarrel(
+  components: Array<{ filename: string; componentName: string }>
+): string {
+  const exports = components
+    .map(({ filename, componentName }) => {
+      const moduleName = parse(filename).name;
+      return `export { ${componentName} } from './${moduleName}';`;
+    })
+    .join('\n');
+
+  return `/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// Auto-generated exports for custom icons
+${exports}
+`;
+}
+
+/**
+ * Main generation function
+ */
+function generateIcons() {
+  console.log('🎨 Generating custom icons...');
+
+  const iconsSourceDir = join(
+    projectRoot,
+    'src/components/custom/icons/custom'
+  );
+  // Generate directly to the final location in src
+  const iconsOutputDir = iconsSourceDir;
+
+  // Ensure output directory exists
+  mkdirSync(iconsOutputDir, { recursive: true });
+
+  // Check if source directory exists
+  if (!existsSync(iconsSourceDir)) {
+    console.log('📂 No custom icons directory found, skipping generation');
+    return;
+  }
+
+  // Read all SVG files
+  const svgFiles = readdirSync(iconsSourceDir).filter((file) =>
+    file.endsWith('.svg')
+  );
+
+  if (svgFiles.length === 0) {
+    console.log('📂 No SVG files found in custom icons directory');
+    return;
+  }
+
+  const components: Array<{ filename: string; componentName: string }> = [];
+
+  // Process each SVG file
+  for (const svgFile of svgFiles) {
+    const svgPath = join(iconsSourceDir, svgFile);
+    const componentName = getComponentName(svgFile);
+    const outputName = `${parse(svgFile).name}.tsx`;
+    const outputPath = join(iconsOutputDir, outputName);
+
+    try {
+      console.log(`🔄 Processing ${svgFile} -> ${componentName}`);
+
+      const svgContent = readFileSync(svgPath, 'utf-8');
+      const componentCode = svgToReact(svgContent, componentName);
+
+      writeFileSync(outputPath, componentCode, 'utf-8');
+
+      components.push({ filename: svgFile, componentName });
+    } catch (error) {
+      console.error(`❌ Error processing ${svgFile}:`, error);
+      process.exit(1);
+    }
+  }
+
+  // Generate barrel export file
+  const barrelContent = generateCustomBarrel(components);
+  const barrelPath = join(iconsOutputDir, 'index.ts');
+  writeFileSync(barrelPath, barrelContent, 'utf-8');
+
+  console.log(`✅ Generated ${components.length} custom icon components`);
+  console.log(`📁 Output directory: ${iconsOutputDir}`);
+
+  // List generated components
+  components.forEach(({ componentName }) => {
+    console.log(`   - ${componentName}`);
+  });
+}
+
+// Run the generation
+if (require.main === module) {
+  generateIcons();
+}

--- a/src/components/custom/icons/base-icon.tsx
+++ b/src/components/custom/icons/base-icon.tsx
@@ -1,0 +1,56 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as React from 'react';
+import { cn } from '@/lib/utils';
+
+/**
+ * Icon props interface that matches lucide-react icon signature exactly
+ * This ensures all custom icons have the same API as lucide icons
+ */
+export interface IconProps extends React.SVGProps<SVGSVGElement> {
+  size?: string | number;
+  color?: string;
+  strokeWidth?: string | number;
+  absoluteStrokeWidth?: boolean;
+}
+
+/**
+ * Base icon component for custom SVG icons
+ * Matches lucide-react behavior and provides consistent defaults
+ */
+export const BaseIcon = React.forwardRef<SVGSVGElement, IconProps>(
+  (
+    {
+      size = 24,
+      color = 'currentColor',
+      strokeWidth = 2,
+      absoluteStrokeWidth = false,
+      className,
+      children,
+      ...props
+    },
+    ref
+  ) => {
+    return (
+      <svg
+        ref={ref}
+        width={size}
+        height={size}
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke={color}
+        strokeWidth={absoluteStrokeWidth ? Number(strokeWidth) : strokeWidth}
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        className={cn('oui:shrink-0', className)}
+        {...props}>
+        {children}
+      </svg>
+    );
+  }
+);
+
+BaseIcon.displayName = 'BaseIcon';

--- a/src/components/custom/icons/custom/discover.svg
+++ b/src/components/custom/icons/custom/discover.svg
@@ -1,0 +1,29 @@
+<!--
+  - SPDX-License-Identifier: Apache-2.0
+  -
+  - The OpenSearch Contributors require contributions made to
+  - this file be licensed under the Apache-2.0 license or a
+  - compatible open source license.
+  -
+  - Modifications Copyright OpenSearch Contributors. See
+  - GitHub history for details.
+  -->
+<!--
+  - Copyright (C) 2004 Remix Icon
+  -
+  - Licensed under the Apache License, Version 2.0 (the "License");
+  - you may not use this file except in compliance with the License.
+  - You may obtain a copy of the License at
+  -
+  -         http://www.apache.org/licenses/LICENSE-2.0
+  -
+  - Unless required by applicable law or agreed to in writing, software
+  - distributed under the License is distributed on an "AS IS" BASIS,
+  - WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  - See the License for the specific language governing permissions and
+  - limitations under the License.
+  -->
+
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16">
+  <path d="M8 14.667A6.667 6.667 0 1 1 8 1.334a6.667 6.667 0 0 1 0 13.333zm0-1.333A5.333 5.333 0 1 0 8 2.667a5.333 5.333 0 0 0 0 10.667zM11 5 9.333 9.334 5 11l1.667-4.333L11 5zM8 8.667a.667.667 0 1 0 0-1.333.667.667 0 0 0 0 1.333z"/>
+</svg>

--- a/src/components/custom/icons/custom/discover.tsx
+++ b/src/components/custom/icons/custom/discover.tsx
@@ -1,0 +1,23 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as React from 'react';
+import { BaseIcon, type IconProps } from '../base-icon';
+
+/**
+ * DiscoverIcon - Custom SVG icon component
+ * Generated from SVG file
+ */
+export const DiscoverIcon = React.forwardRef<SVGSVGElement, IconProps>(
+  (props, ref) => {
+    return (
+      <BaseIcon ref={ref} viewBox="0 0 16 16" {...props}>
+        <path d="M8 14.667A6.667 6.667 0 1 1 8 1.334a6.667 6.667 0 0 1 0 13.333zm0-1.333A5.333 5.333 0 1 0 8 2.667a5.333 5.333 0 0 0 0 10.667zM11 5 9.333 9.334 5 11l1.667-4.333L11 5zM8 8.667a.667.667 0 1 0 0-1.333.667.667 0 0 0 0 1.333z"/>
+      </BaseIcon>
+    );
+  }
+);
+
+DiscoverIcon.displayName = 'DiscoverIcon';

--- a/src/components/custom/icons/custom/index.ts
+++ b/src/components/custom/icons/custom/index.ts
@@ -1,0 +1,7 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// Auto-generated exports for custom icons
+export { DiscoverIcon } from './discover';

--- a/src/components/custom/icons/index.ts
+++ b/src/components/custom/icons/index.ts
@@ -1,0 +1,24 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Centralized icon exports for OUI package
+ *
+ * This module provides a curated set of icons including:
+ * - Lucide React icons that already end with "Icon" suffix
+ * - Custom SVG icons converted to React components
+ *
+ * All icons follow the same API pattern and naming convention.
+ */
+
+// Export curated lucide icons (only aliases ending with "Icon")
+export * from './lucide';
+
+// Export custom OUI icons
+export * from './custom';
+
+// Export types and utilities
+export type { IconProps } from './base-icon';
+export { BaseIcon } from './base-icon';

--- a/src/components/custom/icons/lucide.ts
+++ b/src/components/custom/icons/lucide.ts
@@ -1,0 +1,212 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Re-exports of lucide-react icons that already end with "Icon"
+ * This provides a curated set of lucide icons that follow the naming convention
+ * while maintaining full compatibility with the original lucide-react exports
+ */
+
+export {
+  // Status & Feedback
+  AlertCircleIcon,
+  CheckCircleIcon,
+  InfoIcon,
+  XCircleIcon,
+  AlertTriangleIcon,
+  HelpCircleIcon,
+  CircleCheckIcon,
+  CircleXIcon,
+  CircleAlertIcon,
+  BadgeIcon,
+  BadgeCheckIcon,
+
+  // Navigation & Arrows
+  ArrowLeftIcon,
+  ArrowRightIcon,
+  ArrowUpIcon,
+  ArrowDownIcon,
+  ChevronLeftIcon,
+  ChevronRightIcon,
+  ChevronDownIcon,
+  ChevronUpIcon,
+  ChevronsUpIcon,
+  ChevronsDownIcon,
+  ChevronsLeftIcon,
+  ChevronsRightIcon,
+  ChevronsUpDownIcon,
+  ArrowUpRightIcon,
+  ArrowDownLeftIcon,
+  ArrowUpLeftIcon,
+  ArrowDownRightIcon,
+  LogOutIcon,
+
+  // Actions & Controls
+  PlusIcon,
+  MinusIcon,
+  PlusCircleIcon,
+  MinusCircleIcon,
+  PlayIcon,
+  PlayCircleIcon,
+  PauseIcon,
+  PauseCircleIcon,
+  StopCircleIcon,
+  SkipBackIcon,
+  SkipForwardIcon,
+  RefreshCwIcon,
+  RefreshCcwIcon,
+
+  // UI Elements
+  UserIcon,
+  UsersIcon,
+  SearchIcon,
+  SettingsIcon,
+  MenuIcon,
+  MoreHorizontalIcon,
+  MoreVerticalIcon,
+  XIcon,
+  CheckIcon,
+  FilterIcon,
+  SortAscIcon,
+  SortDescIcon,
+  ListIcon,
+  GridIcon,
+  ArrowUpDownIcon,
+
+  // Files & Folders
+  FileIcon,
+  FilesIcon,
+  FolderIcon,
+  FolderOpenIcon,
+  FileTextIcon,
+  FileImageIcon,
+  FileVideoIcon,
+  FileAudioIcon,
+  FolderPlusIcon,
+  DownloadIcon,
+  UploadIcon,
+  SaveIcon,
+  CopyIcon,
+
+  // Communication
+  MailIcon,
+  PhoneIcon,
+  MessageCircleIcon,
+  MessageSquareIcon,
+  SendIcon,
+  InboxIcon,
+
+  // Time & Calendar
+  CalendarIcon,
+  CalendarDaysIcon,
+  ClockIcon,
+  HistoryIcon,
+  TimerIcon,
+
+  // Visibility & Editing
+  EyeIcon,
+  EyeOffIcon,
+  EditIcon,
+  PenIcon,
+  TrashIcon,
+  Trash2Icon,
+
+  // Text Formatting
+  BoldIcon,
+  ItalicIcon,
+  UnderlineIcon,
+  AlignLeftIcon,
+  AlignCenterIcon,
+  AlignRightIcon,
+
+  // Favorites & Ratings
+  StarIcon,
+  HeartIcon,
+  BookmarkIcon,
+  ThumbsUpIcon,
+  ThumbsDownIcon,
+  ShareIcon,
+  CrownIcon,
+
+  // Tech & Devices
+  ZapIcon,
+  WifiIcon,
+  SmartphoneIcon,
+  TabletIcon,
+  LaptopIcon,
+  MonitorIcon,
+  CameraIcon,
+  VideoIcon,
+  MicIcon,
+  MicOffIcon,
+
+  // Security & Access
+  ShieldIcon,
+  LockIcon,
+  UnlockIcon,
+  KeyIcon,
+  UserCheckIcon,
+
+  // Business & Shopping
+  HomeIcon,
+  BuildingIcon,
+  CreditCardIcon,
+  ShoppingCartIcon,
+  ShoppingBagIcon,
+  TagIcon,
+  DollarSignIcon,
+
+  // Data & Analytics
+  ActivityIcon,
+  TrendingUpIcon,
+  TrendingDownIcon,
+  BarChartIcon,
+  BarChart3Icon,
+  PieChartIcon,
+  LineChartIcon,
+  DatabaseIcon,
+  ServerIcon,
+
+  // Tools & Utilities
+  SlidersIcon,
+  ZoomInIcon,
+  ZoomOutIcon,
+  MaximizeIcon,
+  MinimizeIcon,
+
+  // Links & External
+  ExternalLinkIcon,
+  LinkIcon,
+  Link2Icon,
+  UnlinkIcon,
+
+  // Miscellaneous Common
+  BellIcon,
+  BellOffIcon,
+  FlagIcon,
+  GlobeIcon,
+  MapPinIcon,
+  ImageIcon,
+  TypeIcon,
+  HashIcon,
+  CircleIcon,
+  SmileIcon,
+  CalculatorIcon,
+  ScissorsIcon,
+  ClipboardPasteIcon,
+  ArchiveIcon,
+  ArrowUpAZIcon,
+  ArrowDownAZIcon,
+  Grid3X3Icon,
+  CloudIcon,
+  GithubIcon,
+  KeyboardIcon,
+  LifeBuoyIcon,
+  UserPlusIcon,
+  Building2Icon,
+  GraduationCapIcon,
+  CodeIcon,
+  MusicIcon,
+} from 'lucide-react';

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -26,6 +26,7 @@ export * from './ui/drawer';
 export * from './ui/dropdown-menu';
 export * from './ui/form';
 export * from './ui/hover-card';
+export * from './custom/icons';
 export * from './ui/input-otp';
 export * from './ui/input';
 export * from './ui/label';

--- a/stories/Alert.stories.tsx
+++ b/stories/Alert.stories.tsx
@@ -1,6 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
-import { Alert, AlertTitle, AlertDescription } from '@/components';
-import { AlertCircle, CheckCircle, Info, AlertTriangle } from 'lucide-react';
+import { Alert, AlertTitle, AlertDescription, AlertCircleIcon, CheckCircleIcon, InfoIcon, AlertTriangleIcon } from '@/components';
 
 const meta: Meta<typeof Alert> = {
     title: 'UI/Alert',
@@ -28,7 +27,7 @@ type Story = StoryObj<typeof meta>;
 export const Default: Story = {
     render: (args) => (
         <Alert {...args}>
-            <Info />
+            <InfoIcon />
             <AlertTitle>Information</AlertTitle>
             <AlertDescription>
                 Your account has been successfully updated. Changes will take effect within 24 hours.
@@ -41,7 +40,7 @@ export const Default: Story = {
 export const Destructive: Story = {
     render: (args) => (
         <Alert {...args} variant="destructive">
-            <AlertCircle />
+            <AlertCircleIcon />
             <AlertTitle>Error</AlertTitle>
             <AlertDescription>
                 Unable to save changes. Please check your internet connection and try again.
@@ -66,7 +65,7 @@ export const WithoutIcon: Story = {
 export const DescriptionOnly: Story = {
     render: (args) => (
         <Alert {...args}>
-            <Info />
+            <InfoIcon />
             <AlertDescription>
                 New features are now available in your dashboard. Explore the updated interface to discover enhanced functionality.
             </AlertDescription>
@@ -78,7 +77,7 @@ export const DescriptionOnly: Story = {
 export const Success: Story = {
     render: (args) => (
         <Alert {...args}>
-            <CheckCircle />
+            <CheckCircleIcon />
             <AlertTitle>Success</AlertTitle>
             <AlertDescription>
                 Your payment has been processed successfully. A confirmation email has been sent to your registered email address.
@@ -91,7 +90,7 @@ export const Success: Story = {
 export const Warning: Story = {
     render: (args) => (
         <Alert {...args}>
-            <AlertTriangle />
+            <AlertTriangleIcon />
             <AlertTitle>Warning</AlertTitle>
             <AlertDescription>
                 Your subscription expires in 3 days. Renew now to avoid service interruption.
@@ -105,7 +104,7 @@ export const AllVariants: Story = {
     render: () => (
         <div className="oui:space-y-4 oui:w-full oui:max-w-md">
             <Alert variant="default">
-                <Info />
+                <InfoIcon />
                 <AlertTitle>Information</AlertTitle>
                 <AlertDescription>
                     Your account settings have been updated successfully.
@@ -113,7 +112,7 @@ export const AllVariants: Story = {
             </Alert>
 
             <Alert variant="destructive">
-                <AlertCircle />
+                <AlertCircleIcon />
                 <AlertTitle>Error</AlertTitle>
                 <AlertDescription>
                     Unable to process your request. Please try again later.
@@ -134,7 +133,7 @@ export const AlertTypes: Story = {
     render: () => (
         <div className="oui:space-y-4 oui:w-full oui:max-w-md">
             <Alert>
-                <CheckCircle />
+                <CheckCircleIcon />
                 <AlertTitle>Success</AlertTitle>
                 <AlertDescription>
                     Your changes have been saved successfully.
@@ -142,7 +141,7 @@ export const AlertTypes: Story = {
             </Alert>
 
             <Alert>
-                <Info />
+                <InfoIcon />
                 <AlertTitle>Information</AlertTitle>
                 <AlertDescription>
                     New features are available in your dashboard.
@@ -150,7 +149,7 @@ export const AlertTypes: Story = {
             </Alert>
 
             <Alert>
-                <AlertTriangle />
+                <AlertTriangleIcon />
                 <AlertTitle>Warning</AlertTitle>
                 <AlertDescription>
                     Your session will expire in 5 minutes.
@@ -158,7 +157,7 @@ export const AlertTypes: Story = {
             </Alert>
 
             <Alert variant="destructive">
-                <AlertCircle />
+                <AlertCircleIcon />
                 <AlertTitle>Error</AlertTitle>
                 <AlertDescription>
                     Failed to connect to the server. Check your connection.
@@ -179,7 +178,7 @@ export const AlertStructures: Story = {
     render: () => (
         <div className="oui:space-y-4 oui:w-full oui:max-w-md">
             <Alert>
-                <Info />
+                <InfoIcon />
                 <AlertTitle>With Title and Description</AlertTitle>
                 <AlertDescription>
                     This alert includes both a title and detailed description for comprehensive messaging.
@@ -191,7 +190,7 @@ export const AlertStructures: Story = {
             </Alert>
 
             <Alert>
-                <Info />
+                <InfoIcon />
                 <AlertDescription>
                     Description only alert without a title, useful for simple notifications.
                 </AlertDescription>

--- a/stories/Avatar.stories.tsx
+++ b/stories/Avatar.stories.tsx
@@ -1,7 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import { expect, within } from '@storybook/test';
-import { Avatar, AvatarImage, AvatarFallback } from '@/components';
-import { User, UserCheck, Crown, Shield } from 'lucide-react';
+import { Avatar, AvatarImage, AvatarFallback, UserIcon, UserCheckIcon, CrownIcon, ShieldIcon } from '@/components';
 
 const meta: Meta<typeof Avatar> = {
   title: 'UI/Avatar',
@@ -110,7 +109,7 @@ export const WithIconFallback: Story = {
   render: () => (
     <Avatar>
       <AvatarFallback>
-        <User className="oui:size-4" />
+        <UserIcon className="oui:size-4" />
       </AvatarFallback>
     </Avatar>
   ),
@@ -205,7 +204,7 @@ export const UserProfiles: Story = {
       </Avatar>
       <Avatar>
         <AvatarFallback>
-          <User className="oui:size-4" />
+          <UserIcon className="oui:size-4" />
         </AvatarFallback>
       </Avatar>
     </div>
@@ -263,7 +262,7 @@ export const TeamMembers: Story = {
           <AvatarFallback>TL</AvatarFallback>
         </Avatar>
         <div className="oui:absolute oui:-top-1 oui:-right-1 oui:size-4 oui:bg-yellow-500 oui:rounded-full oui:flex oui:items-center oui:justify-center">
-          <Crown className="oui:size-2.5 oui:text-white" />
+          <CrownIcon className="oui:size-2.5 oui:text-white" />
         </div>
       </div>
       <div className="oui:relative">
@@ -271,7 +270,7 @@ export const TeamMembers: Story = {
           <AvatarFallback>AD</AvatarFallback>
         </Avatar>
         <div className="oui:absolute oui:-top-1 oui:-right-1 oui:size-4 oui:bg-blue-500 oui:rounded-full oui:flex oui:items-center oui:justify-center">
-          <Shield className="oui:size-2.5 oui:text-white" />
+          <ShieldIcon className="oui:size-2.5 oui:text-white" />
         </div>
       </div>
       <Avatar>
@@ -280,7 +279,7 @@ export const TeamMembers: Story = {
       <Avatar>
         <AvatarImage src="https://github.com/vercel.png" alt="Developer" />
         <AvatarFallback>
-          <UserCheck className="oui:size-4" />
+          <UserCheckIcon className="oui:size-4" />
         </AvatarFallback>
       </Avatar>
     </div>
@@ -525,7 +524,7 @@ export const FallbackVariations: Story = {
       <div className="oui:text-center">
         <Avatar>
           <AvatarFallback>
-            <User className="oui:size-4" />
+            <UserIcon className="oui:size-4" />
           </AvatarFallback>
         </Avatar>
         <p className="oui:text-xs oui:mt-2 oui:text-muted-foreground">User Icon</p>
@@ -533,7 +532,7 @@ export const FallbackVariations: Story = {
       <div className="oui:text-center">
         <Avatar>
           <AvatarFallback>
-            <UserCheck className="oui:size-4" />
+            <UserCheckIcon className="oui:size-4" />
           </AvatarFallback>
         </Avatar>
         <p className="oui:text-xs oui:mt-2 oui:text-muted-foreground">Verified Icon</p>

--- a/stories/Badge.stories.tsx
+++ b/stories/Badge.stories.tsx
@@ -1,6 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
-import { Badge } from '@/components';
-import { BadgeCheck, Star, AlertTriangle, Shield, Zap } from 'lucide-react';
+import { Badge, BadgeCheckIcon, StarIcon, AlertTriangleIcon, ShieldIcon, ZapIcon } from '@/components';
 
 const meta: Meta<typeof Badge> = {
   title: 'UI/Badge',
@@ -62,7 +61,7 @@ export const Verified: Story = {
     variant: 'verified',
     children: (
       <>
-        <BadgeCheck size={12} />
+        <BadgeCheckIcon size={12} />
         Verified
       </>
     ),
@@ -103,23 +102,23 @@ export const WithIcons: Story = {
   render: () => (
     <div className="oui:flex oui:flex-wrap oui:gap-4">
       <Badge variant="default">
-        <Star size={12} />
+        <StarIcon size={12} />
         Featured
       </Badge>
       <Badge variant="verified">
-        <BadgeCheck size={12} />
+        <BadgeCheckIcon size={12} />
         Verified
       </Badge>
       <Badge variant="destructive">
-        <AlertTriangle size={12} />
+        <AlertTriangleIcon size={12} />
         Error
       </Badge>
       <Badge variant="secondary">
-        <Shield size={12} />
+        <ShieldIcon size={12} />
         Protected
       </Badge>
       <Badge variant="severity-high">
-        <Zap size={12} />
+        <ZapIcon size={12} />
         Urgent
       </Badge>
     </div>
@@ -142,7 +141,7 @@ export const AllVariants: Story = {
       <Badge variant="destructive">Urgent</Badge>
       <Badge variant="outline">Optional</Badge>
       <Badge variant="verified">
-        <BadgeCheck size={12} />
+        <BadgeCheckIcon size={12} />
         Verified
       </Badge>
       <Badge variant="severity-low">Low</Badge>
@@ -168,7 +167,7 @@ export const StatusBadges: Story = {
       <Badge variant="outline">Inactive</Badge>
       <Badge variant="destructive">Failed</Badge>
       <Badge variant="verified">
-        <BadgeCheck size={12} />
+        <BadgeCheckIcon size={12} />
         Completed
       </Badge>
     </div>
@@ -189,7 +188,7 @@ export const PriorityBadges: Story = {
       <Badge variant="severity-med">Medium Priority</Badge>
       <Badge variant="severity-high">High Priority</Badge>
       <Badge variant="severity-critical">
-        <AlertTriangle size={12} />
+        <AlertTriangleIcon size={12} />
         Critical
       </Badge>
     </div>

--- a/stories/Breadcrumb.stories.tsx
+++ b/stories/Breadcrumb.stories.tsx
@@ -14,7 +14,7 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from '@/components';
-import { ChevronDown } from 'lucide-react';
+import { ChevronDownIcon } from '@/components';
 
 const meta: Meta<typeof Breadcrumb> = {
   title: 'UI/Breadcrumb',
@@ -124,7 +124,7 @@ export const WithDropdown: Story = {
           <DropdownMenu>
             <DropdownMenuTrigger className="oui:flex oui:items-center oui:gap-1 oui:hover:text-foreground oui:transition-colors">
               Components
-              <ChevronDown className="oui:h-4 oui:w-4" />
+              <ChevronDownIcon className="oui:h-4 oui:w-4" />
             </DropdownMenuTrigger>
             <DropdownMenuContent align="start">
               <DropdownMenuItem>

--- a/stories/ButtonGroup.stories.tsx
+++ b/stories/ButtonGroup.stories.tsx
@@ -1,8 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import { useState } from 'react';
-import { ButtonGroup, ButtonGroupSeparator, ButtonGroupText } from '@/components';
-import { Button } from '@/components';
-import { Heart, Bookmark, Share, Check, Trash2 } from 'lucide-react';
+import { ButtonGroup, ButtonGroupSeparator, ButtonGroupText, Button, HeartIcon, BookmarkIcon, ShareIcon, CheckIcon, Trash2Icon } from '@/components';
 
 const meta: Meta<typeof ButtonGroup> = {
   title: 'UI/ButtonGroup',
@@ -140,15 +138,15 @@ export const WithIcons: Story = {
   render: () => (
     <ButtonGroup>
       <Button variant="outline">
-        <Heart />
+        <HeartIcon />
         Like
       </Button>
       <Button variant="outline">
-        <Bookmark />
+        <BookmarkIcon />
         Bookmark
       </Button>
       <Button variant="outline">
-        <Share />
+        <ShareIcon />
         Share
       </Button>
     </ButtonGroup>
@@ -236,10 +234,10 @@ export const ToolbarExample: Story = {
       <ButtonGroup>
         <ButtonGroupText>Edit:</ButtonGroupText>
         <Button variant="outline" size="sm">
-          <Check />
+          <CheckIcon />
         </Button>
         <Button variant="outline" size="sm">
-          <Trash2 />
+          <Trash2Icon />
         </Button>
         <ButtonGroupSeparator />
         <Button variant="outline" size="sm">Copy</Button>

--- a/stories/Collapsible.stories.tsx
+++ b/stories/Collapsible.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react';
 import { useState, useEffect } from 'react';
-import { ChevronsUpDown } from 'lucide-react';
+import { ChevronsUpDownIcon } from '@/components';
 import {
     Collapsible,
     CollapsibleContent,
@@ -62,7 +62,7 @@ export const Default: Story = {
                         </h4>
                         <CollapsibleTrigger asChild>
                             <Button variant="ghost" size="sm" className="oui:w-9 oui:p-0">
-                                <ChevronsUpDown className="oui:h-4 oui:w-4 oui:text-foreground" />
+                                <ChevronsUpDownIcon className="oui:h-4 oui:w-4 oui:text-foreground" />
                                 <span className="oui:sr-only">Toggle</span>
                             </Button>
                         </CollapsibleTrigger>
@@ -132,7 +132,7 @@ export const Navigation: Story = {
                         >
                             <CollapsibleTrigger className="oui:flex oui:items-center oui:justify-between oui:w-full oui:p-2 oui:text-left oui:hover:bg-accent oui:rounded-md">
                                 <span className="oui:font-medium">{section.title}</span>
-                                <ChevronsUpDown className="oui:h-4 oui:w-4 oui:text-foreground" />
+                                <ChevronsUpDownIcon className="oui:h-4 oui:w-4 oui:text-foreground" />
                             </CollapsibleTrigger>
                             <CollapsibleContent className="oui:ml-4 oui:mt-1">
                                 <div className="oui:space-y-1">

--- a/stories/Combobox.stories.tsx
+++ b/stories/Combobox.stories.tsx
@@ -3,14 +3,14 @@ import { expect, userEvent, within } from '@storybook/test';
 import { Combobox, ComboboxOption } from '@/components';
 import { Avatar, AvatarFallback, AvatarImage } from '@/components';
 import { useState } from 'react';
-import { 
-  Building2, 
-  GraduationCap,
-  Code,
-  Globe,
-  Plus,
-  ChevronsUpDown
-} from 'lucide-react';
+import {
+  Building2Icon,
+  GraduationCapIcon,
+  CodeIcon,
+  GlobeIcon,
+  PlusIcon,
+  ChevronsUpDownIcon
+} from '@/components';
 
 const meta: Meta<typeof Combobox> = {
   title: 'UI/Combobox',
@@ -464,7 +464,7 @@ export const UseCases: Story = {
       <div className="oui:grid oui:grid-cols-2 oui:gap-6 oui:w-[500px]">
         <div className="oui:space-y-2">
           <div className="oui:flex oui:items-center oui:gap-2">
-            <Code className="oui:h-4 oui:w-4 oui:text-muted-foreground" />
+            <CodeIcon className="oui:h-4 oui:w-4 oui:text-muted-foreground" />
             <label className="oui:text-sm oui:font-medium">Framework</label>
           </div>
           <Combobox
@@ -478,7 +478,7 @@ export const UseCases: Story = {
         
         <div className="oui:space-y-2">
           <div className="oui:flex oui:items-center oui:gap-2">
-            <Globe className="oui:h-4 oui:w-4 oui:text-muted-foreground" />
+            <GlobeIcon className="oui:h-4 oui:w-4 oui:text-muted-foreground" />
             <label className="oui:text-sm oui:font-medium">Country</label>
           </div>
           <Combobox
@@ -492,7 +492,7 @@ export const UseCases: Story = {
         
         <div className="oui:space-y-2">
           <div className="oui:flex oui:items-center oui:gap-2">
-            <GraduationCap className="oui:h-4 oui:w-4 oui:text-muted-foreground" />
+            <GraduationCapIcon className="oui:h-4 oui:w-4 oui:text-muted-foreground" />
             <label className="oui:text-sm oui:font-medium">Skill</label>
           </div>
           <Combobox
@@ -506,7 +506,7 @@ export const UseCases: Story = {
         
         <div className="oui:space-y-2">
           <div className="oui:flex oui:items-center oui:gap-2">
-            <Building2 className="oui:h-4 oui:w-4 oui:text-muted-foreground" />
+            <Building2Icon className="oui:h-4 oui:w-4 oui:text-muted-foreground" />
             <label className="oui:text-sm oui:font-medium">Department</label>
           </div>
           <Combobox
@@ -581,7 +581,7 @@ export const UserSelection: StoryObj = {
         content: (
           <div className="oui:flex oui:items-center oui:gap-2">
             <div className="oui:flex oui:h-6 oui:w-6 oui:items-center oui:justify-center oui:rounded-full oui:border oui:border-dashed oui:border-muted-foreground">
-              <Plus className="oui:h-3 oui:w-3" />
+              <PlusIcon className="oui:h-3 oui:w-3" />
             </div>
             <span>Create user</span>
           </div>
@@ -621,7 +621,7 @@ export const UserSelection: StoryObj = {
                 ) : (
                   <span className="oui:text-muted-foreground">Search user...</span>
                 )}
-                <ChevronsUpDown className="oui:ml-2 oui:h-4 oui:w-4 oui:shrink-0 oui:opacity-50" />
+                <ChevronsUpDownIcon className="oui:ml-2 oui:h-4 oui:w-4 oui:shrink-0 oui:opacity-50" />
               </button>
             );
           }}

--- a/stories/Command.stories.tsx
+++ b/stories/Command.stories.tsx
@@ -2,17 +2,17 @@ import type { Meta, StoryObj } from '@storybook/react';
 import { expect, userEvent, within } from '@storybook/test';
 import { useState } from 'react';
 import {
-  Calculator,
-  Calendar,
-  CreditCard,
-  Settings,
-  Smile,
-  User,
-  FileText,
-  Search,
-  Home,
-  Mail,
-} from 'lucide-react';
+  CalculatorIcon,
+  CalendarIcon,
+  CreditCardIcon,
+  SettingsIcon,
+  SmileIcon,
+  UserIcon,
+  FileTextIcon,
+  SearchIcon,
+  HomeIcon,
+  MailIcon,
+} from '@/components';
 import {
   Command,
   CommandDialog,
@@ -55,32 +55,32 @@ export const Default: Story = {
           <CommandEmpty>No results found.</CommandEmpty>
           <CommandGroup heading="Suggestions">
             <CommandItem>
-              <Calendar className="oui:mr-2 oui:h-4 oui:w-4" />
+              <CalendarIcon className="oui:mr-2 oui:h-4 oui:w-4" />
               <span>Calendar</span>
             </CommandItem>
             <CommandItem>
-              <Smile className="oui:mr-2 oui:h-4 oui:w-4" />
+              <SmileIcon className="oui:mr-2 oui:h-4 oui:w-4" />
               <span>Search Emoji</span>
             </CommandItem>
             <CommandItem>
-              <Calculator className="oui:mr-2 oui:h-4 oui:w-4" />
+              <CalculatorIcon className="oui:mr-2 oui:h-4 oui:w-4" />
               <span>Calculator</span>
             </CommandItem>
           </CommandGroup>
           <CommandSeparator />
           <CommandGroup heading="Settings">
             <CommandItem>
-              <User className="oui:mr-2 oui:h-4 oui:w-4" />
+              <UserIcon className="oui:mr-2 oui:h-4 oui:w-4" />
               <span>Profile</span>
               <CommandShortcut>⌘P</CommandShortcut>
             </CommandItem>
             <CommandItem>
-              <CreditCard className="oui:mr-2 oui:h-4 oui:w-4" />
+              <CreditCardIcon className="oui:mr-2 oui:h-4 oui:w-4" />
               <span>Billing</span>
               <CommandShortcut>⌘B</CommandShortcut>
             </CommandItem>
             <CommandItem>
-              <Settings className="oui:mr-2 oui:h-4 oui:w-4" />
+              <SettingsIcon className="oui:mr-2 oui:h-4 oui:w-4" />
               <span>Settings</span>
               <CommandShortcut>⌘S</CommandShortcut>
             </CommandItem>
@@ -142,17 +142,17 @@ export const Dialog: Story = {
             <CommandEmpty>No results found.</CommandEmpty>
             <CommandGroup heading="Quick Actions">
               <CommandItem onSelect={() => setOpen(false)}>
-                <FileText className="oui:mr-2 oui:h-4 oui:w-4" />
+                <FileTextIcon className="oui:mr-2 oui:h-4 oui:w-4" />
                 <span>New Document</span>
                 <CommandShortcut>⌘N</CommandShortcut>
               </CommandItem>
               <CommandItem onSelect={() => setOpen(false)}>
-                <Search className="oui:mr-2 oui:h-4 oui:w-4" />
+                <SearchIcon className="oui:mr-2 oui:h-4 oui:w-4" />
                 <span>Search Files</span>
                 <CommandShortcut>⌘F</CommandShortcut>
               </CommandItem>
               <CommandItem onSelect={() => setOpen(false)}>
-                <Home className="oui:mr-2 oui:h-4 oui:w-4" />
+                <HomeIcon className="oui:mr-2 oui:h-4 oui:w-4" />
                 <span>Go to Dashboard</span>
                 <CommandShortcut>⌘D</CommandShortcut>
               </CommandItem>
@@ -160,17 +160,17 @@ export const Dialog: Story = {
             <CommandSeparator />
             <CommandGroup heading="Navigation">
               <CommandItem onSelect={() => setOpen(false)}>
-                <User className="oui:mr-2 oui:h-4 oui:w-4" />
+                <UserIcon className="oui:mr-2 oui:h-4 oui:w-4" />
                 <span>Profile</span>
                 <CommandShortcut>⌘P</CommandShortcut>
               </CommandItem>
               <CommandItem onSelect={() => setOpen(false)}>
-                <Mail className="oui:mr-2 oui:h-4 oui:w-4" />
+                <MailIcon className="oui:mr-2 oui:h-4 oui:w-4" />
                 <span>Messages</span>
                 <CommandShortcut>⌘M</CommandShortcut>
               </CommandItem>
               <CommandItem onSelect={() => setOpen(false)}>
-                <Settings className="oui:mr-2 oui:h-4 oui:w-4" />
+                <SettingsIcon className="oui:mr-2 oui:h-4 oui:w-4" />
                 <span>Settings</span>
                 <CommandShortcut>⌘,</CommandShortcut>
               </CommandItem>
@@ -202,7 +202,7 @@ export const SearchableList: Story = {
             <CommandGroup heading="Team Members">
               {items.map((item) => (
                 <CommandItem key={item.email} value={`${item.name} ${item.email} ${item.role}`}>
-                  <User className="oui:mr-2 oui:h-4 oui:w-4" />
+                  <UserIcon className="oui:mr-2 oui:h-4 oui:w-4" />
                   <div className="oui:flex oui:flex-col">
                     <span className="oui:font-medium">{item.name}</span>
                     <span className="oui:text-sm oui:text-muted-foreground">{item.email}</span>
@@ -238,17 +238,17 @@ export const MultipleGroups: Story = {
           <CommandEmpty>No results found.</CommandEmpty>
           <CommandGroup heading="File">
             <CommandItem>
-              <FileText className="oui:mr-2 oui:h-4 oui:w-4" />
+              <FileTextIcon className="oui:mr-2 oui:h-4 oui:w-4" />
               <span>New File</span>
               <CommandShortcut>⌘N</CommandShortcut>
             </CommandItem>
             <CommandItem>
-              <FileText className="oui:mr-2 oui:h-4 oui:w-4" />
+              <FileTextIcon className="oui:mr-2 oui:h-4 oui:w-4" />
               <span>Open File</span>
               <CommandShortcut>⌘O</CommandShortcut>
             </CommandItem>
             <CommandItem>
-              <FileText className="oui:mr-2 oui:h-4 oui:w-4" />
+              <FileTextIcon className="oui:mr-2 oui:h-4 oui:w-4" />
               <span>Save File</span>
               <CommandShortcut>⌘S</CommandShortcut>
             </CommandItem>
@@ -313,11 +313,11 @@ export const Showcase: Story = {
                   <CommandEmpty>No results found.</CommandEmpty>
                   <CommandGroup heading="Actions">
                     <CommandItem>
-                      <Home className="oui:mr-2 oui:h-4 oui:w-4" />
+                      <HomeIcon className="oui:mr-2 oui:h-4 oui:w-4" />
                       <span>Home</span>
                     </CommandItem>
                     <CommandItem>
-                      <Settings className="oui:mr-2 oui:h-4 oui:w-4" />
+                      <SettingsIcon className="oui:mr-2 oui:h-4 oui:w-4" />
                       <span>Settings</span>
                     </CommandItem>
                   </CommandGroup>
@@ -340,12 +340,12 @@ export const Showcase: Story = {
                   <CommandEmpty>No results found.</CommandEmpty>
                   <CommandGroup heading="Quick Actions">
                     <CommandItem onSelect={() => setDialogOpen(false)}>
-                      <FileText className="oui:mr-2 oui:h-4 oui:w-4" />
+                      <FileTextIcon className="oui:mr-2 oui:h-4 oui:w-4" />
                       <span>New Document</span>
                       <CommandShortcut>⌘N</CommandShortcut>
                     </CommandItem>
                     <CommandItem onSelect={() => setDialogOpen(false)}>
-                      <Search className="oui:mr-2 oui:h-4 oui:w-4" />
+                      <SearchIcon className="oui:mr-2 oui:h-4 oui:w-4" />
                       <span>Search</span>
                       <CommandShortcut>⌘K</CommandShortcut>
                     </CommandItem>

--- a/stories/ContextMenu.stories.tsx
+++ b/stories/ContextMenu.stories.tsx
@@ -14,36 +14,36 @@ import {
     ContextMenuSubContent,
     ContextMenuSubTrigger,
 } from '@/components';
-import { 
-    Copy, 
-    Scissors, 
-    ClipboardPaste, 
-    Edit, 
-    Trash2, 
-    Download, 
-    Share, 
-    Star, 
-    Archive,
-    MoreHorizontal,
-    FileText,
-    Video,
-    Music,
-    Settings,
-    User,
-    Mail,
-    Phone,
-    Calendar,
-    Clock,
-    Bookmark,
-    Tag,
-    Filter,
-    ArrowUpAZ,
-    ArrowDownAZ,
-    Grid3X3,
-    List,
-    Eye,
-    EyeOff
-} from 'lucide-react';
+import {
+    CopyIcon,
+    ScissorsIcon,
+    ClipboardPasteIcon,
+    EditIcon,
+    Trash2Icon,
+    DownloadIcon,
+    ShareIcon,
+    StarIcon,
+    ArchiveIcon,
+    MoreHorizontalIcon,
+    FileTextIcon,
+    VideoIcon,
+    MusicIcon,
+    SettingsIcon,
+    UserIcon,
+    MailIcon,
+    PhoneIcon,
+    CalendarIcon,
+    ClockIcon,
+    BookmarkIcon,
+    TagIcon,
+    FilterIcon,
+    ArrowUpAZIcon,
+    ArrowDownAZIcon,
+    Grid3X3Icon,
+    ListIcon,
+    EyeIcon,
+    EyeOffIcon
+} from '@/components';
 
 const meta: Meta<typeof ContextMenu> = {
     title: 'UI/ContextMenu',
@@ -82,17 +82,17 @@ export const Default: Story = {
                 </ContextMenuTrigger>
                 <ContextMenuContent>
                     <ContextMenuItem>
-                        <Copy className="oui:mr-2 oui:h-4 oui:w-4" />
+                        <CopyIcon className="oui:mr-2 oui:h-4 oui:w-4" />
                         Copy
                         <ContextMenuShortcut>⌘C</ContextMenuShortcut>
                     </ContextMenuItem>
                     <ContextMenuItem>
-                        <Scissors className="oui:mr-2 oui:h-4 oui:w-4" />
+                        <ScissorsIcon className="oui:mr-2 oui:h-4 oui:w-4" />
                         Cut
                         <ContextMenuShortcut>⌘X</ContextMenuShortcut>
                     </ContextMenuItem>
                     <ContextMenuItem>
-                        <ClipboardPaste className="oui:mr-2 oui:h-4 oui:w-4" />
+                        <ClipboardPasteIcon className="oui:mr-2 oui:h-4 oui:w-4" />
                         Paste
                         <ContextMenuShortcut>⌘V</ContextMenuShortcut>
                     </ContextMenuItem>
@@ -118,31 +118,31 @@ export const WithSeparators: Story = {
                 </ContextMenuTrigger>
                 <ContextMenuContent>
                     <ContextMenuItem>
-                        <Edit className="oui:mr-2 oui:h-4 oui:w-4" />
+                        <EditIcon className="oui:mr-2 oui:h-4 oui:w-4" />
                         Edit
                         <ContextMenuShortcut>⌘E</ContextMenuShortcut>
                     </ContextMenuItem>
                     <ContextMenuItem>
-                        <Copy className="oui:mr-2 oui:h-4 oui:w-4" />
+                        <CopyIcon className="oui:mr-2 oui:h-4 oui:w-4" />
                         Duplicate
                         <ContextMenuShortcut>⌘D</ContextMenuShortcut>
                     </ContextMenuItem>
                     <ContextMenuSeparator />
                     <ContextMenuItem>
-                        <Download className="oui:mr-2 oui:h-4 oui:w-4" />
+                        <DownloadIcon className="oui:mr-2 oui:h-4 oui:w-4" />
                         Download
                     </ContextMenuItem>
                     <ContextMenuItem>
-                        <Share className="oui:mr-2 oui:h-4 oui:w-4" />
+                        <ShareIcon className="oui:mr-2 oui:h-4 oui:w-4" />
                         Share
                     </ContextMenuItem>
                     <ContextMenuSeparator />
                     <ContextMenuItem>
-                        <Archive className="oui:mr-2 oui:h-4 oui:w-4" />
+                        <ArchiveIcon className="oui:mr-2 oui:h-4 oui:w-4" />
                         Archive
                     </ContextMenuItem>
                     <ContextMenuItem variant="destructive">
-                        <Trash2 className="oui:mr-2 oui:h-4 oui:w-4" />
+                        <Trash2Icon className="oui:mr-2 oui:h-4 oui:w-4" />
                         Delete
                         <ContextMenuShortcut>⌘⌫</ContextMenuShortcut>
                     </ContextMenuItem>
@@ -170,24 +170,24 @@ export const WithCheckboxItems: Story = {
                     <ContextMenuLabel>View Options</ContextMenuLabel>
                     <ContextMenuSeparator />
                     <ContextMenuCheckboxItem checked>
-                        <Eye className="oui:mr-2 oui:h-4 oui:w-4" />
+                        <EyeIcon className="oui:mr-2 oui:h-4 oui:w-4" />
                         Show Preview
                     </ContextMenuCheckboxItem>
                     <ContextMenuCheckboxItem>
-                        <Grid3X3 className="oui:mr-2 oui:h-4 oui:w-4" />
+                        <Grid3X3Icon className="oui:mr-2 oui:h-4 oui:w-4" />
                         Grid View
                     </ContextMenuCheckboxItem>
                     <ContextMenuCheckboxItem checked>
-                        <List className="oui:mr-2 oui:h-4 oui:w-4" />
+                        <ListIcon className="oui:mr-2 oui:h-4 oui:w-4" />
                         List View
                     </ContextMenuCheckboxItem>
                     <ContextMenuSeparator />
                     <ContextMenuCheckboxItem>
-                        <Bookmark className="oui:mr-2 oui:h-4 oui:w-4" />
+                        <BookmarkIcon className="oui:mr-2 oui:h-4 oui:w-4" />
                         Show Bookmarks
                     </ContextMenuCheckboxItem>
                     <ContextMenuCheckboxItem checked>
-                        <Tag className="oui:mr-2 oui:h-4 oui:w-4" />
+                        <TagIcon className="oui:mr-2 oui:h-4 oui:w-4" />
                         Show Tags
                     </ContextMenuCheckboxItem>
                 </ContextMenuContent>
@@ -215,30 +215,30 @@ export const WithRadioGroup: Story = {
                     <ContextMenuSeparator />
                     <ContextMenuRadioGroup value="name">
                         <ContextMenuRadioItem value="name">
-                            <FileText className="oui:mr-2 oui:h-4 oui:w-4" />
+                            <FileTextIcon className="oui:mr-2 oui:h-4 oui:w-4" />
                             Name
                         </ContextMenuRadioItem>
                         <ContextMenuRadioItem value="date">
-                            <Calendar className="oui:mr-2 oui:h-4 oui:w-4" />
+                            <CalendarIcon className="oui:mr-2 oui:h-4 oui:w-4" />
                             Date Modified
                         </ContextMenuRadioItem>
                         <ContextMenuRadioItem value="size">
-                            <Archive className="oui:mr-2 oui:h-4 oui:w-4" />
+                            <ArchiveIcon className="oui:mr-2 oui:h-4 oui:w-4" />
                             File Size
                         </ContextMenuRadioItem>
                         <ContextMenuRadioItem value="type">
-                            <Filter className="oui:mr-2 oui:h-4 oui:w-4" />
+                            <FilterIcon className="oui:mr-2 oui:h-4 oui:w-4" />
                             File Type
                         </ContextMenuRadioItem>
                     </ContextMenuRadioGroup>
                     <ContextMenuSeparator />
                     <ContextMenuRadioGroup value="asc">
                         <ContextMenuRadioItem value="asc">
-                            <ArrowUpAZ className="oui:mr-2 oui:h-4 oui:w-4" />
+                            <ArrowUpAZIcon className="oui:mr-2 oui:h-4 oui:w-4" />
                             Ascending
                         </ContextMenuRadioItem>
                         <ContextMenuRadioItem value="desc">
-                            <ArrowDownAZ className="oui:mr-2 oui:h-4 oui:w-4" />
+                            <ArrowDownAZIcon className="oui:mr-2 oui:h-4 oui:w-4" />
                             Descending
                         </ContextMenuRadioItem>
                     </ContextMenuRadioGroup>
@@ -264,52 +264,52 @@ export const WithSubmenus: Story = {
                 </ContextMenuTrigger>
                 <ContextMenuContent>
                     <ContextMenuItem>
-                        <Edit className="oui:mr-2 oui:h-4 oui:w-4" />
+                        <EditIcon className="oui:mr-2 oui:h-4 oui:w-4" />
                         Edit
                     </ContextMenuItem>
                     <ContextMenuSub>
                         <ContextMenuSubTrigger>
-                            <Share className="oui:mr-2 oui:h-4 oui:w-4" />
+                            <ShareIcon className="oui:mr-2 oui:h-4 oui:w-4" />
                             Share
                         </ContextMenuSubTrigger>
                         <ContextMenuSubContent>
                             <ContextMenuItem>
-                                <Mail className="oui:mr-2 oui:h-4 oui:w-4" />
+                                <MailIcon className="oui:mr-2 oui:h-4 oui:w-4" />
                                 Email
                             </ContextMenuItem>
                             <ContextMenuItem>
-                                <Copy className="oui:mr-2 oui:h-4 oui:w-4" />
+                                <CopyIcon className="oui:mr-2 oui:h-4 oui:w-4" />
                                 Copy Link
                             </ContextMenuItem>
                             <ContextMenuItem>
-                                <Download className="oui:mr-2 oui:h-4 oui:w-4" />
+                                <DownloadIcon className="oui:mr-2 oui:h-4 oui:w-4" />
                                 Export
                             </ContextMenuItem>
                         </ContextMenuSubContent>
                     </ContextMenuSub>
                     <ContextMenuSub>
                         <ContextMenuSubTrigger>
-                            <MoreHorizontal className="oui:mr-2 oui:h-4 oui:w-4" />
+                            <MoreHorizontalIcon className="oui:mr-2 oui:h-4 oui:w-4" />
                             More Actions
                         </ContextMenuSubTrigger>
                         <ContextMenuSubContent>
                             <ContextMenuItem>
-                                <Star className="oui:mr-2 oui:h-4 oui:w-4" />
+                                <StarIcon className="oui:mr-2 oui:h-4 oui:w-4" />
                                 Add to Favorites
                             </ContextMenuItem>
                             <ContextMenuItem>
-                                <Archive className="oui:mr-2 oui:h-4 oui:w-4" />
+                                <ArchiveIcon className="oui:mr-2 oui:h-4 oui:w-4" />
                                 Archive
                             </ContextMenuItem>
                             <ContextMenuItem>
-                                <Settings className="oui:mr-2 oui:h-4 oui:w-4" />
+                                <SettingsIcon className="oui:mr-2 oui:h-4 oui:w-4" />
                                 Properties
                             </ContextMenuItem>
                         </ContextMenuSubContent>
                     </ContextMenuSub>
                     <ContextMenuSeparator />
                     <ContextMenuItem variant="destructive">
-                        <Trash2 className="oui:mr-2 oui:h-4 oui:w-4" />
+                        <Trash2Icon className="oui:mr-2 oui:h-4 oui:w-4" />
                         Delete
                     </ContextMenuItem>
                 </ContextMenuContent>
@@ -334,56 +334,56 @@ export const FileExplorer: Story = {
                 </ContextMenuTrigger>
                 <ContextMenuContent>
                     <ContextMenuItem>
-                        <FileText className="oui:mr-2 oui:h-4 oui:w-4" />
+                        <FileTextIcon className="oui:mr-2 oui:h-4 oui:w-4" />
                         Open
                         <ContextMenuShortcut>⌘O</ContextMenuShortcut>
                     </ContextMenuItem>
                     <ContextMenuItem>
-                        <Edit className="oui:mr-2 oui:h-4 oui:w-4" />
+                        <EditIcon className="oui:mr-2 oui:h-4 oui:w-4" />
                         Open With...
                     </ContextMenuItem>
                     <ContextMenuSeparator />
                     <ContextMenuItem>
-                        <Copy className="oui:mr-2 oui:h-4 oui:w-4" />
+                        <CopyIcon className="oui:mr-2 oui:h-4 oui:w-4" />
                         Copy
                         <ContextMenuShortcut>⌘C</ContextMenuShortcut>
                     </ContextMenuItem>
                     <ContextMenuItem>
-                        <Scissors className="oui:mr-2 oui:h-4 oui:w-4" />
+                        <ScissorsIcon className="oui:mr-2 oui:h-4 oui:w-4" />
                         Cut
                         <ContextMenuShortcut>⌘X</ContextMenuShortcut>
                     </ContextMenuItem>
                     <ContextMenuItem>
-                        <Copy className="oui:mr-2 oui:h-4 oui:w-4" />
+                        <CopyIcon className="oui:mr-2 oui:h-4 oui:w-4" />
                         Duplicate
                         <ContextMenuShortcut>⌘D</ContextMenuShortcut>
                     </ContextMenuItem>
                     <ContextMenuSeparator />
                     <ContextMenuItem>
-                        <Download className="oui:mr-2 oui:h-4 oui:w-4" />
+                        <DownloadIcon className="oui:mr-2 oui:h-4 oui:w-4" />
                         Download
                     </ContextMenuItem>
                     <ContextMenuItem>
-                        <Share className="oui:mr-2 oui:h-4 oui:w-4" />
+                        <ShareIcon className="oui:mr-2 oui:h-4 oui:w-4" />
                         Share
                     </ContextMenuItem>
                     <ContextMenuSeparator />
                     <ContextMenuItem>
-                        <Star className="oui:mr-2 oui:h-4 oui:w-4" />
+                        <StarIcon className="oui:mr-2 oui:h-4 oui:w-4" />
                         Add to Favorites
                     </ContextMenuItem>
                     <ContextMenuItem>
-                        <Archive className="oui:mr-2 oui:h-4 oui:w-4" />
+                        <ArchiveIcon className="oui:mr-2 oui:h-4 oui:w-4" />
                         Move to Archive
                     </ContextMenuItem>
                     <ContextMenuSeparator />
                     <ContextMenuItem>
-                        <Settings className="oui:mr-2 oui:h-4 oui:w-4" />
+                        <SettingsIcon className="oui:mr-2 oui:h-4 oui:w-4" />
                         Properties
                         <ContextMenuShortcut>⌘I</ContextMenuShortcut>
                     </ContextMenuItem>
                     <ContextMenuItem variant="destructive">
-                        <Trash2 className="oui:mr-2 oui:h-4 oui:w-4" />
+                        <Trash2Icon className="oui:mr-2 oui:h-4 oui:w-4" />
                         Move to Trash
                         <ContextMenuShortcut>⌘⌫</ContextMenuShortcut>
                     </ContextMenuItem>
@@ -409,19 +409,19 @@ export const MediaPlayer: Story = {
                 </ContextMenuTrigger>
                 <ContextMenuContent>
                     <ContextMenuItem>
-                        <Music className="oui:mr-2 oui:h-4 oui:w-4" />
+                        <MusicIcon className="oui:mr-2 oui:h-4 oui:w-4" />
                         Play
                         <ContextMenuShortcut>Space</ContextMenuShortcut>
                     </ContextMenuItem>
                     <ContextMenuItem>
-                        <Clock className="oui:mr-2 oui:h-4 oui:w-4" />
+                        <ClockIcon className="oui:mr-2 oui:h-4 oui:w-4" />
                         Pause
                         <ContextMenuShortcut>Space</ContextMenuShortcut>
                     </ContextMenuItem>
                     <ContextMenuSeparator />
                     <ContextMenuSub>
                         <ContextMenuSubTrigger>
-                            <Settings className="oui:mr-2 oui:h-4 oui:w-4" />
+                            <SettingsIcon className="oui:mr-2 oui:h-4 oui:w-4" />
                             Playback Speed
                         </ContextMenuSubTrigger>
                         <ContextMenuSubContent>
@@ -437,7 +437,7 @@ export const MediaPlayer: Story = {
                     </ContextMenuSub>
                     <ContextMenuSub>
                         <ContextMenuSubTrigger>
-                            <Video className="oui:mr-2 oui:h-4 oui:w-4" />
+                            <VideoIcon className="oui:mr-2 oui:h-4 oui:w-4" />
                             Quality
                         </ContextMenuSubTrigger>
                         <ContextMenuSubContent>
@@ -451,20 +451,20 @@ export const MediaPlayer: Story = {
                     </ContextMenuSub>
                     <ContextMenuSeparator />
                     <ContextMenuCheckboxItem checked>
-                        <Eye className="oui:mr-2 oui:h-4 oui:w-4" />
+                        <EyeIcon className="oui:mr-2 oui:h-4 oui:w-4" />
                         Show Controls
                     </ContextMenuCheckboxItem>
                     <ContextMenuCheckboxItem>
-                        <EyeOff className="oui:mr-2 oui:h-4 oui:w-4" />
+                        <EyeOffIcon className="oui:mr-2 oui:h-4 oui:w-4" />
                         Picture in Picture
                     </ContextMenuCheckboxItem>
                     <ContextMenuSeparator />
                     <ContextMenuItem>
-                        <Download className="oui:mr-2 oui:h-4 oui:w-4" />
+                        <DownloadIcon className="oui:mr-2 oui:h-4 oui:w-4" />
                         Download
                     </ContextMenuItem>
                     <ContextMenuItem>
-                        <Share className="oui:mr-2 oui:h-4 oui:w-4" />
+                        <ShareIcon className="oui:mr-2 oui:h-4 oui:w-4" />
                         Share
                     </ContextMenuItem>
                 </ContextMenuContent>
@@ -489,42 +489,42 @@ export const ContactCard: Story = {
                 </ContextMenuTrigger>
                 <ContextMenuContent>
                     <ContextMenuItem>
-                        <User className="oui:mr-2 oui:h-4 oui:w-4" />
+                        <UserIcon className="oui:mr-2 oui:h-4 oui:w-4" />
                         View Profile
                     </ContextMenuItem>
                     <ContextMenuItem>
-                        <Edit className="oui:mr-2 oui:h-4 oui:w-4" />
+                        <EditIcon className="oui:mr-2 oui:h-4 oui:w-4" />
                         Edit Contact
                     </ContextMenuItem>
                     <ContextMenuSeparator />
                     <ContextMenuItem>
-                        <Mail className="oui:mr-2 oui:h-4 oui:w-4" />
+                        <MailIcon className="oui:mr-2 oui:h-4 oui:w-4" />
                         Send Email
                     </ContextMenuItem>
                     <ContextMenuItem>
-                        <Phone className="oui:mr-2 oui:h-4 oui:w-4" />
+                        <PhoneIcon className="oui:mr-2 oui:h-4 oui:w-4" />
                         Call
                     </ContextMenuItem>
                     <ContextMenuItem>
-                        <Calendar className="oui:mr-2 oui:h-4 oui:w-4" />
+                        <CalendarIcon className="oui:mr-2 oui:h-4 oui:w-4" />
                         Schedule Meeting
                     </ContextMenuItem>
                     <ContextMenuSeparator />
                     <ContextMenuItem>
-                        <Star className="oui:mr-2 oui:h-4 oui:w-4" />
+                        <StarIcon className="oui:mr-2 oui:h-4 oui:w-4" />
                         Add to Favorites
                     </ContextMenuItem>
                     <ContextMenuItem>
-                        <Tag className="oui:mr-2 oui:h-4 oui:w-4" />
+                        <TagIcon className="oui:mr-2 oui:h-4 oui:w-4" />
                         Add Tag
                     </ContextMenuItem>
                     <ContextMenuSeparator />
                     <ContextMenuItem>
-                        <Share className="oui:mr-2 oui:h-4 oui:w-4" />
+                        <ShareIcon className="oui:mr-2 oui:h-4 oui:w-4" />
                         Share Contact
                     </ContextMenuItem>
                     <ContextMenuItem variant="destructive">
-                        <Trash2 className="oui:mr-2 oui:h-4 oui:w-4" />
+                        <Trash2Icon className="oui:mr-2 oui:h-4 oui:w-4" />
                         Delete Contact
                     </ContextMenuItem>
                 </ContextMenuContent>
@@ -549,32 +549,32 @@ export const DisabledItems: Story = {
                 </ContextMenuTrigger>
                 <ContextMenuContent>
                     <ContextMenuItem>
-                        <Copy className="oui:mr-2 oui:h-4 oui:w-4" />
+                        <CopyIcon className="oui:mr-2 oui:h-4 oui:w-4" />
                         Copy
                         <ContextMenuShortcut>⌘C</ContextMenuShortcut>
                     </ContextMenuItem>
                     <ContextMenuItem disabled>
-                        <Scissors className="oui:mr-2 oui:h-4 oui:w-4" />
+                        <ScissorsIcon className="oui:mr-2 oui:h-4 oui:w-4" />
                         Cut
                         <ContextMenuShortcut>⌘X</ContextMenuShortcut>
                     </ContextMenuItem>
                     <ContextMenuItem disabled>
-                        <ClipboardPaste className="oui:mr-2 oui:h-4 oui:w-4" />
+                        <ClipboardPasteIcon className="oui:mr-2 oui:h-4 oui:w-4" />
                         Paste
                         <ContextMenuShortcut>⌘V</ContextMenuShortcut>
                     </ContextMenuItem>
                     <ContextMenuSeparator />
                     <ContextMenuItem>
-                        <Edit className="oui:mr-2 oui:h-4 oui:w-4" />
+                        <EditIcon className="oui:mr-2 oui:h-4 oui:w-4" />
                         Edit
                     </ContextMenuItem>
                     <ContextMenuItem disabled>
-                        <Share className="oui:mr-2 oui:h-4 oui:w-4" />
+                        <ShareIcon className="oui:mr-2 oui:h-4 oui:w-4" />
                         Share
                     </ContextMenuItem>
                     <ContextMenuSeparator />
                     <ContextMenuItem variant="destructive" disabled>
-                        <Trash2 className="oui:mr-2 oui:h-4 oui:w-4" />
+                        <Trash2Icon className="oui:mr-2 oui:h-4 oui:w-4" />
                         Delete
                     </ContextMenuItem>
                 </ContextMenuContent>
@@ -600,15 +600,15 @@ export const Showcase: Story = {
                     </ContextMenuTrigger>
                     <ContextMenuContent>
                         <ContextMenuItem>
-                            <Copy className="oui:mr-2 oui:h-4 oui:w-4" />
+                            <CopyIcon className="oui:mr-2 oui:h-4 oui:w-4" />
                             Copy
                         </ContextMenuItem>
                         <ContextMenuItem>
-                            <Edit className="oui:mr-2 oui:h-4 oui:w-4" />
+                            <EditIcon className="oui:mr-2 oui:h-4 oui:w-4" />
                             Edit
                         </ContextMenuItem>
                         <ContextMenuItem variant="destructive">
-                            <Trash2 className="oui:mr-2 oui:h-4 oui:w-4" />
+                            <Trash2Icon className="oui:mr-2 oui:h-4 oui:w-4" />
                             Delete
                         </ContextMenuItem>
                     </ContextMenuContent>
@@ -622,17 +622,17 @@ export const Showcase: Story = {
                     </ContextMenuTrigger>
                     <ContextMenuContent>
                         <ContextMenuItem>
-                            <Edit className="oui:mr-2 oui:h-4 oui:w-4" />
+                            <EditIcon className="oui:mr-2 oui:h-4 oui:w-4" />
                             Edit
                         </ContextMenuItem>
                         <ContextMenuSeparator />
                         <ContextMenuItem>
-                            <Share className="oui:mr-2 oui:h-4 oui:w-4" />
+                            <ShareIcon className="oui:mr-2 oui:h-4 oui:w-4" />
                             Share
                         </ContextMenuItem>
                         <ContextMenuSeparator />
                         <ContextMenuItem variant="destructive">
-                            <Trash2 className="oui:mr-2 oui:h-4 oui:w-4" />
+                            <Trash2Icon className="oui:mr-2 oui:h-4 oui:w-4" />
                             Delete
                         </ContextMenuItem>
                     </ContextMenuContent>
@@ -646,15 +646,15 @@ export const Showcase: Story = {
                     </ContextMenuTrigger>
                     <ContextMenuContent>
                         <ContextMenuCheckboxItem checked>
-                            <Eye className="oui:mr-2 oui:h-4 oui:w-4" />
+                            <EyeIcon className="oui:mr-2 oui:h-4 oui:w-4" />
                             Show Preview
                         </ContextMenuCheckboxItem>
                         <ContextMenuCheckboxItem>
-                            <Grid3X3 className="oui:mr-2 oui:h-4 oui:w-4" />
+                            <Grid3X3Icon className="oui:mr-2 oui:h-4 oui:w-4" />
                             Grid View
                         </ContextMenuCheckboxItem>
                         <ContextMenuCheckboxItem checked>
-                            <List className="oui:mr-2 oui:h-4 oui:w-4" />
+                            <ListIcon className="oui:mr-2 oui:h-4 oui:w-4" />
                             List View
                         </ContextMenuCheckboxItem>
                     </ContextMenuContent>
@@ -668,27 +668,27 @@ export const Showcase: Story = {
                     </ContextMenuTrigger>
                     <ContextMenuContent>
                         <ContextMenuItem>
-                            <Edit className="oui:mr-2 oui:h-4 oui:w-4" />
+                            <EditIcon className="oui:mr-2 oui:h-4 oui:w-4" />
                             Edit
                         </ContextMenuItem>
                         <ContextMenuSub>
                             <ContextMenuSubTrigger>
-                                <Share className="oui:mr-2 oui:h-4 oui:w-4" />
+                                <ShareIcon className="oui:mr-2 oui:h-4 oui:w-4" />
                                 Share
                             </ContextMenuSubTrigger>
                             <ContextMenuSubContent>
                                 <ContextMenuItem>
-                                    <Mail className="oui:mr-2 oui:h-4 oui:w-4" />
+                                    <MailIcon className="oui:mr-2 oui:h-4 oui:w-4" />
                                     Email
                                 </ContextMenuItem>
                                 <ContextMenuItem>
-                                    <Copy className="oui:mr-2 oui:h-4 oui:w-4" />
+                                    <CopyIcon className="oui:mr-2 oui:h-4 oui:w-4" />
                                     Copy Link
                                 </ContextMenuItem>
                             </ContextMenuSubContent>
                         </ContextMenuSub>
                         <ContextMenuItem variant="destructive">
-                            <Trash2 className="oui:mr-2 oui:h-4 oui:w-4" />
+                            <Trash2Icon className="oui:mr-2 oui:h-4 oui:w-4" />
                             Delete
                         </ContextMenuItem>
                     </ContextMenuContent>

--- a/stories/Drawer.stories.tsx
+++ b/stories/Drawer.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react';
 import { useState } from 'react';
-import { Minus, Plus } from 'lucide-react';
+import { MinusIcon, PlusIcon } from '@/components';
 import {
   Drawer,
   DrawerClose,
@@ -105,7 +105,7 @@ export const WithCounter: Story = {
                   onClick={() => onClick(-10)}
                   disabled={goal <= 200}
                 >
-                  <Minus className="oui:h-4 oui:w-4" />
+                  <MinusIcon className="oui:h-4 oui:w-4" />
                   <span className="oui:sr-only">Decrease</span>
                 </Button>
                 <div className="oui:flex-1 oui:text-center">
@@ -123,7 +123,7 @@ export const WithCounter: Story = {
                   onClick={() => onClick(10)}
                   disabled={goal >= 400}
                 >
-                  <Plus className="oui:h-4 oui:w-4" />
+                  <PlusIcon className="oui:h-4 oui:w-4" />
                   <span className="oui:sr-only">Increase</span>
                 </Button>
               </div>

--- a/stories/DropdownMenu.stories.tsx
+++ b/stories/DropdownMenu.stories.tsx
@@ -1,21 +1,21 @@
 import type { Meta, StoryObj } from '@storybook/react';
 import { useState } from 'react';
 import {
-  Cloud,
-  CreditCard,
-  Github,
-  Keyboard,
-  LifeBuoy,
-  LogOut,
-  Mail,
-  MessageSquare,
-  Plus,
-  PlusCircle,
-  Settings,
-  User,
-  UserPlus,
-  Users,
-} from 'lucide-react';
+  CloudIcon,
+  CreditCardIcon,
+  GithubIcon,
+  KeyboardIcon,
+  LifeBuoyIcon,
+  LogOutIcon,
+  MailIcon,
+  MessageSquareIcon,
+  PlusIcon,
+  PlusCircleIcon,
+  SettingsIcon,
+  UserIcon,
+  UserPlusIcon,
+  UsersIcon,
+} from '@/components';
 import {
   DropdownMenu,
   DropdownMenuCheckboxItem,
@@ -73,22 +73,22 @@ export const Default: Story = {
         <DropdownMenuSeparator />
         <DropdownMenuGroup>
           <DropdownMenuItem>
-            <User className="oui:mr-2 oui:h-4 oui:w-4" />
+            <UserIcon className="oui:mr-2 oui:h-4 oui:w-4" />
             <span>Profile</span>
             <DropdownMenuShortcut>⇧⌘P</DropdownMenuShortcut>
           </DropdownMenuItem>
           <DropdownMenuItem>
-            <CreditCard className="oui:mr-2 oui:h-4 oui:w-4" />
+            <CreditCardIcon className="oui:mr-2 oui:h-4 oui:w-4" />
             <span>Billing</span>
             <DropdownMenuShortcut>⌘B</DropdownMenuShortcut>
           </DropdownMenuItem>
           <DropdownMenuItem>
-            <Settings className="oui:mr-2 oui:h-4 oui:w-4" />
+            <SettingsIcon className="oui:mr-2 oui:h-4 oui:w-4" />
             <span>Settings</span>
             <DropdownMenuShortcut>⌘S</DropdownMenuShortcut>
           </DropdownMenuItem>
           <DropdownMenuItem>
-            <Keyboard className="oui:mr-2 oui:h-4 oui:w-4" />
+            <KeyboardIcon className="oui:mr-2 oui:h-4 oui:w-4" />
             <span>Keyboard shortcuts</span>
             <DropdownMenuShortcut>⌘K</DropdownMenuShortcut>
           </DropdownMenuItem>
@@ -96,54 +96,54 @@ export const Default: Story = {
         <DropdownMenuSeparator />
         <DropdownMenuGroup>
           <DropdownMenuItem>
-            <Users className="oui:mr-2 oui:h-4 oui:w-4" />
+            <UsersIcon className="oui:mr-2 oui:h-4 oui:w-4" />
             <span>Team</span>
           </DropdownMenuItem>
           <DropdownMenuSub>
             <DropdownMenuSubTrigger>
-              <UserPlus className="oui:mr-2 oui:h-4 oui:w-4" />
+              <UserPlusIcon className="oui:mr-2 oui:h-4 oui:w-4" />
               <span>Invite users</span>
             </DropdownMenuSubTrigger>
             <DropdownMenuPortal>
               <DropdownMenuSubContent>
                 <DropdownMenuItem>
-                  <Mail className="oui:mr-2 oui:h-4 oui:w-4" />
+                  <MailIcon className="oui:mr-2 oui:h-4 oui:w-4" />
                   <span>Email</span>
                 </DropdownMenuItem>
                 <DropdownMenuItem>
-                  <MessageSquare className="oui:mr-2 oui:h-4 oui:w-4" />
+                  <MessageSquareIcon className="oui:mr-2 oui:h-4 oui:w-4" />
                   <span>Message</span>
                 </DropdownMenuItem>
                 <DropdownMenuSeparator />
                 <DropdownMenuItem>
-                  <PlusCircle className="oui:mr-2 oui:h-4 oui:w-4" />
+                  <PlusCircleIcon className="oui:mr-2 oui:h-4 oui:w-4" />
                   <span>More...</span>
                 </DropdownMenuItem>
               </DropdownMenuSubContent>
             </DropdownMenuPortal>
           </DropdownMenuSub>
           <DropdownMenuItem>
-            <Plus className="oui:mr-2 oui:h-4 oui:w-4" />
+            <PlusIcon className="oui:mr-2 oui:h-4 oui:w-4" />
             <span>New Team</span>
             <DropdownMenuShortcut>⌘+T</DropdownMenuShortcut>
           </DropdownMenuItem>
         </DropdownMenuGroup>
         <DropdownMenuSeparator />
         <DropdownMenuItem>
-          <Github className="oui:mr-2 oui:h-4 oui:w-4" />
+          <GithubIcon className="oui:mr-2 oui:h-4 oui:w-4" />
           <span>GitHub</span>
         </DropdownMenuItem>
         <DropdownMenuItem>
-          <LifeBuoy className="oui:mr-2 oui:h-4 oui:w-4" />
+          <LifeBuoyIcon className="oui:mr-2 oui:h-4 oui:w-4" />
           <span>Support</span>
         </DropdownMenuItem>
         <DropdownMenuItem disabled>
-          <Cloud className="oui:mr-2 oui:h-4 oui:w-4" />
+          <CloudIcon className="oui:mr-2 oui:h-4 oui:w-4" />
           <span>API</span>
         </DropdownMenuItem>
         <DropdownMenuSeparator />
         <DropdownMenuItem>
-          <LogOut className="oui:mr-2 oui:h-4 oui:w-4" />
+          <LogOutIcon className="oui:mr-2 oui:h-4 oui:w-4" />
           <span>Log out</span>
           <DropdownMenuShortcut>⇧⌘Q</DropdownMenuShortcut>
         </DropdownMenuItem>
@@ -299,11 +299,11 @@ export const Destructive: Story = {
         <DropdownMenuLabel>Actions</DropdownMenuLabel>
         <DropdownMenuSeparator />
         <DropdownMenuItem>
-          <Settings className="oui:mr-2 oui:h-4 oui:w-4" />
+          <SettingsIcon className="oui:mr-2 oui:h-4 oui:w-4" />
           <span>Edit</span>
         </DropdownMenuItem>
         <DropdownMenuItem>
-          <User className="oui:mr-2 oui:h-4 oui:w-4" />
+          <UserIcon className="oui:mr-2 oui:h-4 oui:w-4" />
           <span>Duplicate</span>
         </DropdownMenuItem>
         <DropdownMenuSeparator />
@@ -347,16 +347,16 @@ export const Showcase: Story = {
             </DropdownMenuTrigger>
             <DropdownMenuContent className="oui:w-56">
               <DropdownMenuItem>
-                <User className="oui:mr-2 oui:h-4 oui:w-4" />
+                <UserIcon className="oui:mr-2 oui:h-4 oui:w-4" />
                 <span>Profile</span>
               </DropdownMenuItem>
               <DropdownMenuItem>
-                <Settings className="oui:mr-2 oui:h-4 oui:w-4" />
+                <SettingsIcon className="oui:mr-2 oui:h-4 oui:w-4" />
                 <span>Settings</span>
               </DropdownMenuItem>
               <DropdownMenuSeparator />
               <DropdownMenuItem>
-                <LogOut className="oui:mr-2 oui:h-4 oui:w-4" />
+                <LogOutIcon className="oui:mr-2 oui:h-4 oui:w-4" />
                 <span>Logout</span>
               </DropdownMenuItem>
             </DropdownMenuContent>

--- a/stories/HoverCard.stories.tsx
+++ b/stories/HoverCard.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react';
-import { CalendarDays } from 'lucide-react';
+import { CalendarDaysIcon } from '@/components';
 import {
   HoverCard,
   HoverCardContent,
@@ -54,7 +54,7 @@ export const Default: Story = {
               The React Framework – created and maintained by @vercel.
             </p>
             <div className="oui:flex oui:items-center oui:pt-2">
-              <CalendarDays className="oui:mr-2 oui:h-4 oui:w-4 oui:opacity-70" />{' '}
+              <CalendarDaysIcon className="oui:mr-2 oui:h-4 oui:w-4 oui:opacity-70" />{' '}
               <span className="oui:text-xs oui:text-muted-foreground">
                 Joined December 2021
               </span>
@@ -93,7 +93,7 @@ export const UserProfile: Story = {
                     Senior Frontend Developer at Acme Corp. Passionate about React and TypeScript.
                   </p>
                   <div className="oui:flex oui:items-center oui:pt-2">
-                    <CalendarDays className="oui:mr-2 oui:h-4 oui:w-4 oui:opacity-70" />
+                    <CalendarDaysIcon className="oui:mr-2 oui:h-4 oui:w-4 oui:opacity-70" />
                     <span className="oui:text-xs oui:text-muted-foreground">
                       Joined March 2020
                     </span>
@@ -125,7 +125,7 @@ export const UserProfile: Story = {
                     UX Designer with 8+ years of experience. Loves creating intuitive user experiences.
                   </p>
                   <div className="oui:flex oui:items-center oui:pt-2">
-                    <CalendarDays className="oui:mr-2 oui:h-4 oui:w-4 oui:opacity-70" />
+                    <CalendarDaysIcon className="oui:mr-2 oui:h-4 oui:w-4 oui:opacity-70" />
                     <span className="oui:text-xs oui:text-muted-foreground">
                       Joined January 2019
                     </span>
@@ -248,7 +248,7 @@ export const Showcase: Story = {
                       The React Framework – created and maintained by @vercel.
                     </p>
                     <div className="oui:flex oui:items-center oui:pt-2">
-                      <CalendarDays className="oui:mr-2 oui:h-4 oui:w-4 oui:opacity-70" />
+                      <CalendarDaysIcon className="oui:mr-2 oui:h-4 oui:w-4 oui:opacity-70" />
                       <span className="oui:text-xs oui:text-muted-foreground">
                         Joined December 2021
                       </span>

--- a/stories/Icons.stories.tsx
+++ b/stories/Icons.stories.tsx
@@ -1,0 +1,352 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import * as LucideIcons from '@/components/custom/icons/lucide';
+import * as OUICustomIcons from '@/components/custom/icons/custom';
+// Direct imports for usage examples
+import {
+  SearchIcon,
+  HeartIcon,
+  StarIcon,
+  CheckCircleIcon,
+  AlertTriangleIcon,
+  CircleIcon,
+  DiscoverIcon
+} from '@/components/custom/icons';
+
+const meta: Meta = {
+  title: 'UI/Icons',
+  parameters: {
+    layout: 'centered',
+    docs: {
+      description: {
+        component: 'Icon system with Lucide React icons and custom OUI icons. All icons follow consistent naming and API patterns.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+// Helper component to display icon grids
+const IconGrid = ({ icons, title }: { icons: Array<{ name: string; component: React.ComponentType<any> }>; title: string }) => (
+  <div className="oui:mb-8">
+    <h3 className="oui:text-lg oui:font-semibold oui:mb-4 oui:text-gray-900">{title}</h3>
+    <div className="oui:grid oui:grid-cols-6 sm:oui:grid-cols-8 md:oui:grid-cols-10 lg:oui:grid-cols-12 oui:gap-4">
+      {icons.map(({ name, component: IconComponent }) => (
+        <div key={name} className="oui:flex oui:flex-col oui:items-center oui:p-3 oui:rounded-lg oui:border oui:bg-white hover:oui:bg-gray-50 oui:transition-colors">
+          <IconComponent className="oui:w-6 oui:h-6 oui:text-gray-700 oui:mb-2" />
+          <span className="oui:text-xs oui:text-center oui:text-gray-600 oui:leading-tight">
+            {name.replace('Icon', '')}
+          </span>
+        </div>
+      ))}
+    </div>
+  </div>
+);
+
+// Organize lucide icons by category
+const lucideIconsByCategory = {
+  'Status & Feedback': [
+    { name: 'AlertCircleIcon', component: LucideIcons.AlertCircleIcon },
+    { name: 'CheckCircleIcon', component: LucideIcons.CheckCircleIcon },
+    { name: 'InfoIcon', component: LucideIcons.InfoIcon },
+    { name: 'XCircleIcon', component: LucideIcons.XCircleIcon },
+    { name: 'AlertTriangleIcon', component: LucideIcons.AlertTriangleIcon },
+    { name: 'HelpCircleIcon', component: LucideIcons.HelpCircleIcon },
+    { name: 'CircleCheckIcon', component: LucideIcons.CircleCheckIcon },
+    { name: 'CircleXIcon', component: LucideIcons.CircleXIcon },
+    { name: 'CircleAlertIcon', component: LucideIcons.CircleAlertIcon },
+    { name: 'BadgeIcon', component: LucideIcons.BadgeIcon },
+    { name: 'BadgeCheckIcon', component: LucideIcons.BadgeCheckIcon },
+  ],
+  'Navigation & Arrows': [
+    { name: 'ArrowLeftIcon', component: LucideIcons.ArrowLeftIcon },
+    { name: 'ArrowRightIcon', component: LucideIcons.ArrowRightIcon },
+    { name: 'ArrowUpIcon', component: LucideIcons.ArrowUpIcon },
+    { name: 'ArrowDownIcon', component: LucideIcons.ArrowDownIcon },
+    { name: 'ChevronLeftIcon', component: LucideIcons.ChevronLeftIcon },
+    { name: 'ChevronRightIcon', component: LucideIcons.ChevronRightIcon },
+    { name: 'ChevronDownIcon', component: LucideIcons.ChevronDownIcon },
+    { name: 'ChevronUpIcon', component: LucideIcons.ChevronUpIcon },
+    { name: 'ChevronsUpIcon', component: LucideIcons.ChevronsUpIcon },
+    { name: 'ChevronsDownIcon', component: LucideIcons.ChevronsDownIcon },
+    { name: 'ChevronsLeftIcon', component: LucideIcons.ChevronsLeftIcon },
+    { name: 'ChevronsRightIcon', component: LucideIcons.ChevronsRightIcon },
+    { name: 'ArrowUpRightIcon', component: LucideIcons.ArrowUpRightIcon },
+    { name: 'ArrowDownLeftIcon', component: LucideIcons.ArrowDownLeftIcon },
+    { name: 'ArrowUpLeftIcon', component: LucideIcons.ArrowUpLeftIcon },
+    { name: 'ArrowDownRightIcon', component: LucideIcons.ArrowDownRightIcon },
+  ],
+  'Actions & Controls': [
+    { name: 'PlusIcon', component: LucideIcons.PlusIcon },
+    { name: 'MinusIcon', component: LucideIcons.MinusIcon },
+    { name: 'PlusCircleIcon', component: LucideIcons.PlusCircleIcon },
+    { name: 'MinusCircleIcon', component: LucideIcons.MinusCircleIcon },
+    { name: 'PlayIcon', component: LucideIcons.PlayIcon },
+    { name: 'PlayCircleIcon', component: LucideIcons.PlayCircleIcon },
+    { name: 'PauseIcon', component: LucideIcons.PauseIcon },
+    { name: 'PauseCircleIcon', component: LucideIcons.PauseCircleIcon },
+    { name: 'StopCircleIcon', component: LucideIcons.StopCircleIcon },
+    { name: 'SkipBackIcon', component: LucideIcons.SkipBackIcon },
+    { name: 'SkipForwardIcon', component: LucideIcons.SkipForwardIcon },
+    { name: 'RefreshCwIcon', component: LucideIcons.RefreshCwIcon },
+    { name: 'RefreshCcwIcon', component: LucideIcons.RefreshCcwIcon },
+  ],
+  'UI Elements': [
+    { name: 'UserIcon', component: LucideIcons.UserIcon },
+    { name: 'UsersIcon', component: LucideIcons.UsersIcon },
+    { name: 'SearchIcon', component: LucideIcons.SearchIcon },
+    { name: 'SettingsIcon', component: LucideIcons.SettingsIcon },
+    { name: 'MenuIcon', component: LucideIcons.MenuIcon },
+    { name: 'MoreHorizontalIcon', component: LucideIcons.MoreHorizontalIcon },
+    { name: 'MoreVerticalIcon', component: LucideIcons.MoreVerticalIcon },
+    { name: 'XIcon', component: LucideIcons.XIcon },
+    { name: 'CheckIcon', component: LucideIcons.CheckIcon },
+    { name: 'FilterIcon', component: LucideIcons.FilterIcon },
+    { name: 'SortAscIcon', component: LucideIcons.SortAscIcon },
+    { name: 'SortDescIcon', component: LucideIcons.SortDescIcon },
+  ],
+  'Files & Folders': [
+    { name: 'FileIcon', component: LucideIcons.FileIcon },
+    { name: 'FilesIcon', component: LucideIcons.FilesIcon },
+    { name: 'FolderIcon', component: LucideIcons.FolderIcon },
+    { name: 'FolderOpenIcon', component: LucideIcons.FolderOpenIcon },
+    { name: 'FileTextIcon', component: LucideIcons.FileTextIcon },
+    { name: 'FileImageIcon', component: LucideIcons.FileImageIcon },
+    { name: 'FileVideoIcon', component: LucideIcons.FileVideoIcon },
+    { name: 'FileAudioIcon', component: LucideIcons.FileAudioIcon },
+    { name: 'FolderPlusIcon', component: LucideIcons.FolderPlusIcon },
+    { name: 'DownloadIcon', component: LucideIcons.DownloadIcon },
+    { name: 'UploadIcon', component: LucideIcons.UploadIcon },
+    { name: 'SaveIcon', component: LucideIcons.SaveIcon },
+    { name: 'CopyIcon', component: LucideIcons.CopyIcon },
+  ],
+  'Communication': [
+    { name: 'MailIcon', component: LucideIcons.MailIcon },
+    { name: 'PhoneIcon', component: LucideIcons.PhoneIcon },
+    { name: 'MessageCircleIcon', component: LucideIcons.MessageCircleIcon },
+    { name: 'MessageSquareIcon', component: LucideIcons.MessageSquareIcon },
+    { name: 'SendIcon', component: LucideIcons.SendIcon },
+    { name: 'InboxIcon', component: LucideIcons.InboxIcon },
+  ],
+  'Time & Calendar': [
+    { name: 'CalendarIcon', component: LucideIcons.CalendarIcon },
+    { name: 'ClockIcon', component: LucideIcons.ClockIcon },
+    { name: 'HistoryIcon', component: LucideIcons.HistoryIcon },
+    { name: 'TimerIcon', component: LucideIcons.TimerIcon },
+  ],
+  'Visibility & Editing': [
+    { name: 'EyeIcon', component: LucideIcons.EyeIcon },
+    { name: 'EyeOffIcon', component: LucideIcons.EyeOffIcon },
+    { name: 'EditIcon', component: LucideIcons.EditIcon },
+    { name: 'PenIcon', component: LucideIcons.PenIcon },
+    { name: 'TrashIcon', component: LucideIcons.TrashIcon },
+    { name: 'Trash2Icon', component: LucideIcons.Trash2Icon },
+  ],
+  'Favorites & Ratings': [
+    { name: 'StarIcon', component: LucideIcons.StarIcon },
+    { name: 'HeartIcon', component: LucideIcons.HeartIcon },
+    { name: 'BookmarkIcon', component: LucideIcons.BookmarkIcon },
+    { name: 'ThumbsUpIcon', component: LucideIcons.ThumbsUpIcon },
+    { name: 'ThumbsDownIcon', component: LucideIcons.ThumbsDownIcon },
+  ],
+  'Tech & Devices': [
+    { name: 'ZapIcon', component: LucideIcons.ZapIcon },
+    { name: 'WifiIcon', component: LucideIcons.WifiIcon },
+    { name: 'SmartphoneIcon', component: LucideIcons.SmartphoneIcon },
+    { name: 'TabletIcon', component: LucideIcons.TabletIcon },
+    { name: 'LaptopIcon', component: LucideIcons.LaptopIcon },
+    { name: 'MonitorIcon', component: LucideIcons.MonitorIcon },
+    { name: 'CameraIcon', component: LucideIcons.CameraIcon },
+    { name: 'VideoIcon', component: LucideIcons.VideoIcon },
+    { name: 'MicIcon', component: LucideIcons.MicIcon },
+    { name: 'MicOffIcon', component: LucideIcons.MicOffIcon },
+  ],
+  'Security & Access': [
+    { name: 'ShieldIcon', component: LucideIcons.ShieldIcon },
+    { name: 'LockIcon', component: LucideIcons.LockIcon },
+    { name: 'UnlockIcon', component: LucideIcons.UnlockIcon },
+    { name: 'KeyIcon', component: LucideIcons.KeyIcon },
+    { name: 'UserCheckIcon', component: LucideIcons.UserCheckIcon },
+  ],
+  'Business & Shopping': [
+    { name: 'HomeIcon', component: LucideIcons.HomeIcon },
+    { name: 'BuildingIcon', component: LucideIcons.BuildingIcon },
+    { name: 'CreditCardIcon', component: LucideIcons.CreditCardIcon },
+    { name: 'ShoppingCartIcon', component: LucideIcons.ShoppingCartIcon },
+    { name: 'ShoppingBagIcon', component: LucideIcons.ShoppingBagIcon },
+    { name: 'TagIcon', component: LucideIcons.TagIcon },
+    { name: 'DollarSignIcon', component: LucideIcons.DollarSignIcon },
+  ],
+  'Data & Analytics': [
+    { name: 'ActivityIcon', component: LucideIcons.ActivityIcon },
+    { name: 'TrendingUpIcon', component: LucideIcons.TrendingUpIcon },
+    { name: 'TrendingDownIcon', component: LucideIcons.TrendingDownIcon },
+    { name: 'BarChartIcon', component: LucideIcons.BarChartIcon },
+    { name: 'PieChartIcon', component: LucideIcons.PieChartIcon },
+    { name: 'LineChartIcon', component: LucideIcons.LineChartIcon },
+    { name: 'DatabaseIcon', component: LucideIcons.DatabaseIcon },
+    { name: 'ServerIcon', component: LucideIcons.ServerIcon },
+  ],
+  'Tools & Utilities': [
+    { name: 'SlidersIcon', component: LucideIcons.SlidersIcon },
+    { name: 'ZoomInIcon', component: LucideIcons.ZoomInIcon },
+    { name: 'ZoomOutIcon', component: LucideIcons.ZoomOutIcon },
+    { name: 'MaximizeIcon', component: LucideIcons.MaximizeIcon },
+    { name: 'MinimizeIcon', component: LucideIcons.MinimizeIcon },
+  ],
+  'Links & External': [
+    { name: 'ExternalLinkIcon', component: LucideIcons.ExternalLinkIcon },
+    { name: 'LinkIcon', component: LucideIcons.LinkIcon },
+    { name: 'Link2Icon', component: LucideIcons.Link2Icon },
+    { name: 'UnlinkIcon', component: LucideIcons.UnlinkIcon },
+  ],
+  'Miscellaneous': [
+    { name: 'BellIcon', component: LucideIcons.BellIcon },
+    { name: 'BellOffIcon', component: LucideIcons.BellOffIcon },
+    { name: 'FlagIcon', component: LucideIcons.FlagIcon },
+    { name: 'GlobeIcon', component: LucideIcons.GlobeIcon },
+    { name: 'MapPinIcon', component: LucideIcons.MapPinIcon },
+    { name: 'ImageIcon', component: LucideIcons.ImageIcon },
+    { name: 'TypeIcon', component: LucideIcons.TypeIcon },
+    { name: 'HashIcon', component: LucideIcons.HashIcon },
+    { name: 'CircleIcon', component: LucideIcons.CircleIcon },
+  ],
+};
+
+const customIcons = [
+  { name: 'DiscoverIcon', component: OUICustomIcons.DiscoverIcon },
+];
+
+export const Default: Story = {
+  render: () => (
+    <div className="oui:max-w-7xl oui:mx-auto oui:space-y-12">
+      {/* Header */}
+      <div className="oui:text-center oui:mb-12">
+        <h1 className="oui:text-3xl oui:font-bold oui:text-gray-900 oui:mb-4">Icons</h1>
+        <p className="oui:text-lg oui:text-gray-600 oui:max-w-3xl oui:mx-auto">
+          Complete icon system with curated Lucide React icons and custom OUI icons.
+          All icons follow consistent naming and API patterns, supporting size, color, and stroke width customization.
+        </p>
+      </div>
+
+      {/* Usage Examples */}
+      <div className="oui:space-y-8 oui:mb-16">
+        <h2 className="oui:text-2xl oui:font-semibold oui:text-gray-900 oui:border-b oui:pb-2">Usage Examples</h2>
+
+        {/* Size Examples */}
+        <div>
+          <h3 className="oui:text-lg oui:font-semibold oui:mb-4">Size Examples</h3>
+          <div className="oui:flex oui:gap-6 oui:items-end oui:p-6 oui:bg-gray-50 oui:rounded-lg">
+            <div className="oui:text-center">
+              <SearchIcon size={16} className="oui:mb-2 oui:text-gray-700" />
+              <code className="oui:text-xs oui:bg-white oui:px-2 oui:py-1 oui:rounded oui:text-gray-800 oui:font-mono">
+                &lt;SearchIcon size={16} /&gt;
+              </code>
+            </div>
+            <div className="oui:text-center">
+              <SearchIcon size={24} className="oui:mb-2 oui:text-gray-700" />
+              <code className="oui:text-xs oui:bg-white oui:px-2 oui:py-1 oui:rounded oui:text-gray-800 oui:font-mono">
+                &lt;SearchIcon /&gt;
+              </code>
+            </div>
+            <div className="oui:text-center">
+              <SearchIcon size={32} className="oui:mb-2 oui:text-gray-700" />
+              <code className="oui:text-xs oui:bg-white oui:px-2 oui:py-1 oui:rounded oui:text-gray-800 oui:font-mono">
+                &lt;SearchIcon size={32} /&gt;
+              </code>
+            </div>
+            <div className="oui:text-center">
+              <DiscoverIcon size={48} className="oui:mb-2 oui:text-orange-600" />
+              <code className="oui:text-xs oui:bg-white oui:px-2 oui:py-1 oui:rounded oui:text-gray-800 oui:font-mono">
+                &lt;DiscoverIcon size={48} /&gt;
+              </code>
+            </div>
+          </div>
+        </div>
+
+        {/* Color Examples */}
+        <div>
+          <h3 className="oui:text-lg oui:font-semibold oui:mb-4">Color Examples</h3>
+          <div className="oui:flex oui:gap-6 oui:items-center oui:p-6 oui:bg-gray-50 oui:rounded-lg">
+            <div className="oui:text-center">
+              <HeartIcon className="oui:mb-2 oui:text-red-500" />
+              <code className="oui:text-xs oui:bg-white oui:px-2 oui:py-1 oui:rounded oui:text-gray-800 oui:font-mono">
+                &lt;HeartIcon className="text-red-500" /&gt;
+              </code>
+            </div>
+            <div className="oui:text-center">
+              <StarIcon color="#fbbf24" className="oui:mb-2" />
+              <code className="oui:text-xs oui:bg-white oui:px-2 oui:py-1 oui:rounded oui:text-gray-800 oui:font-mono">
+                &lt;StarIcon color="#fbbf24" /&gt;
+              </code>
+            </div>
+            <div className="oui:text-center">
+              <CheckCircleIcon className="oui:mb-2 oui:text-green-600" />
+              <code className="oui:text-xs oui:bg-white oui:px-2 oui:py-1 oui:rounded oui:text-gray-800 oui:font-mono">
+                &lt;CheckCircleIcon className="text-green-600" /&gt;
+              </code>
+            </div>
+            <div className="oui:text-center">
+              <AlertTriangleIcon className="oui:mb-2 oui:text-yellow-500" />
+              <code className="oui:text-xs oui:bg-white oui:px-2 oui:py-1 oui:rounded oui:text-gray-800 oui:font-mono">
+                &lt;AlertTriangleIcon className="text-yellow-500" /&gt;
+              </code>
+            </div>
+          </div>
+        </div>
+
+        {/* Stroke Width Examples */}
+        <div>
+          <h3 className="oui:text-lg oui:font-semibold oui:mb-4">Stroke Width Examples</h3>
+          <div className="oui:flex oui:gap-6 oui:items-center oui:p-6 oui:bg-gray-50 oui:rounded-lg">
+            <div className="oui:text-center">
+              <CircleIcon strokeWidth={1} className="oui:mb-2 oui:text-gray-700" />
+              <code className="oui:text-xs oui:bg-white oui:px-2 oui:py-1 oui:rounded oui:text-gray-800 oui:font-mono">
+                &lt;CircleIcon strokeWidth={1} /&gt;
+              </code>
+            </div>
+            <div className="oui:text-center">
+              <CircleIcon strokeWidth={2} className="oui:mb-2 oui:text-gray-700" />
+              <code className="oui:text-xs oui:bg-white oui:px-2 oui:py-1 oui:rounded oui:text-gray-800 oui:font-mono">
+                &lt;CircleIcon /&gt;
+              </code>
+            </div>
+            <div className="oui:text-center">
+              <CircleIcon strokeWidth={3} className="oui:mb-2 oui:text-gray-700" />
+              <code className="oui:text-xs oui:bg-white oui:px-2 oui:py-1 oui:rounded oui:text-gray-800 oui:font-mono">
+                &lt;CircleIcon strokeWidth={3} /&gt;
+              </code>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {/* Custom OUI Icons */}
+      <div className="oui:space-y-8">
+        <h2 className="oui:text-2xl oui:font-semibold oui:text-gray-900 oui:border-b oui:pb-2">Custom OUI Icons</h2>
+        <p className="oui:text-gray-600 oui:mb-6">
+          Custom icons created from SVG files. These follow the same API patterns as Lucide icons and are generated at build time.
+        </p>
+        <IconGrid title="Custom Icons" icons={customIcons} />
+      </div>
+
+      {/* Lucide React Icons */}
+      <div className="oui:space-y-8">
+        <h2 className="oui:text-2xl oui:font-semibold oui:text-gray-900 oui:border-b oui:pb-2">Lucide React Icons</h2>
+        <p className="oui:text-gray-600 oui:mb-6">
+          Curated collection of Lucide React icons organized by category. These icons maintain full API compatibility with the lucide-react package.
+        </p>
+        {Object.entries(lucideIconsByCategory).map(([category, icons]) => (
+          <IconGrid key={category} title={category} icons={icons} />
+        ))}
+      </div>
+    </div>
+  ),
+};

--- a/stories/Popover.stories.tsx
+++ b/stories/Popover.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react';
 import { useState } from 'react';
-import { Settings, User, CreditCard, LogOut, Plus } from 'lucide-react';
+import { SettingsIcon, UserIcon, CreditCardIcon, LogOutIcon, PlusIcon } from '@/components';
 import {
   Popover,
   PopoverContent,
@@ -120,21 +120,21 @@ export const UserMenu: Story = {
         <Separator className="oui:my-2" />
         <div className="oui:space-y-1">
           <Button variant="ghost" className="oui:w-full oui:justify-start" size="sm">
-            <User className="oui:mr-2 oui:h-4 oui:w-4" />
+            <UserIcon className="oui:mr-2 oui:h-4 oui:w-4" />
             Profile
           </Button>
           <Button variant="ghost" className="oui:w-full oui:justify-start" size="sm">
-            <CreditCard className="oui:mr-2 oui:h-4 oui:w-4" />
+            <CreditCardIcon className="oui:mr-2 oui:h-4 oui:w-4" />
             Billing
           </Button>
           <Button variant="ghost" className="oui:w-full oui:justify-start" size="sm">
-            <Settings className="oui:mr-2 oui:h-4 oui:w-4" />
+            <SettingsIcon className="oui:mr-2 oui:h-4 oui:w-4" />
             Settings
           </Button>
         </div>
         <Separator className="oui:my-2" />
         <Button variant="ghost" className="oui:w-full oui:justify-start" size="sm">
-          <LogOut className="oui:mr-2 oui:h-4 oui:w-4" />
+          <LogOutIcon className="oui:mr-2 oui:h-4 oui:w-4" />
           Log out
         </Button>
       </PopoverContent>
@@ -248,7 +248,7 @@ export const AddItem: Story = {
         <Popover open={open} onOpenChange={setOpen} {...args}>
           <PopoverTrigger asChild>
             <Button variant="outline" size="sm">
-              <Plus className="oui:mr-2 oui:h-4 oui:w-4" />
+              <PlusIcon className="oui:mr-2 oui:h-4 oui:w-4" />
               Add Item
             </Button>
           </PopoverTrigger>
@@ -354,16 +354,16 @@ export const Showcase: Story = {
             <PopoverContent className="oui:w-56">
               <div className="oui:space-y-1">
                 <Button variant="ghost" className="oui:w-full oui:justify-start" size="sm">
-                  <User className="oui:mr-2 oui:h-4 oui:w-4" />
+                  <UserIcon className="oui:mr-2 oui:h-4 oui:w-4" />
                   Profile
                 </Button>
                 <Button variant="ghost" className="oui:w-full oui:justify-start" size="sm">
-                  <Settings className="oui:mr-2 oui:h-4 oui:w-4" />
+                  <SettingsIcon className="oui:mr-2 oui:h-4 oui:w-4" />
                   Settings
                 </Button>
                 <Separator className="oui:my-1" />
                 <Button variant="ghost" className="oui:w-full oui:justify-start" size="sm">
-                  <LogOut className="oui:mr-2 oui:h-4 oui:w-4" />
+                  <LogOutIcon className="oui:mr-2 oui:h-4 oui:w-4" />
                   Log out
                 </Button>
               </div>

--- a/stories/Select.stories.tsx
+++ b/stories/Select.stories.tsx
@@ -9,7 +9,7 @@ import {
   SelectLabel,
   SelectSeparator,
 } from '@/components';
-import { LineChart, BarChart3, PieChart } from 'lucide-react';
+import { LineChartIcon, BarChart3Icon, PieChartIcon } from '@/components';
 
 const meta: Meta<typeof Select> = {
   title: 'UI/Select',
@@ -121,19 +121,19 @@ export const WithIcon: Story = {
       <SelectContent>
         <SelectItem value="line">
           <div className="oui:flex oui:items-center oui:gap-2">
-            <LineChart className="oui:size-3 oui:text-muted-foreground" />
+            <LineChartIcon className="oui:size-3 oui:text-muted-foreground" />
             Line
           </div>
         </SelectItem>
         <SelectItem value="bar">
           <div className="oui:flex oui:items-center oui:gap-2">
-            <BarChart3 className="oui:size-3 oui:text-muted-foreground" />
+            <BarChart3Icon className="oui:size-3 oui:text-muted-foreground" />
             Bar
           </div>
         </SelectItem>
         <SelectItem value="pie">
           <div className="oui:flex oui:items-center oui:gap-2">
-            <PieChart className="oui:size-3 oui:text-muted-foreground" />
+            <PieChartIcon className="oui:size-3 oui:text-muted-foreground" />
             Pie
           </div>
         </SelectItem>
@@ -152,19 +152,19 @@ export const WithIconSelected: Story = {
       <SelectContent>
         <SelectItem value="line">
           <div className="oui:flex oui:items-center oui:gap-2">
-            <LineChart className="oui:size-3 oui:text-muted-foreground" />
+            <LineChartIcon className="oui:size-3 oui:text-muted-foreground" />
             Line
           </div>
         </SelectItem>
         <SelectItem value="bar">
           <div className="oui:flex oui:items-center oui:gap-2">
-            <BarChart3 className="oui:size-3 oui:text-muted-foreground" />
+            <BarChart3Icon className="oui:size-3 oui:text-muted-foreground" />
             Bar
           </div>
         </SelectItem>
         <SelectItem value="pie">
           <div className="oui:flex oui:items-center oui:gap-2">
-            <PieChart className="oui:size-3 oui:text-muted-foreground" />
+            <PieChartIcon className="oui:size-3 oui:text-muted-foreground" />
             Pie
           </div>
         </SelectItem>

--- a/stories/Sheet.stories.tsx
+++ b/stories/Sheet.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react';
 import { useState } from 'react';
-import { Menu, Settings, User, Bell, Search } from 'lucide-react';
+import { MenuIcon, SettingsIcon, UserIcon, BellIcon, SearchIcon } from '@/components';
 import {
   Sheet,
   SheetClose,
@@ -86,7 +86,7 @@ export const FromLeft: Story = {
     <Sheet {...args}>
       <SheetTrigger asChild>
         <Button variant="outline">
-          <Menu className="oui:mr-2 oui:h-4 oui:w-4" />
+          <MenuIcon className="oui:mr-2 oui:h-4 oui:w-4" />
           Menu
         </Button>
       </SheetTrigger>
@@ -100,15 +100,15 @@ export const FromLeft: Story = {
         <div className="oui:py-4">
           <nav className="oui:space-y-2">
             <Button variant="ghost" className="oui:w-full oui:justify-start">
-              <User className="oui:mr-2 oui:h-4 oui:w-4" />
+              <UserIcon className="oui:mr-2 oui:h-4 oui:w-4" />
               Profile
             </Button>
             <Button variant="ghost" className="oui:w-full oui:justify-start">
-              <Settings className="oui:mr-2 oui:h-4 oui:w-4" />
+              <SettingsIcon className="oui:mr-2 oui:h-4 oui:w-4" />
               Settings
             </Button>
             <Button variant="ghost" className="oui:w-full oui:justify-start">
-              <Bell className="oui:mr-2 oui:h-4 oui:w-4" />
+              <BellIcon className="oui:mr-2 oui:h-4 oui:w-4" />
               Notifications
             </Button>
             <Separator className="oui:my-2" />
@@ -137,7 +137,7 @@ export const FromTop: Story = {
     <Sheet {...args}>
       <SheetTrigger asChild>
         <Button variant="outline">
-          <Search className="oui:mr-2 oui:h-4 oui:w-4" />
+          <SearchIcon className="oui:mr-2 oui:h-4 oui:w-4" />
           Search
         </Button>
       </SheetTrigger>
@@ -187,7 +187,7 @@ export const FromBottom: Story = {
     <Sheet {...args}>
       <SheetTrigger asChild>
         <Button variant="outline">
-          <Settings className="oui:mr-2 oui:h-4 oui:w-4" />
+          <SettingsIcon className="oui:mr-2 oui:h-4 oui:w-4" />
           Quick Settings
         </Button>
       </SheetTrigger>

--- a/stories/Table.stories.tsx
+++ b/stories/Table.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react';
 import { useState } from 'react';
-import { MoreHorizontal, ArrowUpDown } from 'lucide-react';
+import { MoreHorizontalIcon, ArrowUpDownIcon } from '@/components';
 import {
   Table,
   TableBody,
@@ -252,7 +252,7 @@ export const WithActions: Story = {
                     <DropdownMenuTrigger asChild>
                       <Button variant="ghost" className="oui:h-8 oui:w-8 oui:p-0">
                         <span className="oui:sr-only">Open menu</span>
-                        <MoreHorizontal className="oui:h-4 oui:w-4" />
+                        <MoreHorizontalIcon className="oui:h-4 oui:w-4" />
                       </Button>
                     </DropdownMenuTrigger>
                     <DropdownMenuContent align="end">
@@ -314,7 +314,7 @@ export const Sortable: Story = {
         className="oui:h-auto oui:p-0 oui:font-medium oui:hover:bg-transparent"
       >
         {children}
-        <ArrowUpDown className="oui:ml-2 oui:h-4 oui:w-4" />
+        <ArrowUpDownIcon className="oui:ml-2 oui:h-4 oui:w-4" />
       </Button>
     );
 

--- a/stories/Toggle.stories.tsx
+++ b/stories/Toggle.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react';
 import { useState } from 'react';
-import { Bold, Italic, Underline, AlignLeft, AlignCenter, AlignRight } from 'lucide-react';
+import { BoldIcon, ItalicIcon, UnderlineIcon, AlignLeftIcon, AlignCenterIcon, AlignRightIcon } from '@/components';
 import { Toggle } from '@/components';
 
 
@@ -56,7 +56,7 @@ export const Default: Story = {
         aria-label="Toggle bold"
         {...args}
       >
-        <Bold className="oui:h-4 oui:w-4" />
+        <BoldIcon className="oui:h-4 oui:w-4" />
       </Toggle>
     );
   },
@@ -73,8 +73,8 @@ export const WithText: Story = {
         aria-label="Toggle bold"
         {...args}
       >
-        <Bold className="oui:h-4 oui:w-4" />
-        Bold
+        <BoldIcon className="oui:h-4 oui:w-4" />
+        BoldIcon
       </Toggle>
     );
   },
@@ -101,7 +101,7 @@ export const Outline: Story = {
         aria-label="Toggle italic"
         {...args}
       >
-        <Italic className="oui:h-4 oui:w-4" />
+        <ItalicIcon className="oui:h-4 oui:w-4" />
       </Toggle>
     );
   },
@@ -129,7 +129,7 @@ export const Sizes: Story = {
           aria-label="Small toggle"
           {...args}
         >
-          <Bold className="oui:h-3 oui:w-3" />
+          <BoldIcon className="oui:h-3 oui:w-3" />
         </Toggle>
         <Toggle
           size="default"
@@ -138,7 +138,7 @@ export const Sizes: Story = {
           aria-label="Default toggle"
           {...args}
         >
-          <Bold className="oui:h-4 oui:w-4" />
+          <BoldIcon className="oui:h-4 oui:w-4" />
         </Toggle>
         <Toggle
           size="lg"
@@ -147,7 +147,7 @@ export const Sizes: Story = {
           aria-label="Large toggle"
           {...args}
         >
-          <Bold className="oui:h-5 oui:w-5" />
+          <BoldIcon className="oui:h-5 oui:w-5" />
         </Toggle>
       </div>
     );
@@ -163,35 +163,35 @@ export const Sizes: Story = {
 
 export const TextFormatting: Story = {
   render: (args) => {
-    const [bold, setBold] = useState(false);
-    const [italic, setItalic] = useState(false);
-    const [underline, setUnderline] = useState(false);
+    const [bold, setBoldIcon] = useState(false);
+    const [italic, setItalicIcon] = useState(false);
+    const [underline, setUnderlineIcon] = useState(false);
 
     return (
       <div className="oui:flex oui:items-center oui:space-x-1">
         <Toggle
           pressed={bold}
-          onPressedChange={setBold}
+          onPressedChange={setBoldIcon}
           aria-label="Toggle bold"
           {...args}
         >
-          <Bold className="oui:h-4 oui:w-4" />
+          <BoldIcon className="oui:h-4 oui:w-4" />
         </Toggle>
         <Toggle
           pressed={italic}
-          onPressedChange={setItalic}
+          onPressedChange={setItalicIcon}
           aria-label="Toggle italic"
           {...args}
         >
-          <Italic className="oui:h-4 oui:w-4" />
+          <ItalicIcon className="oui:h-4 oui:w-4" />
         </Toggle>
         <Toggle
           pressed={underline}
-          onPressedChange={setUnderline}
+          onPressedChange={setUnderlineIcon}
           aria-label="Toggle underline"
           {...args}
         >
-          <Underline className="oui:h-4 oui:w-4" />
+          <UnderlineIcon className="oui:h-4 oui:w-4" />
         </Toggle>
       </div>
     );
@@ -217,7 +217,7 @@ export const TextAlignment: Story = {
           aria-label="Align left"
           {...args}
         >
-          <AlignLeft className="oui:h-4 oui:w-4" />
+          <AlignLeftIcon className="oui:h-4 oui:w-4" />
         </Toggle>
         <Toggle
           pressed={alignment === 'center'}
@@ -225,7 +225,7 @@ export const TextAlignment: Story = {
           aria-label="Align center"
           {...args}
         >
-          <AlignCenter className="oui:h-4 oui:w-4" />
+          <AlignCenterIcon className="oui:h-4 oui:w-4" />
         </Toggle>
         <Toggle
           pressed={alignment === 'right'}
@@ -233,7 +233,7 @@ export const TextAlignment: Story = {
           aria-label="Align right"
           {...args}
         >
-          <AlignRight className="oui:h-4 oui:w-4" />
+          <AlignRightIcon className="oui:h-4 oui:w-4" />
         </Toggle>
       </div>
     );
@@ -254,7 +254,7 @@ export const Disabled: Story = {
   },
   render: (args) => (
     <Toggle aria-label="Disabled toggle" {...args}>
-      <Bold className="oui:h-4 oui:w-4" />
+      <BoldIcon className="oui:h-4 oui:w-4" />
     </Toggle>
   ),
   parameters: {
@@ -286,14 +286,14 @@ export const Showcase: Story = {
             <div>
               <p className="oui:text-sm oui:font-medium oui:mb-4">Basic Toggles</p>
               <div className="oui:flex oui:items-center oui:space-x-2">
-                <Toggle aria-label="Bold">
-                  <Bold className="oui:h-4 oui:w-4" />
+                <Toggle aria-label="BoldIcon">
+                  <BoldIcon className="oui:h-4 oui:w-4" />
                 </Toggle>
-                <Toggle variant="outline" aria-label="Italic">
-                  <Italic className="oui:h-4 oui:w-4" />
+                <Toggle variant="outline" aria-label="ItalicIcon">
+                  <ItalicIcon className="oui:h-4 oui:w-4" />
                 </Toggle>
-                <Toggle aria-label="Underline">
-                  <Underline className="oui:h-4 oui:w-4" />
+                <Toggle aria-label="UnderlineIcon">
+                  <UnderlineIcon className="oui:h-4 oui:w-4" />
                 </Toggle>
               </div>
             </div>
@@ -304,18 +304,18 @@ export const Showcase: Story = {
                 <Toggle
                   pressed={formatting.bold}
                   onPressedChange={() => toggleFormatting('bold')}
-                  aria-label="Bold"
+                  aria-label="BoldIcon"
                 >
-                  <Bold className="oui:h-4 oui:w-4" />
-                  Bold
+                  <BoldIcon className="oui:h-4 oui:w-4" />
+                  BoldIcon
                 </Toggle>
                 <Toggle
                   pressed={formatting.italic}
                   onPressedChange={() => toggleFormatting('italic')}
-                  aria-label="Italic"
+                  aria-label="ItalicIcon"
                 >
-                  <Italic className="oui:h-4 oui:w-4" />
-                  Italic
+                  <ItalicIcon className="oui:h-4 oui:w-4" />
+                  ItalicIcon
                 </Toggle>
               </div>
             </div>
@@ -324,13 +324,13 @@ export const Showcase: Story = {
               <p className="oui:text-sm oui:font-medium oui:mb-4">Sizes</p>
               <div className="oui:flex oui:items-center oui:space-x-2">
                 <Toggle size="sm" aria-label="Small">
-                  <Bold className="oui:h-3 oui:w-3" />
+                  <BoldIcon className="oui:h-3 oui:w-3" />
                 </Toggle>
                 <Toggle size="default" aria-label="Default">
-                  <Bold className="oui:h-4 oui:w-4" />
+                  <BoldIcon className="oui:h-4 oui:w-4" />
                 </Toggle>
                 <Toggle size="lg" aria-label="Large">
-                  <Bold className="oui:h-5 oui:w-5" />
+                  <BoldIcon className="oui:h-5 oui:w-5" />
                 </Toggle>
               </div>
             </div>

--- a/stories/ToggleGroup.stories.tsx
+++ b/stories/ToggleGroup.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react';
 import { useState } from 'react';
-import { Bold, Italic, Underline, AlignLeft, AlignCenter, AlignRight, List, Grid, Calendar } from 'lucide-react';
+import { BoldIcon, ItalicIcon, UnderlineIcon, AlignLeftIcon, AlignCenterIcon, AlignRightIcon, ListIcon, GridIcon, CalendarIcon } from '@/components';
 import { ToggleGroup, ToggleGroupItem } from '@/components';
 
 
@@ -58,13 +58,13 @@ export const Default: Story = {
         onValueChange={setValue}
       >
         <ToggleGroupItem value="bold" aria-label="Toggle bold">
-          <Bold className="oui:h-4 oui:w-4" />
+          <BoldIcon className="oui:h-4 oui:w-4" />
         </ToggleGroupItem>
         <ToggleGroupItem value="italic" aria-label="Toggle italic">
-          <Italic className="oui:h-4 oui:w-4" />
+          <ItalicIcon className="oui:h-4 oui:w-4" />
         </ToggleGroupItem>
         <ToggleGroupItem value="underline" aria-label="Toggle underline">
-          <Underline className="oui:h-4 oui:w-4" />
+          <UnderlineIcon className="oui:h-4 oui:w-4" />
         </ToggleGroupItem>
       </ToggleGroup>
     );
@@ -83,13 +83,13 @@ export const Multiple: Story = {
         onValueChange={setValue}
       >
         <ToggleGroupItem value="bold" aria-label="Toggle bold">
-          <Bold className="oui:h-4 oui:w-4" />
+          <BoldIcon className="oui:h-4 oui:w-4" />
         </ToggleGroupItem>
         <ToggleGroupItem value="italic" aria-label="Toggle italic">
-          <Italic className="oui:h-4 oui:w-4" />
+          <ItalicIcon className="oui:h-4 oui:w-4" />
         </ToggleGroupItem>
         <ToggleGroupItem value="underline" aria-label="Toggle underline">
-          <Underline className="oui:h-4 oui:w-4" />
+          <UnderlineIcon className="oui:h-4 oui:w-4" />
         </ToggleGroupItem>
       </ToggleGroup>
     );
@@ -116,13 +116,13 @@ export const Outline: Story = {
         onValueChange={setValue}
       >
         <ToggleGroupItem value="left" aria-label="Align left">
-          <AlignLeft className="oui:h-4 oui:w-4" />
+          <AlignLeftIcon className="oui:h-4 oui:w-4" />
         </ToggleGroupItem>
         <ToggleGroupItem value="center" aria-label="Align center">
-          <AlignCenter className="oui:h-4 oui:w-4" />
+          <AlignCenterIcon className="oui:h-4 oui:w-4" />
         </ToggleGroupItem>
         <ToggleGroupItem value="right" aria-label="Align right">
-          <AlignRight className="oui:h-4 oui:w-4" />
+          <AlignRightIcon className="oui:h-4 oui:w-4" />
         </ToggleGroupItem>
       </ToggleGroup>
     );
@@ -148,15 +148,15 @@ export const WithText: Story = {
         onValueChange={setValue}
       >
         <ToggleGroupItem value="list" aria-label="List view">
-          <List className="oui:h-4 oui:w-4" />
+          <ListIcon className="oui:h-4 oui:w-4" />
           List
         </ToggleGroupItem>
         <ToggleGroupItem value="grid" aria-label="Grid view">
-          <Grid className="oui:h-4 oui:w-4" />
+          <GridIcon className="oui:h-4 oui:w-4" />
           Grid
         </ToggleGroupItem>
         <ToggleGroupItem value="calendar" aria-label="Calendar view">
-          <Calendar className="oui:h-4 oui:w-4" />
+          <CalendarIcon className="oui:h-4 oui:w-4" />
           Calendar
         </ToggleGroupItem>
       </ToggleGroup>
@@ -188,14 +188,14 @@ export const Sizes: Story = {
             value={smallValue}
             onValueChange={setSmallValue}
               >
-            <ToggleGroupItem value="bold" aria-label="Bold">
-              <Bold className="oui:h-3 oui:w-3" />
+            <ToggleGroupItem value="bold" aria-label="BoldIcon">
+              <BoldIcon className="oui:h-3 oui:w-3" />
             </ToggleGroupItem>
-            <ToggleGroupItem value="italic" aria-label="Italic">
-              <Italic className="oui:h-3 oui:w-3" />
+            <ToggleGroupItem value="italic" aria-label="ItalicIcon">
+              <ItalicIcon className="oui:h-3 oui:w-3" />
             </ToggleGroupItem>
-            <ToggleGroupItem value="underline" aria-label="Underline">
-              <Underline className="oui:h-3 oui:w-3" />
+            <ToggleGroupItem value="underline" aria-label="UnderlineIcon">
+              <UnderlineIcon className="oui:h-3 oui:w-3" />
             </ToggleGroupItem>
           </ToggleGroup>
         </div>
@@ -208,14 +208,14 @@ export const Sizes: Story = {
             value={defaultValue}
             onValueChange={setDefaultValue}
               >
-            <ToggleGroupItem value="bold" aria-label="Bold">
-              <Bold className="oui:h-4 oui:w-4" />
+            <ToggleGroupItem value="bold" aria-label="BoldIcon">
+              <BoldIcon className="oui:h-4 oui:w-4" />
             </ToggleGroupItem>
-            <ToggleGroupItem value="italic" aria-label="Italic">
-              <Italic className="oui:h-4 oui:w-4" />
+            <ToggleGroupItem value="italic" aria-label="ItalicIcon">
+              <ItalicIcon className="oui:h-4 oui:w-4" />
             </ToggleGroupItem>
-            <ToggleGroupItem value="underline" aria-label="Underline">
-              <Underline className="oui:h-4 oui:w-4" />
+            <ToggleGroupItem value="underline" aria-label="UnderlineIcon">
+              <UnderlineIcon className="oui:h-4 oui:w-4" />
             </ToggleGroupItem>
           </ToggleGroup>
         </div>
@@ -228,14 +228,14 @@ export const Sizes: Story = {
             value={largeValue}
             onValueChange={setLargeValue}
               >
-            <ToggleGroupItem value="bold" aria-label="Bold">
-              <Bold className="oui:h-5 oui:w-5" />
+            <ToggleGroupItem value="bold" aria-label="BoldIcon">
+              <BoldIcon className="oui:h-5 oui:w-5" />
             </ToggleGroupItem>
-            <ToggleGroupItem value="italic" aria-label="Italic">
-              <Italic className="oui:h-5 oui:w-5" />
+            <ToggleGroupItem value="italic" aria-label="ItalicIcon">
+              <ItalicIcon className="oui:h-5 oui:w-5" />
             </ToggleGroupItem>
-            <ToggleGroupItem value="underline" aria-label="Underline">
-              <Underline className="oui:h-5 oui:w-5" />
+            <ToggleGroupItem value="underline" aria-label="UnderlineIcon">
+              <UnderlineIcon className="oui:h-5 oui:w-5" />
             </ToggleGroupItem>
           </ToggleGroup>
         </div>
@@ -266,14 +266,14 @@ export const TextEditor: Story = {
             value={formatting}
             onValueChange={setFormatting}
               >
-            <ToggleGroupItem value="bold" aria-label="Bold">
-              <Bold className="oui:h-4 oui:w-4" />
+            <ToggleGroupItem value="bold" aria-label="BoldIcon">
+              <BoldIcon className="oui:h-4 oui:w-4" />
             </ToggleGroupItem>
-            <ToggleGroupItem value="italic" aria-label="Italic">
-              <Italic className="oui:h-4 oui:w-4" />
+            <ToggleGroupItem value="italic" aria-label="ItalicIcon">
+              <ItalicIcon className="oui:h-4 oui:w-4" />
             </ToggleGroupItem>
-            <ToggleGroupItem value="underline" aria-label="Underline">
-              <Underline className="oui:h-4 oui:w-4" />
+            <ToggleGroupItem value="underline" aria-label="UnderlineIcon">
+              <UnderlineIcon className="oui:h-4 oui:w-4" />
             </ToggleGroupItem>
           </ToggleGroup>
         </div>
@@ -286,13 +286,13 @@ export const TextEditor: Story = {
             onValueChange={setAlignment}
               >
             <ToggleGroupItem value="left" aria-label="Align left">
-              <AlignLeft className="oui:h-4 oui:w-4" />
+              <AlignLeftIcon className="oui:h-4 oui:w-4" />
             </ToggleGroupItem>
             <ToggleGroupItem value="center" aria-label="Align center">
-              <AlignCenter className="oui:h-4 oui:w-4" />
+              <AlignCenterIcon className="oui:h-4 oui:w-4" />
             </ToggleGroupItem>
             <ToggleGroupItem value="right" aria-label="Align right">
-              <AlignRight className="oui:h-4 oui:w-4" />
+              <AlignRightIcon className="oui:h-4 oui:w-4" />
             </ToggleGroupItem>
           </ToggleGroup>
         </div>
@@ -324,10 +324,10 @@ export const ViewSwitcher: Story = {
             onValueChange={setView}
               >
             <ToggleGroupItem value="list" aria-label="List view">
-              <List className="oui:h-4 oui:w-4" />
+              <ListIcon className="oui:h-4 oui:w-4" />
             </ToggleGroupItem>
             <ToggleGroupItem value="grid" aria-label="Grid view">
-              <Grid className="oui:h-4 oui:w-4" />
+              <GridIcon className="oui:h-4 oui:w-4" />
             </ToggleGroupItem>
           </ToggleGroup>
         </div>
@@ -367,13 +367,13 @@ export const Showcase: Story = {
                 onValueChange={setAlignment}
               >
                 <ToggleGroupItem value="left" aria-label="Align left">
-                  <AlignLeft className="oui:h-4 oui:w-4" />
+                  <AlignLeftIcon className="oui:h-4 oui:w-4" />
                 </ToggleGroupItem>
                 <ToggleGroupItem value="center" aria-label="Align center">
-                  <AlignCenter className="oui:h-4 oui:w-4" />
+                  <AlignCenterIcon className="oui:h-4 oui:w-4" />
                 </ToggleGroupItem>
                 <ToggleGroupItem value="right" aria-label="Align right">
-                  <AlignRight className="oui:h-4 oui:w-4" />
+                  <AlignRightIcon className="oui:h-4 oui:w-4" />
                 </ToggleGroupItem>
               </ToggleGroup>
             </div>
@@ -385,14 +385,14 @@ export const Showcase: Story = {
                 value={formatting}
                 onValueChange={setFormatting}
               >
-                <ToggleGroupItem value="bold" aria-label="Bold">
-                  <Bold className="oui:h-4 oui:w-4" />
+                <ToggleGroupItem value="bold" aria-label="BoldIcon">
+                  <BoldIcon className="oui:h-4 oui:w-4" />
                 </ToggleGroupItem>
-                <ToggleGroupItem value="italic" aria-label="Italic">
-                  <Italic className="oui:h-4 oui:w-4" />
+                <ToggleGroupItem value="italic" aria-label="ItalicIcon">
+                  <ItalicIcon className="oui:h-4 oui:w-4" />
                 </ToggleGroupItem>
-                <ToggleGroupItem value="underline" aria-label="Underline">
-                  <Underline className="oui:h-4 oui:w-4" />
+                <ToggleGroupItem value="underline" aria-label="UnderlineIcon">
+                  <UnderlineIcon className="oui:h-4 oui:w-4" />
                 </ToggleGroupItem>
               </ToggleGroup>
             </div>
@@ -406,11 +406,11 @@ export const Showcase: Story = {
                 onValueChange={setView}
               >
                 <ToggleGroupItem value="list" aria-label="List view">
-                  <List className="oui:h-4 oui:w-4" />
+                  <ListIcon className="oui:h-4 oui:w-4" />
                   List
                 </ToggleGroupItem>
                 <ToggleGroupItem value="grid" aria-label="Grid view">
-                  <Grid className="oui:h-4 oui:w-4" />
+                  <GridIcon className="oui:h-4 oui:w-4" />
                   Grid
                 </ToggleGroupItem>
               </ToggleGroup>

--- a/stories/Tooltip.stories.tsx
+++ b/stories/Tooltip.stories.tsx
@@ -1,7 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/react';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components';
 import { Button } from '@/components';
-import { HelpCircle, Trash2, Edit, Copy, AlertTriangle } from 'lucide-react';
+import { HelpCircleIcon, Trash2Icon, EditIcon, CopyIcon, AlertTriangleIcon } from '@/components';
 
 const meta: Meta<typeof Tooltip> = {
   title: 'UI/Tooltip',
@@ -132,10 +132,10 @@ export const WithKeyboardShortcut: Story = {
   render: () => (
     <Tooltip>
       <TooltipTrigger asChild>
-        <Button variant="outline">Copy</Button>
+        <Button variant="outline">CopyIcon</Button>
       </TooltipTrigger>
       <TooltipContent>
-        <p>Copy to clipboard</p>
+        <p>CopyIcon to clipboard</p>
         <p className="oui:text-xs oui:opacity-70 oui:mt-1">⌘+C</p>
       </TooltipContent>
     </Tooltip>
@@ -148,7 +148,7 @@ export const WithIconButton: Story = {
     <Tooltip>
       <TooltipTrigger asChild>
         <Button size="icon" variant="outline">
-          <HelpCircle className="oui:h-4 oui:w-4" />
+          <HelpCircleIcon className="oui:h-4 oui:w-4" />
         </Button>
       </TooltipTrigger>
       <TooltipContent>
@@ -271,7 +271,7 @@ export const CommonUseCases: Story = {
       <Tooltip>
         <TooltipTrigger asChild>
           <Button size="icon" variant="outline">
-            <Trash2 className="oui:h-4 oui:w-4" />
+            <Trash2Icon className="oui:h-4 oui:w-4" />
           </Button>
         </TooltipTrigger>
         <TooltipContent>
@@ -283,11 +283,11 @@ export const CommonUseCases: Story = {
       <Tooltip>
         <TooltipTrigger asChild>
           <Button size="icon" variant="outline">
-            <Edit className="oui:h-4 oui:w-4" />
+            <EditIcon className="oui:h-4 oui:w-4" />
           </Button>
         </TooltipTrigger>
         <TooltipContent>
-          <p>Edit item</p>
+          <p>EditIcon item</p>
           <p className="oui:text-xs oui:opacity-70 oui:mt-1">⌘+E</p>
         </TooltipContent>
       </Tooltip>
@@ -295,11 +295,11 @@ export const CommonUseCases: Story = {
       <Tooltip>
         <TooltipTrigger asChild>
           <Button size="icon" variant="outline">
-            <Copy className="oui:h-4 oui:w-4" />
+            <CopyIcon className="oui:h-4 oui:w-4" />
           </Button>
         </TooltipTrigger>
         <TooltipContent>
-          <p>Copy to clipboard</p>
+          <p>CopyIcon to clipboard</p>
           <p className="oui:text-xs oui:opacity-70 oui:mt-1">⌘+C</p>
         </TooltipContent>
       </Tooltip>
@@ -307,7 +307,7 @@ export const CommonUseCases: Story = {
       <Tooltip>
         <TooltipTrigger asChild>
           <Button size="icon" variant="outline">
-            <AlertTriangle className="oui:h-4 oui:w-4" />
+            <AlertTriangleIcon className="oui:h-4 oui:w-4" />
           </Button>
         </TooltipTrigger>
         <TooltipContent>

--- a/wiki/consuming.md
+++ b/wiki/consuming.md
@@ -182,22 +182,52 @@ If you get an error when importing a React component, you might need to configur
 
 ### Icons
 
-OUI 2.x uses Lucide React icons instead of the legacy icon system. Icons are imported directly from the `lucide-react` package:
+OUI 2.x provides a comprehensive icon system that combines curated Lucide React icons with custom OpenSearch icons. All icons should be imported from the OUI package:
 
 ```javascript
-import { ArrowDown, ArrowLeft, Settings } from 'lucide-react';
+import {
+  ChevronDownIcon,
+  ChevronLeftIcon,
+  SettingsIcon,
+  SearchIcon,
+  UserIcon,
+  DiscoverIcon  // Custom OUI icon
+} from '@opensearch-project/oui';
 
 function MyComponent() {
   return (
     <Button>
-      <ArrowDown className="h-4 w-4" />
+      <ChevronDownIcon className="h-4 w-4" />
       Click me
     </Button>
   );
 }
 ```
 
-If you need the legacy icon handling for compatibility, the old approach with `appendIconComponentCache` may still be available but is not recommended for new implementations.
+**Icon System Features:**
+- **118+ curated Lucide icons** - All with consistent "Icon" suffix naming
+- **Custom OUI icons** - OpenSearch-specific icons like `DiscoverIcon`
+- **Unified API** - All icons support size, color, strokeWidth, and standard SVG props
+- **Tree-shakable** - Import only the icons you use
+
+**Important**: Don't import icons directly from `lucide-react`. Always use the OUI package to ensure consistency and access to custom OpenSearch icons.
+
+**Example Usage:**
+```javascript
+// Size variants
+<SearchIcon size={16} />
+<SearchIcon size={24} />  // default
+<SearchIcon size={32} />
+
+// Color and styling
+<HeartIcon className="text-red-500" />
+<StarIcon color="#fbbf24" />
+<CheckCircleIcon className="text-green-600" />
+
+// Stroke width
+<CircleIcon strokeWidth={1} />  // thin
+<CircleIcon strokeWidth={3} />  // bold
+```
 
 ## Customizing with `className`
 

--- a/wiki/creating-components-manually.md
+++ b/wiki/creating-components-manually.md
@@ -165,13 +165,13 @@ Tests should be written in Storybook stories using the `@storybook/test` package
 
 ## Adding Icons
 
-If you need icons, use `lucide-react`:
+If you need icons, you can import Lucide or custom icons from `@opensearch-project/oui` (with Icon suffix):
 
 ```tsx
-import { ChevronDown } from 'lucide-react'
+import { ChevronDownIcon } from '@opensearch-project/oui'
 
 // Use in component
-<ChevronDown className="h-4 w-4" />
+<ChevronDownIcon className="h-4 w-4" />
 ```
 
 ## Best Practices

--- a/wiki/creating-icons.md
+++ b/wiki/creating-icons.md
@@ -1,12 +1,23 @@
 # Creating icons
 
-OUI provides an ever-growing set of [icons][icons], but our set can be incomplete. If you find you need an icon that does not exist, create a new issue and tag it with the *icons* label. A designer from the OUI team will respond to discuss your needs.
+OUI 2.x provides a comprehensive icon system combining curated Lucide React icons with custom OUI icons. If you need an icon that doesn't exist in our collection, create a new issue and tag it with the *icons* label. A designer from the OUI team will respond to discuss your needs.
 
-If you are willing and able to design the icon yourself, this document describes the guidelines for designing a new icon, cleaning up the SVG, and getting it added to OUI. While designers on the OUI team are available to assist, we greatly appreciate your contributions and pull requests.
+If you are willing and able to design the icon yourself, this document describes the guidelines for designing a new custom icon, cleaning up the SVG, and getting it added to OUI. While designers on the OUI team are available to assist, we greatly appreciate your contributions and pull requests.
 
 If you read through these guidelines or begin designing your icon and realize you're in too deep, then create an issue in this repo and request assistance. An OUI team member will reply and discuss options.
 
-_**Note**: The `OuiIcon` component accepts external references to icon files, so you have the option to maintain the icon in your consuming application._
+## Icon System Overview
+
+OUI 2.x provides two types of icons:
+
+1. **Lucide React Icons**: A curated collection of 118+ icons from the lucide-react package, all following consistent naming with "Icon" suffix
+2. **Custom OUI Icons**: SVG-based icons specific to OpenSearch/OUI use cases, automatically generated as React components
+
+All icons are imported from a single source:
+
+```typescript
+import { SearchIcon, UserIcon, DiscoverIcon } from '@opensearch-project/oui';
+```
 
 ## Design the icon
 
@@ -21,6 +32,8 @@ Finding and sharing reference icons is a great way to get moving if you're uncer
 Lastly, we reserve the right to reject any icons that do not fit the OUI style or may be deemed inappropriate.
 
 ### Style
+
+<!-- TODO: update with new Icon style guidelines: https://lucide.dev/guide/design/icon-design-guide -->
 
 This is where things get more opinionated. To maintain a cohesive, high quality icon set, we require that all new glpyhs adhere to the following guidelines:
 
@@ -40,9 +53,18 @@ _As a reference, you can download and view the `icons.sketch` file via the **Ske
 #### _For non-Sketch users_
 _While we use Sketch to maintain our internal design library, you can use any design tool to produce the SVG file._
 
-## Add the icon to the OUI repo
+## Before Adding a Custom Icon
 
-Once you've designed your new icon, the last step is adding it to the OUI repo.
+First, check if a suitable icon already exists in our Lucide React collection:
+1. Browse available icons at `http://localhost:6006/?path=/story/ui-icons--default` when running Storybook locally
+2. Search through our curated collection of 118+ Lucide icons organized by category
+3. If a Lucide icon meets your needs, use it instead of creating a custom one
+
+If no suitable Lucide icon exists, proceed with creating a custom icon.
+
+## Add a Custom Icon to OUI
+
+Once you've designed your new icon, follow these steps to add it to the OUI repo.
 
 ### Clean the SVG
 
@@ -59,34 +81,41 @@ _**Note**: Sketch users can use the [SVGO plugin][sketch-SVGO-plugin] to remove 
 
 Create a new feature branch against this repo and make the following changes:
 
-_1. Add your glyph to the `OuiIcon` component_
-- Add your SVG file to the `/src/components/icon/assets` folder
-- Add a reference in the `/src/components/icon/icon.tsx` file (in alphabetical order)
+_1. Add your SVG to the custom icons directory_
+- Add your cleaned SVG file to `/src/components/custom/icons/custom/` folder
+- Use kebab-case naming (e.g., `my-new-icon.svg`)
+- The build system will automatically generate a PascalCase component name with "Icon" suffix (e.g., `MyNewIconIcon`)
 
-_2. Display the icon in the docs_
-- Add the icon name to `/src-docs/src/views/icon/icons.js` *
+_2. Generate the React component_
+- Run `yarn build:icons` to generate the React component from your SVG
+- This creates a TypeScript component in the same directory following OUI patterns
+- The component automatically includes proper TypeScript types and forwardRef implementation
 
 _3. Compile and test_
-- Run `yarn compile-icons`
-- Preview your icon locally at `http://localhost:8030/#/display/icons` **
-- Switch the docs to dark mode and verify that the icon is visible (all paths should be filled with the reverse color)
-- Run `yarn run test-unit icon -u` to create/update the jest snapshots
+- Run `yarn build` to build the complete package
+- Add your icon to the Icons story
+- Preview your icon in Storybook at `http://localhost:6006/?path=/story/ui-icons--default`
+- Your icon will appear in the "Custom OUI Icons" section
+- Switch between light and dark themes to verify visibility
+- Run `yarn test` to ensure all tests pass
 
 If everything looks good, then commit your changes, push up your branch, and open a PR! :raised_hands:
 
 Opening a PR will notify the OUI team that your work is ready for review. Please include a screenshot in the description and reference the issue that your PR fixes.
 
 ### Ship it
-Once your PR is approved, you will be able to merge it and give yourself a well-deserved pat on the back. Finally, stay tuned for the next release of OUI at which point your icon will become available to the masses and appear on the OUI docs site.
+Once your PR is approved, you will be able to merge it and give yourself a well-deserved pat on the back. Finally, stay tuned for the next release of OUI at which point your icon will become available to the masses and appear on the OUI Storybook site.
 
-:trophy: _**Welcome to the Official OUI Icon Design Club**_ :beers:
+## Usage
 
----
+After your icon is published, consumers can use it like any other OUI icon:
 
-_\* The Icons page actually contains several sections. In most cases, you will be adding your icon to the base set. However, if your icon should appear in a different set, then add it to the appropriate section file in `/src-docs/src/views/icon`._
+```typescript
+import { MyNewIcon } from '@opensearch-project/oui';
 
-_\** Run `yarn && yarn start` to view the OUI docs site locally._
-
+// Use with all standard icon props
+<MyNewIcon size={24} className="text-blue-500" strokeWidth={2} />
+```
 
 [icons]: https://oui.opensearch.org/#/display/icons
 [docs]: https://oui.opensearch.org

--- a/wiki/oui-1.x-2.x-component-mapping-reference.md
+++ b/wiki/oui-1.x-2.x-component-mapping-reference.md
@@ -20,7 +20,7 @@ This document serves as the definitive mapping guide for migrating from OUI 1.x 
 
 | Category | OUI 1.x Component | OUI 2.x Component | Status | Key Prop Changes | Migration Phase | Migration Notes |
 |----------|-------------------|-------------------|--------|------------------|----------------|-----------------|
-| Actions | **EuiButton** | `Button` | ⬜ Phase 1 | `color="primary"` → `variant="default"`<br/>`color="danger"` → `variant="destructive"`<br/>`fill={true}` → `variant="default"`<br/>`fill={false}` → `variant="outline"`<br/>`size="s"` → `size="sm"` | Phase 1 | Icon handling changed: `iconType="add"` → `<PlusIcon className="h-4 w-4" />` |
+| Actions | **EuiButton** | `Button` | ⬜ Phase 1 | `color="primary"` → `variant="default"`<br/>`color="danger"` → `variant="destructive"`<br/>`fill={true}` → `variant="default"`<br/>`fill={false}` → `variant="outline"`<br/>`size="s"` → `size="sm"` | Phase 1 | Icon handling changed: `iconType="add"` → `import { PlusIcon } from '@opensearch-project/oui'; <PlusIcon className="h-4 w-4" />` |
 | Actions | **EuiButtonEmpty** | `Button` | ⬜ Phase 1 | Equivalent to `variant="ghost"` | Phase 1 | Use ghost variant for similar appearance |
 | Actions | **EuiButtonIcon** | `Button` + Icon | 📋 Unknown | `iconType="name"` → `<NameIcon />` component | Unknown | Requires icon mapping and sizing |
 | Actions | **EuiLink** | `Link` or `<a>` | 📋 Unknown | Similar props expected | Unknown | External vs internal link handling TBD |
@@ -70,7 +70,7 @@ This document serves as the definitive mapping guide for migrating from OUI 1.x 
 | Overlays | **EuiToolTip** | `Tooltip` | 📋 Unknown | `content` → children of tooltip | Unknown | Positioning and delay configuration |
 | Feedback | **EuiProgress** | `Progress` | 📋 Unknown | `value`, `max` props similar | Unknown | Indeterminate state and animations |
 | Feedback | **EuiLoadingSpinner** | `Spinner` or CSS | 📋 Unknown | Size variants mapping | Unknown | Animation performance and accessibility |
-| Media | **EuiIcon** | Lucide React icons | ⬜ Phase 1 | `type="add"` → `<PlusIcon />` | Phase 1 | See icon mapping table below |
+| Media | **EuiIcon** | OUI 2.x Icon System | ✅ Ready | `type="add"` → `<PlusIcon />` from OUI package | Phase 1 | Uses Lucide React icons + custom OUI icons - see icon mapping below |
 | Media | **EuiImage** | `<img>` + utilities | 📋 Unknown | Similar src, alt props | Unknown | Lazy loading and responsive image patterns |
 | Media | **EuiAvatar** | `Avatar` | 📋 Unknown | `name`, `src` props similar | Unknown | Fallback patterns and size variants |
 | Display | **EuiBadge** | `Badge` | 📋 Unknown | `color` → `variant`<br/>`iconType` → icon component | Unknown | Color mapping and icon handling |
@@ -168,21 +168,30 @@ This document serves as the definitive mapping guide for migrating from OUI 1.x 
 
 ## Icon Mapping Table
 
+**Import Pattern**: All icons should be imported from the OUI package:
+```typescript
+import { PlusIcon, SearchIcon, UserIcon, DiscoverIcon } from '@opensearch-project/oui';
+```
+
+OUI 2.x provides two types of icons:
+1. **Lucide React Icons**: 118+ curated icons from lucide-react, all with "Icon" suffix
+2. **Custom OUI Icons**: SVG-based icons specific to OpenSearch, generated as React components
+
 ### Core Action Icons
-| OUI 1.x Icon | Category | Lucide React Icon | Status | Migration Notes |
-|--------------|----------|-------------------|--------|-----------------|
-| `type="add"` | Actions | `<PlusIcon />` | ✅ Direct | Direct replacement |
-| `type="addDataApp"` | Actions | `<PlusIcon /> + <DatabaseIcon />` | ❓ Composite | Combine plus with database icon |
-| `type="apps"` | Actions | `<GridIcon />` | ✅ Direct | Application launcher |
-| `type="arrowDown"` | Actions | `<ChevronDownIcon />` | ✅ Direct | Use for dropdowns |
-| `type="arrowLeft"` | Actions | `<ChevronLeftIcon />` | ✅ Direct | Navigation back |
-| `type="arrowRight"` | Actions | `<ChevronRightIcon />` | ✅ Direct | Navigation forward |
-| `type="arrowUp"` | Actions | `<ChevronUpIcon />` | ✅ Direct | Collapse/minimize |
-| `type="bell"` | Actions | `<BellIcon />` | ✅ Direct | Notifications |
-| `type="bellSlash"` | Actions | `<BellOffIcon />` | ✅ Direct | Muted notifications |
-| `type="bolt"` | Actions | `<ZapIcon />` | ✅ Direct | Quick actions/power |
-| `type="bookmark"` | Actions | `<BookmarkIcon />` | ✅ Direct | Save for later |
-| `type="broom"` | Actions | `<BroomIcon />` | ⚠️ No Match | Cleaning/clearing actions |
+| OUI 1.x Icon | Category | OUI 2.x Icon | Lucide Source | Status | Migration Notes |
+|--------------|----------|--------------|---------------|--------|-----------------|
+| `type="add"` | Actions | `<PlusIcon />` | ✅ Lucide | ✅ Direct | Direct replacement |
+| `type="addDataApp"` | Actions | `<PlusIcon /> + <DatabaseIcon />` | ✅ Lucide | ❓ Composite | Combine plus with database icon |
+| `type="apps"` | Actions | `<MenuIcon />` | ✅ Lucide | ✅ Direct | Application launcher menu |
+| `type="arrowDown"` | Actions | `<ChevronDownIcon />` | ✅ Lucide | ✅ Direct | Use for dropdowns |
+| `type="arrowLeft"` | Actions | `<ChevronLeftIcon />` | ✅ Lucide | ✅ Direct | Navigation back |
+| `type="arrowRight"` | Actions | `<ChevronRightIcon />` | ✅ Lucide | ✅ Direct | Navigation forward |
+| `type="arrowUp"` | Actions | `<ChevronUpIcon />` | ✅ Lucide | ✅ Direct | Collapse/minimize |
+| `type="bell"` | Actions | `<BellIcon />` | ✅ Lucide | ✅ Direct | Notifications |
+| `type="bellSlash"` | Actions | `<BellOffIcon />` | ✅ Lucide | ✅ Direct | Muted notifications |
+| `type="bolt"` | Actions | `<ZapIcon />` | ✅ Lucide | ✅ Direct | Quick actions/power |
+| `type="bookmark"` | Actions | `<BookmarkIcon />` | ✅ Lucide | ✅ Direct | Save for later |
+| `type="broom"` | Actions | Custom SVG needed | ⚠️ No Match | ⚠️ No Match | Cleaning/clearing actions |
 | `type="brush"` | Actions | `<PaintbrushIcon />` | ✅ Direct | Formatting/styling |
 | `type="bullseye"` | Actions | `<TargetIcon />` | ✅ Direct | Focus/target |
 | `type="calendar"` | Actions | `<CalendarIcon />` | ✅ Direct | Date/time selection |


### PR DESCRIPTION
### Description
Because we want custom icons and we should have a place to centrally update/change icons, I've centralized icons. This does a couple things:
- Lucide icons with "Icon" suffix are included (only using Icon suffix to avoid named export conflicts)
- Not all Lucide icons are included, but we can add them as necessary
- Added ability to add custom icons and added discover/compass icon. Callouts:
  - Using same interface as lucide icons
  - Our existing icons are designed differently than lucide, so when using the same defaults, e.g. stroke-width: 2, things don't look great. As we add existing icons, we likely need to update them.
- Updated stories/docs to reflect new icons
  - We should update the creating icons section with appropriate design process.

<img width="1109" height="914" alt="image" src="https://github.com/user-attachments/assets/4efaddd6-342c-4332-a5cd-2bb9a14028ab" />

<img width="1076" height="1276" alt="image" src="https://github.com/user-attachments/assets/b23ca8b1-eb07-4d2f-8201-b64719eff1e3" />

### Issues Resolved
N/A

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] All tests pass
  - [ ] `yarn lint`
  - [ ] `yarn test-unit`
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/oui/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
