### PR TITLE
Enable OSD builds with OUI 2.x in github build workflow

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -110,7 +110,6 @@ jobs:
 
   osd-unit:
     name: OSD Jest test (ciGroup${{ matrix.group }})
-    if: false # Remove when reconfigured to work properly with OUI 1.x and 2.x
     runs-on: ubuntu-latest
     needs: build
     strategy:
@@ -151,7 +150,7 @@ jobs:
 
       - name: Update OUI version in OSD
         run: |
-          find . -type f -name package.json -exec sed -i 's/"@elastic\/eui": ".*"/"@elastic\/eui": "file:${{ env.OUI_PATH }}"/g' {} \;
+          find . -type f -name package.json -exec sed -i 's/"@opensearch-project\/oui": ".*"/"@opensearch-project\/oui": "file:${{ env.OUI_PATH }}"/g' {} \;
 
       - name: Bootstrap OSD
         run: yarn osd bootstrap
@@ -161,7 +160,6 @@ jobs:
 
   osd-integration:
     name: OSD Integration test
-    if: false # Remove when reconfigured to work properly with OUI 1.x and 2.x
     runs-on: ubuntu-latest
     needs: build
     steps:
@@ -204,7 +202,7 @@ jobs:
 
       - name: Update OUI version in OSD
         run: |
-          find . -type f -name package.json -exec sed -i 's/"@elastic\/eui": ".*"/"@elastic\/eui": "file:${{ env.OUI_PATH }}"/g' {} \;
+          find . -type f -name package.json -exec sed -i 's/"@opensearch-project\/oui": ".*"/"@opensearch-project\/oui": "file:${{ env.OUI_PATH }}"/g' {} \;
 
       - name: Bootstrap OSD
         run: yarn osd bootstrap
@@ -214,7 +212,6 @@ jobs:
 
   osd-build:
     name: OSD Build on ${{ matrix.name }}
-    if: false # Remove when reconfigured to work properly with OUI 1.x and 2.x
     strategy:
       matrix:
         include:
@@ -264,7 +261,7 @@ jobs:
 
       - name: Update OUI version in OSD
         run: |
-          find . -type f -name package.json -exec sed -i 's/"@elastic\/eui": ".*"/"@elastic\/eui": "file:${{ env.OUI_PATH }}"/g' {} \;
+          find . -type f -name package.json -exec sed -i 's/"@opensearch-project\/oui": ".*"/"@opensearch-project\/oui": "file:${{ env.OUI_PATH }}"/g' {} \;
 
       - name: Get package version
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### 🐛 Bug Fixes
 
 ### 🚞 Infrastructure
+- Enable OSD builds with OUI 2.x in github build workflow ([#1685](https://github.com/opensearch-project/oui/pull/1685))
 
 ### 📝 Documentation
 


### PR DESCRIPTION
### Description
Adds OSD build back to github workflow

Running in this PR. The one failure is unrelated because OSD main doesn't currently have a dependency on @opensearch-project/oui. 

### Issues Resolved
N/A

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] All tests pass
  - [ ] `yarn lint`
  - [ ] `yarn test-unit`
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/oui/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
