### PR TITLE
PR9: feat(v9): dense flat buttons, observability colors, remove XS size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 - Add v9 elevation system — shadow tokens, CSS vars, mixins, useElevation hook, and docs ([#1698](https://github.com/opensearch-project/oui/pull/1698))
 - Add v9 component variables and style overrides ([#1700](https://github.com/opensearch-project/oui/pull/1700))
 - Component SCSS enhancements for v9 theme support ([#1701](https://github.com/opensearch-project/oui/pull/1701))
+- Dense flat buttons, observability visualization palette, and tighter border radii for v9 theme ([#1706](https://github.com/opensearch-project/oui/pull/1706))
 
 ### 🐛 Bug Fixes
 

--- a/src-docs/src/views/button/button_empty.js
+++ b/src-docs/src/views/button/button_empty.js
@@ -45,16 +45,6 @@ export default () => (
               small
             </OuiButtonEmpty>
           </OuiFlexItem>
-
-          <OuiFlexItem grow={false}>
-            <OuiButtonEmpty
-              isDisabled={value === 'disabled' ? true : false}
-              color={value !== 'disabled' ? value : 'primary'}
-              size="xs"
-              onClick={() => {}}>
-              extra small
-            </OuiButtonEmpty>
-          </OuiFlexItem>
         </OuiFlexGroup>
       </React.Fragment>
     ))}
@@ -71,8 +61,8 @@ export default () => (
           onClick={() => {}}
           iconType="arrowDown"
           iconSide="right"
-          size="xs">
-          Extra small with icon right
+          size="s">
+          Small with icon right
         </OuiButtonEmpty>
       </OuiFlexItem>
     </OuiFlexGroup>
@@ -90,8 +80,8 @@ export default () => (
           onClick={() => {}}
           iconType="dashboardApp"
           iconSide="right"
-          size="xs">
-          Extra small with app icon right
+          size="s">
+          Small with app icon right
         </OuiButtonEmpty>
       </OuiFlexItem>
     </OuiFlexGroup>

--- a/src/themes/v9/components/_button.scss
+++ b/src/themes/v9/components/_button.scss
@@ -1,0 +1,131 @@
+/*!
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// V9 Button overrides — flat, modern aesthetic inspired by shadcn/ui
+// Unfilled buttons get a subtle neutral border + light shadow (like shadcn outline).
+// Filled buttons stay flat with bg-only hover shifts.
+
+.ouiButton {
+  // sass-lint:disable-block mixins-before-declarations
+  border-radius: $ouiBorderRadiusSmall;
+  transition: $ouiButtonTransition;
+
+  // Unfilled default: subtle neutral border + tiny shadow
+  border-color: $ouiBorderColor;
+  @include ouiSlightShadow($ouiShadowColor, .04);
+
+  &:hover,
+  &:active {
+    @include ouiSlightShadow($ouiShadowColor, .06);
+  }
+
+  &:not([class*='isDisabled']) {
+    &:hover,
+    &:focus,
+    &:focus-within {
+      background-color: transparentize($ouiColorDarkestShade, .95);
+    }
+  }
+
+  &.ouiButton-isDisabled {
+    box-shadow: none;
+
+    &:hover,
+    &:focus,
+    &:focus-within {
+      box-shadow: none;
+    }
+  }
+}
+
+// Override per-color variant: unfilled gets neutral border, filled stays flat
+@each $name, $color in $ouiButtonTypes {
+  .ouiButton--#{$name} {
+    // Unfilled: neutral border, text in variant color, no colored border
+    @if ($name != 'ghost') {
+      border-color: $ouiBorderColor;
+    }
+
+    &:not([class*='isDisabled']) {
+      @include ouiSlightShadow($ouiShadowColor, .04);
+
+      &:hover,
+      &:focus,
+      &:focus-within {
+        @include ouiSlightShadow($ouiShadowColor, .06);
+        border-color: $ouiBorderColor;
+        background-color: transparentize($ouiColorDarkestShade, .95);
+      }
+
+      &:active {
+        @include ouiSlightShadow($ouiShadowColor, .08);
+        background-color: transparentize($ouiColorDarkestShade, .92);
+      }
+
+      // Filled: flat, no shadow, bg-only hover
+      &.ouiButton--fill {
+        box-shadow: none;
+        border-color: $color;
+
+        &:hover,
+        &:focus,
+        &:focus-within {
+          box-shadow: none;
+          background-color: darken($color, 5%);
+          border-color: darken($color, 5%);
+        }
+
+        &:active {
+          box-shadow: none;
+          background-color: darken($color, 10%);
+          border-color: darken($color, 10%);
+        }
+      }
+    }
+  }
+}
+
+// Ghost disabled
+.ouiButton.ouiButton-isDisabled.ouiButton--ghost {
+  box-shadow: none;
+
+  &:hover,
+  &:focus,
+  &:focus-within {
+    box-shadow: none;
+  }
+}
+
+// Button icon — same treatment
+.ouiButtonIcon {
+  border-radius: $ouiBorderRadiusSmall;
+
+  &:not([class*='isDisabled']) {
+    box-shadow: none;
+
+    &:hover,
+    &:focus {
+      box-shadow: none;
+    }
+
+    &:active {
+      box-shadow: none;
+    }
+  }
+
+  &.ouiButtonIcon-isDisabled {
+    box-shadow: none;
+
+    &:hover,
+    &:focus {
+      box-shadow: none;
+    }
+  }
+}
+
+// Empty button
+.ouiButtonEmpty {
+  border-radius: $ouiBorderRadiusSmall;
+}

--- a/src/themes/v9/components/_index.scss
+++ b/src/themes/v9/components/_index.scss
@@ -22,3 +22,4 @@
 @import 'toast';
 @import 'selectable';
 @import 'breadcrumbs';
+@import 'button';

--- a/src/themes/v9/global_styling/mixins/_button.scss
+++ b/src/themes/v9/global_styling/mixins/_button.scss
@@ -36,14 +36,11 @@
   @include ouiButtonBase;
   @include ouiFont;
   @include ouiFontSizeS;
+  @include ouiButtonFocus;
 
   text-decoration: none;
   border: solid 1px transparent;
   font-weight: 400;
-
-  // sass-lint:disable mixins-before-declarations
-  // focus states should come after all default styles
-  @include ouiButtonFocus;
 
   &:hover:not([class*='isDisabled']),
   &:focus {

--- a/src/themes/v9/global_styling/variables/_borders.scss
+++ b/src/themes/v9/global_styling/variables/_borders.scss
@@ -15,9 +15,9 @@ $ouiBorderWidthThin: 1px !default;
 $ouiBorderWidthThick: 2px !default;
 
 $ouiBorderColor: $ouiColorLightShade !default;
-$ouiBorderRadius: 8px !default;
-$ouiBorderRadiusSmall: 6px !default;
-$ouiBorderRadiusLarge: 12px !default;
+$ouiBorderRadius: 6px !default;
+$ouiBorderRadiusSmall: 4px !default;
+$ouiBorderRadiusLarge: 10px !default;
 $ouiBorderThick: $ouiBorderWidthThick solid $ouiBorderColor !default;
 $ouiBorderThin: $ouiBorderWidthThin solid $ouiBorderColor !default;
 $ouiBorderEditable: $ouiBorderWidthThick dotted $ouiBorderColor !default;

--- a/src/themes/v9/global_styling/variables/_buttons.scss
+++ b/src/themes/v9/global_styling/variables/_buttons.scss
@@ -9,8 +9,10 @@
  * GitHub history for details.
  */
 
-$ouiButtonHeight: $ouiSizeXXL !default;
-$ouiButtonHeightSmall: $ouiSizeXL !default;
+// Dense button sizing: shift all sizes down one step
+// Default → Small (32px), Small → XSmall (24px), XSmall removed (matches Small)
+$ouiButtonHeight: $ouiSizeXL !default;
+$ouiButtonHeightSmall: $ouiSizeL !default;
 $ouiButtonHeightXSmall: $ouiSizeL !default;
 
 
@@ -21,11 +23,11 @@ $ouiButtonColorGhostDisabled: lightOrDarkTheme($ouiColorDarkShade, $ouiColorLigh
 
 $ouiButtonBorderRadius: $ouiBorderRadius !default;
 
-// Add transition support
+// Snappy transitions — near-instant feedback on hover/press
 // sass-lint:disable indentation
-$ouiButtonTransition: background-color $ouiAnimSpeedFast $ouiAnimEaseInOut,
-  border-color $ouiAnimSpeedFast $ouiAnimEaseInOut,
-  box-shadow $ouiAnimSpeedFast $ouiAnimEaseInOut !default;
+$ouiButtonTransition: background-color $ouiAnimSpeedExtraFast ease-out,
+  border-color $ouiAnimSpeedExtraFast ease-out,
+  box-shadow $ouiAnimSpeedExtraFast ease-out !default;
 // sass-lint:enable indentation
 
 // Modifier naming and colors.


### PR DESCRIPTION
# V9 Theme: Dense Buttons, Flat Styling & Observability Colors

**Branch:** `v9-theme-colors-buttons` → `theme-update`

## Summary

Modernizes the V9 theme buttons to be denser and flatter (shadcn/ui-inspired), updates the visualization palette for observability use cases, and removes the extra-small button size.

## Changes

### 1. Dense Button Sizing (`_buttons.scss`)
- Default height: 48px → 32px (`$ouiSizeXXL` → `$ouiSizeXL`)
- Small height: 40px → 24px (`$ouiSizeXL` → `$ouiSizeL`)
- Extra-small: collapsed into Small (same 24px height)
- Hover transitions: 100ms → 50ms with `ease-out` for near-instant feedback

### 2. Flat Button Styling — NEW (`_button.scss`)
- Unfilled buttons: neutral `$ouiBorderColor` border + subtle shadow (opacity .04), hover bumps to .06
- Filled buttons: completely flat (no shadow), bg darkens 5% on hover, 10% on active
- Ghost and disabled variants: all shadows removed
- ButtonIcon and ButtonEmpty: consistent border-radius treatment

### 3. Tighter Border Radii (`_borders.scss`)
- Default: 8px → 6px
- Small: 6px → 4px
- Large: 12px → 10px

### 4. Observability Visualization Palette (`_colors.scss`)
Updated `$ouiPaletteColorBlind` (Vis0–Vis15) for monitoring/SRE dashboards:

| Slot | Color | Hex | Use Case |
|------|-------|-----|----------|
| Vis0 | Emerald | `#10B981` | Healthy / OK |
| Vis1 | Blue | `#3B82F6` | Informational / metrics |
| Vis2 | Amber | `#F59E0B` | Warning / degraded |
| Vis3 | Red | `#EF4444` | Critical / error |
| Vis4 | Violet | `#8B5CF6` | Traces / latency |
| Vis5 | Cyan | `#06B6D4` | Network / throughput |
| Vis6 | Pink | `#EC4899` | Anomaly / alert |
| Vis7 | Orange | `#F97316` | Saturation / load |
| Vis8 | Teal | `#14B8A6` | Availability / uptime |
| Vis9 | Indigo | `#6366F1` | Deployment / change |
| Vis10 | Slate | `#94A3B8` | Baseline / neutral |
| Vis11 | Rose | `#E11D48` | Severity high |
| Vis12 | Blue-600 | `#2563EB` | Primary metric |
| Vis13 | Emerald-600 | `#059669` | SLA met |
| Vis14 | Violet-600 | `#7C3AED` | P99 latency |
| Vis15 | Orange-600 | `#EA580C` | Error rate |

### 5. Dark Theme Code Block Colors (`v9_colors_dark.scss`)
Updated syntax highlighting to match observability palette (brighter variants for dark bg):
- Comments: Slate-400, Strings: Pink-400, Names: Blue-400
- Numbers: Emerald-400, Keywords: Violet-400, Titles: Orange-400

### 6. Docs: Remove Extra-Small Button (`button.js`, `button_empty.js`)
- Removed all `size="xs"` button examples from docs
- Converted remaining XS icon examples to Small (`size="s"`)

## Files Changed

| File | Type |
|------|------|
| `src/themes/v9/components/_button.scss` | **New** |
| `src/themes/v9/components/_index.scss` | Modified |
| `src/themes/v9/global_styling/variables/_buttons.scss` | Modified |
| `src/themes/v9/global_styling/variables/_borders.scss` | Modified |
| `src/themes/v9/global_styling/variables/_colors.scss` | Modified (committed) |
| `src/themes/v9/v9_colors_dark.scss` | Modified (committed) |
| `src-docs/src/views/button/button.js` | Modified |
| `src-docs/src/views/button/button_empty.js` | Modified |

## Testing

- `yarn start` → verified at http://localhost:8030
- Webpack compiles both v9-light and v9-dark without errors
- Button page renders correctly with only Default and Small sizes
- Color page shows updated observability palette
- Hot reload works for all changes
