### PR TITLE
fix: prevent iconSize prop from leaking to DOM in OuiButtonEmpty

### DIFF
--- a/src/components/button/button_empty/button_empty.tsx
+++ b/src/components/button/button_empty/button_empty.tsx
@@ -138,6 +138,7 @@ export const OuiButtonEmpty: FunctionComponent<OuiButtonEmptyProps> = ({
   iconType,
   iconGap = 'm',
   iconSide = 'left',
+  iconSize: _iconSize,
   color = 'primary',
   size,
   flush,
@@ -182,7 +183,7 @@ export const OuiButtonEmpty: FunctionComponent<OuiButtonEmptyProps> = ({
     textProps && textProps.className
   );
 
-  const iconSize = size === 'xs' ? 's' : 'm';
+  const iconSize = _iconSize ?? (size === 'xs' ? 's' : 'm');
 
   const innerNode = (
     <OuiButtonContent


### PR DESCRIPTION
## Summary
- Destructure `iconSize` from props before the rest spread to prevent it from being passed as an unknown HTML attribute to the `<button>` or `<a>` DOM element
- This eliminates the React console warning: "Unknown prop `iconSize` on <button> tag"
- Also respects user-provided `iconSize` values via nullish coalescing, falling back to the size-based calculation

Fixes #1225

## Files Changed
- `src/components/button/button_empty/button_empty.tsx` — added `iconSize` to destructuring

## Test plan
- [ ] Render `<OuiButtonEmpty iconType="arrowDown" />` — no console warnings
- [ ] Render `<OuiButtonEmpty iconType="arrowDown" iconSize="s" />` — custom iconSize respected, no warnings
- [ ] Existing button_empty snapshot tests pass

Signed-off-by: Anirudha Jadhav <anirudha@duck.com>