### PR TITLE
fix: prevent OuiCheckableCard onChange from firing twice

### DIFF
--- a/src/components/card/checkable_card/checkable_card.tsx
+++ b/src/components/card/checkable_card/checkable_card.tsx
@@ -108,7 +108,12 @@ export const OuiCheckableCard: FunctionComponent<OuiCheckableCardProps> = ({
     'ouiCheckableCard__label-isDisabled': disabled,
   });
 
-  const onChangeAffordance = () => {
+  const onChangeAffordance = (e: React.MouseEvent<HTMLDivElement>) => {
+    // Avoid double-firing onChange when clicking the input directly:
+    // the native input already fires onChange, so only trigger the label
+    // click when the event comes from something other than the input.
+    const target = e.target as HTMLElement;
+    if (target.tagName === 'INPUT') return;
     if (labelEl.current) {
       labelEl.current.click();
     }


### PR DESCRIPTION
## Summary
- When clicking the checkbox/radio input directly inside `OuiCheckableCard`, the `onChange` callback fires twice
- Root cause: native input fires onChange, then the click event bubbles up to the panel wrapper which calls `labelEl.click()`, causing the browser to toggle the input again via the `htmlFor` association
- Fix: guard the affordance click by checking if the event target is already the `INPUT` element — same pattern used by `OuiCard` (see `card.tsx` line 237)

Fixes #1278

## Files Changed
- `src/components/card/checkable_card/checkable_card.tsx` — added target check in `onChangeAffordance`

## Test plan
- [ ] Click directly on the checkbox input — onChange fires exactly once
- [ ] Click on the card panel area (outside checkbox) — onChange still fires correctly
- [ ] Click on the label text — onChange fires exactly once
- [ ] Radio mode works the same way
- [ ] Disabled state still prevents interaction

Signed-off-by: Anirudha Jadhav <anirudha@duck.com>