### PR TITLE
fix: elevate flyout z-index above header to prevent overlap

### DIFF
--- a/src/global_styling/variables/_z_index.scss
+++ b/src/global_styling/variables/_z_index.scss
@@ -40,7 +40,7 @@ $ouiZMask: $ouiZLevel6;
 $ouiZNavigation: $ouiZLevel6;
 $ouiZContentMenu: $ouiZLevel2;
 $ouiZHeader: $ouiZLevel1;
-$ouiZFlyout: $ouiZHeader;
+$ouiZFlyout: $ouiZLevel3;
 $ouiZMaskBelowHeader: $ouiZHeader;
 $ouiZContent: $ouiZLevel0;
 

--- a/src/themes/oui-next/global_styling/variables/_z_index.scss
+++ b/src/themes/oui-next/global_styling/variables/_z_index.scss
@@ -40,7 +40,7 @@ $ouiZMask: $ouiZLevel6;
 $ouiZNavigation: $ouiZLevel6;
 $ouiZContentMenu: $ouiZLevel2;
 $ouiZHeader: $ouiZLevel1;
-$ouiZFlyout: $ouiZHeader;
+$ouiZFlyout: $ouiZLevel3;
 $ouiZMaskBelowHeader: $ouiZHeader;
 $ouiZContent: $ouiZLevel0;
 

--- a/src/themes/v9/global_styling/variables/_z_index.scss
+++ b/src/themes/v9/global_styling/variables/_z_index.scss
@@ -40,7 +40,7 @@ $ouiZMask: $ouiZLevel6;
 $ouiZNavigation: $ouiZLevel6;
 $ouiZContentMenu: $ouiZLevel2;
 $ouiZHeader: $ouiZLevel1;
-$ouiZFlyout: $ouiZHeader;
+$ouiZFlyout: $ouiZLevel3;
 $ouiZMaskBelowHeader: $ouiZHeader;
 $ouiZContent: $ouiZLevel0;
 


### PR DESCRIPTION
## Summary
- `$ouiZFlyout` was set to `$ouiZHeader` (both 1000), causing fixed header elements to appear above flyouts
- Changed `$ouiZFlyout` to `$ouiZLevel3` (3000) across all three theme z-index files
- Flyouts now properly overlay headers while remaining below modals (8000) and toasts (9000)

**Updated z-index hierarchy:**
```
content (0) < header (1000) < contentMenu (2000) < flyout (3000)
< navigation (6000) < mask (6000) < modal (8000) < toast (9000)
```

Fixes #1622

## Files Changed
- `src/global_styling/variables/_z_index.scss`
- `src/themes/v9/global_styling/variables/_z_index.scss`
- `src/themes/oui-next/global_styling/variables/_z_index.scss`

## Test plan
- [ ] Open a flyout with a fixed header present — flyout renders above header
- [ ] Open a modal while flyout is open — modal renders above flyout
- [ ] Toast notifications still render above everything
- [ ] Push-mode flyout (`ouiFlyout--push`) is not affected (uses `$ouiZHeader - 1`)

Signed-off-by: Anirudha Jadhav <anirudha@duck.com>