### PR TITLE
fix: remove transform that breaks drag-and-drop inside accordion

### DIFF
--- a/src/components/accordion/_accordion.scss
+++ b/src/components/accordion/_accordion.scss
@@ -82,7 +82,6 @@
   height: 0;
   opacity: 0;
   overflow: hidden;
-  transform: translatez(0);
   // sass-lint:disable-block indentation
   transition:
     height $ouiAnimSpeedNormal $ouiAnimSlightResistance,


### PR DESCRIPTION
## Summary
- `transform: translatez(0)` on `.ouiAccordion__childWrapper` created a CSS stacking context
- This clipped react-beautiful-dnd's portal-based drag preview, making drag-and-drop items invisible when dragged from within an accordion
- Removed the transform — modern browsers don't need this GPU hint for height/opacity transitions

Fixes #896

## Files Changed
- `src/components/accordion/_accordion.scss` — removed `transform: translatez(0)` from `.ouiAccordion__childWrapper`

## Test plan
- [ ] Place draggable items inside an accordion — drag preview visible during drag
- [ ] Accordion open/close animation still works smoothly
- [ ] No visual regressions in accordion appearance

Signed-off-by: Anirudha Jadhav <anirudha@duck.com>