### PR TITLE
fix: prevent text clipping in OuiButtonEmpty and pagination buttons

### DIFF
--- a/src/components/button/button_empty/_button_empty.scss
+++ b/src/components/button/button_empty/_button_empty.scss
@@ -32,6 +32,7 @@
 
   .ouiButtonEmpty__text {
     display: flex;
+    align-items: center;
     text-overflow: ellipsis;
     overflow: hidden;
   }

--- a/src/components/pagination/_pagination.scss
+++ b/src/components/pagination/_pagination.scss
@@ -31,5 +31,5 @@
 
 .ouiPagination__list {
   display: flex;
-  align-items: baseline;
+  align-items: center;
 }


### PR DESCRIPTION
## Summary
- **OuiButtonEmpty** (#1499): Added `align-items: center` to `.ouiButtonEmpty__text` — the flex container had `overflow: hidden` but no vertical alignment, causing text to clip
- **Pagination** (#1486): Changed `.ouiPagination__list` from `align-items: baseline` to `center` — baseline alignment caused button text to be cut off at the bottom

Fixes #1499
Fixes #1486

## Files Changed
- `src/components/button/button_empty/_button_empty.scss`
- `src/components/pagination/_pagination.scss`

## Test plan
- [ ] OuiButtonEmpty text is fully visible (no clipping at top/bottom)
- [ ] Pagination buttons show full numbers without text cut-off
- [ ] Pagination ellipsis placeholder still aligns properly
- [ ] No visual regression in button sizes (xs, s, default, l)

Signed-off-by: Anirudha Jadhav <anirudha@duck.com>