### PR TITLE
fix: reposition popover on scroll within any scrollable container

### DIFF
--- a/src/components/popover/popover.tsx
+++ b/src/components/popover/popover.tsx
@@ -670,7 +670,7 @@ export class OuiPopover extends Component<Props, State> {
     }
 
     if (this.props.repositionOnScroll) {
-      window.addEventListener('scroll', this.positionPopoverFixed);
+      window.addEventListener('scroll', this.positionPopoverFixed, true);
     }
   }
 
@@ -689,9 +689,9 @@ export class OuiPopover extends Component<Props, State> {
     // update scroll listener
     if (prevProps.repositionOnScroll !== this.props.repositionOnScroll) {
       if (this.props.repositionOnScroll) {
-        window.addEventListener('scroll', this.positionPopoverFixed);
+        window.addEventListener('scroll', this.positionPopoverFixed, true);
       } else {
-        window.removeEventListener('scroll', this.positionPopoverFixed);
+        window.removeEventListener('scroll', this.positionPopoverFixed, true);
       }
     }
 
@@ -712,7 +712,7 @@ export class OuiPopover extends Component<Props, State> {
   }
 
   componentWillUnmount() {
-    window.removeEventListener('scroll', this.positionPopoverFixed);
+    window.removeEventListener('scroll', this.positionPopoverFixed, true);
     this.removeBackupClickDetection();
     clearTimeout(this.respositionTimeout);
     clearTimeout(this.closingTransitionTimeout);


### PR DESCRIPTION
## Summary
- `OuiPopover` with `repositionOnScroll` only listened for `window` scroll events in the bubble phase
- The `scroll` event does **not** bubble — it only fires on the element that actually scrolled
- Fix: use capture phase (`addEventListener('scroll', handler, true)`) so the listener catches scroll events from any ancestor element

Fixes #1184

## Files Changed
- `src/components/popover/popover.tsx` — add `true` (capture) to scroll event listener add/remove

## Test plan
- [ ] Open a popover inside a scrollable container — popover repositions on container scroll
- [ ] Open a popover with `repositionOnScroll` — still repositions on window scroll
- [ ] Open/close popover — no memory leaks (event listener properly removed)

Signed-off-by: Anirudha Jadhav <anirudha@duck.com>