### PR TITLE
fix: remove legacy Firefox focusring hack that broke select display

### DIFF
--- a/src/components/form/select/_select.scss
+++ b/src/components/form/select/_select.scss
@@ -50,8 +50,8 @@
     background: transparent;
   }
 
-  &:-moz-focusring {
-    color: transparent;
-    text-shadow: 0 0 0 $ouiTextColor;
-  }
+  // Removed legacy :-moz-focusring hack that set color: transparent
+  // with a text-shadow workaround. This caused Firefox to not update
+  // the displayed selection text. Modern Firefox handles focus rings
+  // natively and no longer needs this override.
 }


### PR DESCRIPTION
## Summary
- The `:-moz-focusring` CSS rule set `color: transparent` with a `text-shadow` workaround to hide Firefox's dotted focus ring on `<select>` elements
- This caused Firefox to not visually update the displayed selection text when the value changed
- Modern Firefox handles focus rings natively via `:focus-visible` — this hack is no longer needed

Fixes #1655

## Files Changed
- `src/components/form/select/_select.scss` — removed `:-moz-focusring` rule

## Test plan
- [ ] In Firefox: change a select value — displayed text updates immediately
- [ ] In Firefox: select element focus ring appears properly (via :focus-visible)
- [ ] In Chrome/Safari: no visual regression

Signed-off-by: Anirudha Jadhav <anirudha@duck.com>