### PR TITLE
fix: hide overflow scrollbar in DataGrid cells with fixed row heights

### DIFF
--- a/src/components/datagrid/_data_grid_data_row.scss
+++ b/src/components/datagrid/_data_grid_data_row.scss
@@ -160,6 +160,7 @@
 .ouiDataGridRowCell__contentByHeight {
   flex-grow: 1;
   height: 100%;
+  overflow: hidden;
 }
 
 .ouiDataGridRowCell__alignBaseLine {


### PR DESCRIPTION
## Summary
- When `rowHeightsOptions` with `lineCount: 1` is used, cell content exceeding the calculated height would show an unwanted inner scrollbar
- Added `overflow: hidden` to `.ouiDataGridRowCell__contentByHeight` so overflowing content is clipped instead of creating a scrollbar
- Content can still be viewed via the cell expand popover

Fixes #1240

## Files Changed
- `src/components/datagrid/_data_grid_data_row.scss`

## Test plan
- [ ] Set `rowHeightsOptions: { defaultHeight: { lineCount: 1 } }` — no scrollbar in cells
- [ ] Cell expand popover still shows full content
- [ ] Multi-line mode (`lineCount: 3`) still works correctly

Signed-off-by: Anirudha Jadhav <anirudha@duck.com>