### PR TITLE
Upgrade lodash 4.17.21 → 4.18.1 (3 CVEs, highest CVSS 8.1)

### DIFF
--- a/package.json
+++ b/package.json
@@ -105,7 +105,7 @@
     "@types/react-window": "^1.8.5",
     "chroma-js": "^2.4.2",
     "classnames": "^2.3.2",
-    "lodash": "^4.17.21",
+    "lodash": "^4.18.1",
     "mdast-util-to-hast": "^10.0.0",
     "numeral": "^2.0.6",
     "prop-types": "^15.8.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10923,6 +10923,11 @@ lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
 
+lodash@^4.18.1:
+  version "4.18.1"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.18.1.tgz#ff2b66c1f6326d59513de2407bf881439812771c"
+  integrity sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==
+
 log-symbols@^2.1.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/log-symbols/-/log-symbols-2.2.0.tgz#5740e1c5d6f0dfda4ad9323b5332107ef6b4c40a"


### PR DESCRIPTION
## Summary
- Upgrades lodash from 4.17.21 to 4.18.1 to resolve 3 security vulnerabilities:
  - **CVE-2026-4800** (CVSS 8.1, High): `_.template` `options.imports` key injection allows arbitrary code execution
  - **CVE-2025-13465** (CVSS 7.2, High): Prototype pollution via `assignInWith` inherited property enumeration
  - **CVE-2026-2950** (CVSS 6.5, Medium): Additional prototype pollution vector
- OUI uses lodash via individual module imports (`get`, `omit`, `isFunction`, `isArray`, `times`, `memoize`, `defaults`, `range`, etc.) — none of the affected APIs (`_.template`, `assignInWith`) are used, making the upgrade fully backwards compatible
- All 13 lodash functions used in the codebase verified working with 4.18.1

## Test plan
- [x] Verified lodash 4.18.1 installs cleanly via `yarn install`
- [x] Verified all 13 lodash module imports used by OUI (`get`, `omit`, `isFunction`, `isArray`, `isString`, `isBoolean`, `isNumber`, `isNaN`, `isObject`, `times`, `memoize`, `defaults`, `range`) produce correct results
- [x] No API changes between 4.17.x and 4.18.x for the functions OUI uses
- [ ] CI: lint, unit tests (React 16 + 18), build

Closes #1711

Signed-off-by: Anirudha Jadhav <anirudha@duck.com>