### PR TITLE
Fix CVE-2024-53382: upgrade prismjs 1.27.0 → 1.30.0 via yarn resolution

### DIFF
--- a/package.json
+++ b/package.json
@@ -93,7 +93,8 @@
     "webpack/terser-webpack-plugin/serialize-javascript": "^3.1.0",
     "yo/**/find-versions": "^4.0.0",
     "yo/**/got": "^11.8.5",
-    "yo/meow": "^9.0.0"
+    "yo/meow": "^9.0.0",
+    "refractor/prismjs": "^1.30.0"
   },
   "pre-commit": [
     "lint"

--- a/yarn.lock
+++ b/yarn.lock
@@ -13218,10 +13218,10 @@ prism-react-renderer@^1.0.2:
   resolved "https://registry.yarnpkg.com/prism-react-renderer/-/prism-react-renderer-1.2.0.tgz#5ad4f90c3e447069426c8a53a0eafde60909cdf4"
   integrity sha512-GHqzxLYImx1iKN1jJURcuRoA/0ygCcNhfGw1IT8nPIMzarmKQ3Nc+JcG0gi8JXQzuh0C5ShE4npMIoqNin40hg==
 
-prismjs@~1.27.0:
-  version "1.27.0"
-  resolved "https://registry.yarnpkg.com/prismjs/-/prismjs-1.27.0.tgz#bb6ee3138a0b438a3653dd4d6ce0cc6510a45057"
-  integrity sha512-t13BGPUlFDR7wRB5kQDG4jjl7XeuH6jbJGt11JHPL96qwsEHNX2+68tFXqc1/k+/jALsbSWJKUOT/hcYAZ5LkA==
+prismjs@^1.30.0, prismjs@~1.27.0:
+  version "1.30.0"
+  resolved "https://registry.yarnpkg.com/prismjs/-/prismjs-1.30.0.tgz#d9709969d9d4e16403f6f348c63553b19f0975a9"
+  integrity sha512-DEvV2ZF2r2/63V+tK8hQvrR2ZGn10srHbXviTlcv7Kpzw8jWiNTqbVgjO3IY8RxrrOUF8VPMQQFysYYYv0YZxw==
 
 proc-log@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
## Summary
- Fixes **CVE-2024-53382** (CVSS 4.9, Medium): DOM Clobbering vulnerability in prismjs ≤1.29.0 that could enable XSS when processing untrusted HTML input via `document.currentScript` shadowing
- The vulnerable `prismjs@1.27.0` is a transitive dependency of `refractor@3.6.0` (which pins `~1.27.0`)
- Adds a yarn resolution (`refractor/prismjs: ^1.30.0`) to force the patched version without migrating to refractor 4.x (which is ESM-only and would require a major codebase migration)
- `prismjs` 1.30.0 API is backwards compatible with 1.27.0 — `refractor.highlight()` works correctly with the upgraded dependency

## Test plan
- [x] Verified prismjs 1.30.0 installs via the yarn resolution
- [x] Verified `refractor.highlight()` works correctly with prismjs 1.30.0
- [x] Verified named imports (`highlight`, `AST`, `RefractorNode`) from refractor resolve correctly
- [x] Verified `refractor.listLanguages()` and `refractor.register()` still function
- [ ] CI: lint, unit tests (React 16 + 18), build

Closes #1520

Signed-off-by: Anirudha Jadhav <anirudha@duck.com>