### PR TITLE
Add GitHub environment to release workflow

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,4 +1,4 @@
-name: Draft a release
+name: Release Workflow
 
 on:
   push:
@@ -6,53 +6,44 @@ on:
       - "*"
 
 jobs:
-  draft_release:
+  release-to-npm:
+    environment: release-approval
     runs-on: ubuntu-latest
     permissions:
       id-token: write  # Required for OIDC
       contents: write
-      issues: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
-      - id: get_data
-        run: |
-          echo "approvers=$(cat .github/CODEOWNERS | grep @ | tr -d '* ' | sed 's/@/,/g' | sed 's/,//1')" >> $GITHUB_OUTPUT
-          echo "version=$(cat package.json | grep '"version": "[^ ]\+"' | cut -c15- | cut -d'"' -f1)" >> $GITHUB_OUTPUT
-      - uses: trstringer/manual-approval@v1
-        with:
-          secret: ${{ github.TOKEN }}
-          approvers: ${{ steps.get_data.outputs.approvers }}
-          minimum-approvals: 2
-          issue-title: 'Release OUI: ${{ steps.get_data.outputs.version }}'
-          issue-body: "Please approve or deny the release of OUI. **VERSION**: ${{ steps.get_data.outputs.version }} **TAG**: ${{ github.ref_name }}  **COMMIT**: ${{ github.sha }}"
-          exclude-workflow-initiator-as-approver: true
+        uses: actions/checkout@v6
+
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version-file: '.nvmrc'
           registry-url: 'https://registry.npmjs.org'
+          package-manager-cache: false
+
       - name: Setup Yarn
         run: |
           npm uninstall -g yarn
           npm i -g yarn@1.22.10
           yarn install --frozen-lockfile
-      - name: Generate build
-        run: |
-          yarn build
-          yarn pack --filename oui.tar.gz
-          mkdir oui && mv oui.tar.gz oui/oui.tar.gz
-          tar -cvf artifacts.tar.gz oui
-      - uses: actions/setup-node@v4
+
+      - name: Build
+        run: yarn build
+
+      - uses: actions/setup-node@v6
         with:
           node-version: '24'
           registry-url: 'https://registry.npmjs.org'
+          package-manager-cache: false
+
       - run: npm ci
+
       - run: npm publish
-      - name: Release
-        uses: softprops/action-gh-release@v1
+
+      - name: Release on Github
+        uses: softprops/action-gh-release@v2
         with:
           draft: false
           generate_release_notes: true
-          files: |
-            artifacts.tar.gz

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -34,8 +34,7 @@ Repositories create consistent release labels, such as `v1.0.0`, `v1.1.0` and `v
 The release process is standard across repositories in this org and is run by a release manager volunteering from amongst [maintainers](MAINTAINERS.md).
 
 1. Create a tag, e.g. v2.1.0, and push it to the GitHub repo.
-1. The [release-drafter.yml](.github/workflows/release-drafter.yml) will be automatically kicked off and a draft release will be created.
-1. Before creating a release, this workflow creates a GitHub issue asking for approval from the [maintainers](MAINTAINERS.md). See sample [issue](https://github.com/gaiksaya/opensearch-js/issues/1). The maintainers need to approve in order to continue the workflow run.
-1. Since the repo is already added as part of NPM trusted publisher, `npm publish` with npm version v11.5.1 or above will directly authenticate the workflow and publish to NPM.
-1. Once the above release workflow is successful, the release on GitHub is published automatically.
-1. Increment "version" in package.json to the next patch release, e.g. v2.1.1. See [example](https://github.com/opensearch-project/opensearch-js/pull/318)
+1. The [release-drafter.yml](.github/workflows/release-drafter.yml) will be automatically kicked off and is responsible for publishing the package to NPM and creating a release on GitHub.
+1. The workflow requires approval from reviewers configured in the `release-approval` GitHub environment before it proceeds.
+1. Once approved, the workflow publishes to NPM using trusted publishers (OIDC authentication) and creates a GitHub release with auto-generated release notes.
+1. Increment "version" in package.json to the next patch release, e.g. v2.1.1.


### PR DESCRIPTION
### Description

  - Uses release-approval environment instead of the manual-approval GitHub Action
  - Removes artifact bundling (no more yarn pack / artifacts.tar.gz attached to the release) as it is not required for release and users can directly download from npmjs
  - Updates actions to v6 and softprops/action-gh-release to v2

### Issues Resolved
<!-- List any issues this PR will resolve. -->
<!-- Example: Fixes #1234 -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] All tests pass
  - [ ] `yarn lint`
  - [ ] `yarn test-unit`
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/oui/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
