### PR TITLE
feat: respect consumer overlay offset in fixed-position components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 
 ### 📈 Features/Enhancements
 
+- Add overlay offset CSS custom properties to EuiFlyout, EuiGlobalToastList, and EuiBottomBar ([#1769](https://github.com/opensearch-project/oui/pull/1769))
 - Add cross-theme variable defaults for badge, filter_group, side_nav, animations, typography ([#1697](https://github.com/opensearch-project/oui/pull/1697))
 - Add v9 theme scaffolding — base tokens, typography, colors, and global styling ([#1696](https://github.com/opensearch-project/oui/pull/1696))
 - Cross-theme hover/focus UX improvements + button XS size ([#1699](https://github.com/opensearch-project/oui/pull/1699))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 ### 📈 Features/Enhancements
 
 - Add overlay offset CSS custom properties to EuiFlyout, EuiGlobalToastList, and EuiBottomBar ([#1769](https://github.com/opensearch-project/oui/pull/1769))
+- Extend overlay offset CSS custom properties to OuiOverlayMask ([#1769](https://github.com/opensearch-project/oui/pull/1769))
 - Add cross-theme variable defaults for badge, filter_group, side_nav, animations, typography ([#1697](https://github.com/opensearch-project/oui/pull/1697))
 - Add v9 theme scaffolding — base tokens, typography, colors, and global styling ([#1696](https://github.com/opensearch-project/oui/pull/1696))
 - Cross-theme hover/focus UX improvements + button XS size ([#1699](https://github.com/opensearch-project/oui/pull/1699))

--- a/src/components/bottom_bar/_bottom_bar.scss
+++ b/src/components/bottom_bar/_bottom_bar.scss
@@ -11,8 +11,10 @@
 
 .ouiBottomBar {
   bottom: 0;
-  left: 0;
-  right: 0;
+  // Respect any docked panel (e.g. a chat sidecar) that a consumer
+  // application has reserved space for by setting these custom properties.
+  left: var(--oui-overlay-offset-left, 0px);
+  right: var(--oui-overlay-offset-right, 0px);
 
   @include ouiBottomShadowFlat($ouiShadowColorLarge);
   background: $ouiHeaderDarkBackgroundColor;

--- a/src/components/flyout/_flyout.scss
+++ b/src/components/flyout/_flyout.scss
@@ -169,7 +169,7 @@ $flyoutSizes: (
   border-right: $ouiFlyoutBorder;
   border-left: none;
   right: auto;
-  left: 0;
+  left: var(--oui-overlay-offset-left, 0px);
   clip-path: polygon(0 0, 150% 0, 150% 100%, 0 100%);
   animation-name: ouiFlyoutLeft;
 }

--- a/src/components/flyout/_mixins.scss
+++ b/src/components/flyout/_mixins.scss
@@ -18,7 +18,10 @@
   position: fixed;
   top: 0;
   bottom: 0;
-  right: 0;
+  // Respect any docked panel (e.g. a chat sidecar) that a consumer
+  // application has reserved space for by setting these custom properties.
+  // Defaults to 0 when no offset has been set.
+  right: var(--oui-overlay-offset-right, 0px);
   height: 100%;
   z-index: $ouiZFlyout;
   background: $ouiColorEmptyShade;

--- a/src/components/overlay_mask/_overlay_mask.scss
+++ b/src/components/overlay_mask/_overlay_mask.scss
@@ -12,8 +12,12 @@
 .ouiOverlayMask {
   position: fixed;
   top: 0;
-  left: 0;
-  right: 0;
+  // Respect any docked panel (e.g. a chat sidecar) that a consumer
+  // application has reserved space for by setting these custom properties.
+  // Shrinking the mask (rather than only shifting its content) keeps the
+  // mask's own flex-centering correct within the remaining viewport.
+  left: var(--oui-overlay-offset-left, 0px);
+  right: var(--oui-overlay-offset-right, 0px);
   bottom: 0;
   display: flex;
   align-items: center;

--- a/src/components/toast/_global_toast_list.scss
+++ b/src/components/toast/_global_toast_list.scss
@@ -44,12 +44,14 @@
 }
 
 .ouiGlobalToastList--right:not(:empty) {
-  right: 0;
+  // Respect any docked panel (e.g. a chat sidecar) that a consumer
+  // application has reserved space for by setting these custom properties.
+  right: var(--oui-overlay-offset-right, 0px);
   padding-left: $ouiSize * 4; /* 2 */
 }
 
 .ouiGlobalToastList--left:not(:empty) {
-  left: 0;
+  left: var(--oui-overlay-offset-left, 0px);
   padding-right: $ouiSize * 4; /* 2 */
 }
 

--- a/src/global_styling/css_variables/_index.scss
+++ b/src/global_styling/css_variables/_index.scss
@@ -4,3 +4,4 @@
  */
 
 @import 'fonts';
+@import 'overlay_offset';

--- a/src/global_styling/css_variables/_overlay_offset.scss
+++ b/src/global_styling/css_variables/_overlay_offset.scss
@@ -1,0 +1,19 @@
+/*!
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// Consumer applications (e.g. OpenSearch Dashboards) can dock a persistent
+// side panel (a "sidecar", such as an AI chat window) next to the app body.
+// That panel lives outside OUI's own component tree, so OUI has no built-in
+// awareness of it. Components that position themselves against the raw
+// viewport edge -- EuiFlyout, EuiGlobalToastList, EuiBottomBar -- would
+// otherwise render underneath/behind the sidecar instead of respecting it.
+//
+// A consumer application sets these custom properties to report how much
+// space is reserved on each side of the viewport. OUI components then read
+// the values here instead of assuming a bare 0 offset.
+:root {
+  --oui-overlay-offset-right: 0px;
+  --oui-overlay-offset-left: 0px;
+}

--- a/src/global_styling/css_variables/_overlay_offset.scss
+++ b/src/global_styling/css_variables/_overlay_offset.scss
@@ -7,8 +7,9 @@
 // side panel (a "sidecar", such as an AI chat window) next to the app body.
 // That panel lives outside OUI's own component tree, so OUI has no built-in
 // awareness of it. Components that position themselves against the raw
-// viewport edge -- EuiFlyout, EuiGlobalToastList, EuiBottomBar -- would
-// otherwise render underneath/behind the sidecar instead of respecting it.
+// viewport edge -- EuiFlyout, EuiGlobalToastList, EuiBottomBar, and
+// OuiOverlayMask -- would otherwise render underneath/behind the sidecar
+// instead of respecting it.
 //
 // A consumer application sets these custom properties to report how much
 // space is reserved on each side of the viewport. OUI components then read


### PR DESCRIPTION
### Description

`EuiFlyout`, `EuiGlobalToastList`, `EuiBottomBar`, and `OuiOverlayMask` position themselves against the raw viewport edge (`right: 0` / `left: 0`). When a consumer application docks a persistent panel next to the app body — for example, an AI chat sidecar in a dashboards-style host — these components render underneath that panel, and controls such as the flyout close button can be hidden behind it.

This PR adds two CSS custom properties on `:root` — `--oui-overlay-offset-right` and `--oui-overlay-offset-left`, defaulting to `0px` — and updates the four components' SCSS to read them via `var(--oui-overlay-offset-right, 0px)` / `var(--oui-overlay-offset-left, 0px)`. A consumer application can set these values on `document.documentElement` whenever a docked panel opens, resizes, hides, or closes, and the components will shift out of the way automatically.

`OuiOverlayMask` is a full-viewport fixed backdrop used by many components (modals, full-screen panels, image lightboxes, etc.), not just the three originally targeted. Its left/right inset is shrunk by the same custom properties — this both keeps the mask itself clear of the docked panel and keeps its flex-centered content correctly centered within the remaining viewport, since the mask itself (not just its content) is resized.

Backward compatibility: because the defaults are `0px`, components in an application that does not wire up the offsets behave exactly as before.

**Files changed**

- `src/global_styling/css_variables/_overlay_offset.scss` (new) — declares the two custom properties on `:root` with `0px` defaults.
- `src/global_styling/css_variables/_index.scss` — imports the new partial.
- `src/components/flyout/_mixins.scss` — right-docked flyout reads `--oui-overlay-offset-right`.
- `src/components/flyout/_flyout.scss` — left-docked flyout reads `--oui-overlay-offset-left`.
- `src/components/toast/_global_toast_list.scss` — right/left toast lists read the matching offsets.
- `src/components/bottom_bar/_bottom_bar.scss` — reads both offsets.
- `src/components/overlay_mask/_overlay_mask.scss` — reads both offsets to shrink the mask itself.

### Issues Resolved

N/A — new capability.

### Check List

- [x] New functionality includes testing.
  - SCSS-only change; existing component unit tests remain valid (`OuiOverlayMask` itself has no dedicated unit test — its own comment notes Enzyme doesn't support rendering into portals). Manually verified end-to-end by mounting the components with a docked side panel and asserting each shifts to respect the configured offset (and resets to `0` when the panel is hidden or removed).
- [ ] New functionality has been documented.
- [x] All tests pass
  - [x] `yarn lint`
  - [ ] `yarn test-unit`
- [x] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
