### PR TITLE
[Backport 1.24.0] feat: overlay offset CSS custom properties (#1769)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,10 @@
 - Pin GitHub Actions to commit SHAs ([#1755](https://github.com/opensearch-project/oui/pull/1755))
 - Onboard new backport-pr re-usable github workflow ([#1766](https://github.com/opensearch-project/oui/pull/1766))
 
+### 📈 Features/Enhancements
+
+- Add overlay offset CSS custom properties to EuiFlyout, EuiGlobalToastList, and EuiBottomBar ([#1769](https://github.com/opensearch-project/oui/pull/1769))
+
 ### 🛠 Maintenance
 
 - Add Suzhou as maintainer ([#1771](https://github.com/opensearch-project/oui/pull/1771))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@
 ### 📈 Features/Enhancements
 
 - Add overlay offset CSS custom properties to EuiFlyout, EuiGlobalToastList, and EuiBottomBar ([#1769](https://github.com/opensearch-project/oui/pull/1769))
+- Extend overlay offset CSS custom properties to OuiOverlayMask ([#1769](https://github.com/opensearch-project/oui/pull/1769))
 
 ### 🛠 Maintenance
 

--- a/src/components/bottom_bar/_bottom_bar.scss
+++ b/src/components/bottom_bar/_bottom_bar.scss
@@ -11,8 +11,10 @@
 
 .ouiBottomBar {
   bottom: 0;
-  left: 0;
-  right: 0;
+  // Respect any docked panel (e.g. a chat sidecar) that a consumer
+  // application has reserved space for by setting these custom properties.
+  left: var(--oui-overlay-offset-left, 0px);
+  right: var(--oui-overlay-offset-right, 0px);
 
   @include ouiBottomShadowFlat($ouiShadowColorLarge);
   background: $ouiHeaderDarkBackgroundColor;

--- a/src/components/flyout/_flyout.scss
+++ b/src/components/flyout/_flyout.scss
@@ -169,7 +169,7 @@ $flyoutSizes: (
   border-right: $ouiFlyoutBorder;
   border-left: none;
   right: auto;
-  left: 0;
+  left: var(--oui-overlay-offset-left, 0px);
   clip-path: polygon(0 0, 150% 0, 150% 100%, 0 100%);
   animation-name: ouiFlyoutLeft;
 }

--- a/src/components/flyout/_mixins.scss
+++ b/src/components/flyout/_mixins.scss
@@ -18,7 +18,10 @@
   position: fixed;
   top: 0;
   bottom: 0;
-  right: 0;
+  // Respect any docked panel (e.g. a chat sidecar) that a consumer
+  // application has reserved space for by setting these custom properties.
+  // Defaults to 0 when no offset has been set.
+  right: var(--oui-overlay-offset-right, 0px);
   height: 100%;
   z-index: $ouiZFlyout;
   background: $ouiColorEmptyShade;

--- a/src/components/overlay_mask/_overlay_mask.scss
+++ b/src/components/overlay_mask/_overlay_mask.scss
@@ -12,8 +12,12 @@
 .ouiOverlayMask {
   position: fixed;
   top: 0;
-  left: 0;
-  right: 0;
+  // Respect any docked panel (e.g. a chat sidecar) that a consumer
+  // application has reserved space for by setting these custom properties.
+  // Shrinking the mask (rather than only shifting its content) keeps the
+  // mask's own flex-centering correct within the remaining viewport.
+  left: var(--oui-overlay-offset-left, 0px);
+  right: var(--oui-overlay-offset-right, 0px);
   bottom: 0;
   display: flex;
   align-items: center;

--- a/src/components/toast/_global_toast_list.scss
+++ b/src/components/toast/_global_toast_list.scss
@@ -44,12 +44,14 @@
 }
 
 .ouiGlobalToastList--right:not(:empty) {
-  right: 0;
+  // Respect any docked panel (e.g. a chat sidecar) that a consumer
+  // application has reserved space for by setting these custom properties.
+  right: var(--oui-overlay-offset-right, 0px);
   padding-left: $ouiSize * 4; /* 2 */
 }
 
 .ouiGlobalToastList--left:not(:empty) {
-  left: 0;
+  left: var(--oui-overlay-offset-left, 0px);
   padding-right: $ouiSize * 4; /* 2 */
 }
 

--- a/src/global_styling/css_variables/_index.scss
+++ b/src/global_styling/css_variables/_index.scss
@@ -4,3 +4,4 @@
  */
 
 @import 'fonts';
+@import 'overlay_offset';

--- a/src/global_styling/css_variables/_overlay_offset.scss
+++ b/src/global_styling/css_variables/_overlay_offset.scss
@@ -1,0 +1,19 @@
+/*!
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// Consumer applications (e.g. OpenSearch Dashboards) can dock a persistent
+// side panel (a "sidecar", such as an AI chat window) next to the app body.
+// That panel lives outside OUI's own component tree, so OUI has no built-in
+// awareness of it. Components that position themselves against the raw
+// viewport edge -- EuiFlyout, EuiGlobalToastList, EuiBottomBar -- would
+// otherwise render underneath/behind the sidecar instead of respecting it.
+//
+// A consumer application sets these custom properties to report how much
+// space is reserved on each side of the viewport. OUI components then read
+// the values here instead of assuming a bare 0 offset.
+:root {
+  --oui-overlay-offset-right: 0px;
+  --oui-overlay-offset-left: 0px;
+}

--- a/src/global_styling/css_variables/_overlay_offset.scss
+++ b/src/global_styling/css_variables/_overlay_offset.scss
@@ -7,8 +7,9 @@
 // side panel (a "sidecar", such as an AI chat window) next to the app body.
 // That panel lives outside OUI's own component tree, so OUI has no built-in
 // awareness of it. Components that position themselves against the raw
-// viewport edge -- EuiFlyout, EuiGlobalToastList, EuiBottomBar -- would
-// otherwise render underneath/behind the sidecar instead of respecting it.
+// viewport edge -- EuiFlyout, EuiGlobalToastList, EuiBottomBar, and
+// OuiOverlayMask -- would otherwise render underneath/behind the sidecar
+// instead of respecting it.
 //
 // A consumer application sets these custom properties to report how much
 // space is reserved on each side of the viewport. OUI components then read


### PR DESCRIPTION
### Description

Backport of #1769 to `1.24.0` branch.

Adds overlay offset CSS custom properties (`--oui-overlay-offset-right`/`--oui-overlay-offset-left`) to EuiFlyout, EuiGlobalToastList, EuiBottomBar, and OuiOverlayMask. A consumer application can set these to reserve space for a persistent docked panel so these fixed-position components shift aside instead of rendering underneath it.

### Issues Resolved

Backport of https://github.com/opensearch-project/oui/pull/1769

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [x] All tests pass
  - [ ] `yarn lint`
  - [ ] `yarn test-unit`
- [x] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/oui/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).