### PR TITLE
Fix npm pack inclusion for lifecycle scripts

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -14,7 +14,9 @@ packages/eslint-plugin
 types/
 
 # ignore everything in `scripts` except postinstall.js and preinstall.js
-scripts/!(postinstall.js|preinstall.js)
+scripts/*
+!scripts/postinstall.js
+!scripts/preinstall.js
 
 src/**/*.!(scss)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@
 
 ### 🐛 Bug Fixes
 
+- Fix npm pack inclusion for lifecycle scripts with newer npm versions ([#1807](https://github.com/opensearch-project/oui/pull/1807))
+
 ### 🚞 Infrastructure
 
 ### 📝 Documentation


### PR DESCRIPTION
### Description

Updates `.npmignore` to use explicit ignore/unignore rules for `scripts/preinstall.js` and `scripts/postinstall.js`.

The previous extglob rule `scripts/!(postinstall.js|preinstall.js)` is not handled consistently by newer npm pack tooling. As a result, published tarballs can omit both lifecycle scripts while `package.json` still references them.

### Verification

Against unmodified `base/main`:

```
npm@8.19.4  postinstall=true  preinstall=true  scriptCount=2
npm@9.9.4   postinstall=false preinstall=false scriptCount=0
npm@11.18.0 postinstall=false preinstall=false scriptCount=0
```

Against this branch:

```
npm@8.19.4  postinstall=true preinstall=true scriptCount=2
npm@9.8.1   postinstall=true preinstall=true scriptCount=2
npm@9.9.4   postinstall=true preinstall=true scriptCount=2
npm@11.18.0 postinstall=true preinstall=true scriptCount=2
```

closed #1808