### PR TITLE
fix: ship install hooks by replacing extglob negation in .npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -14,7 +14,12 @@ packages/eslint-plugin
 types/
 
 # ignore everything in `scripts` except postinstall.js and preinstall.js
-scripts/!(postinstall.js|preinstall.js)
+# NOTE: use gitignore-style negation rather than an extglob such as
+# `scripts/!(postinstall.js|preinstall.js)`. npm's packer ignores extglob
+# negation and drops the whole directory, which breaks the install hooks.
+scripts/*
+!scripts/preinstall.js
+!scripts/postinstall.js
 
 src/**/*.!(scss)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@
 
 ### 🚞 Infrastructure
 
+- Ship `scripts/preinstall.js` and `scripts/postinstall.js` by replacing the extglob negation in `.npmignore`, which npm's packer ignores ([#1809](https://github.com/opensearch-project/oui/pull/1809))
+
 ### 📝 Documentation
 
 - Add design system documentation pages — Principles, Foundations ([#1702](https://github.com/opensearch-project/oui/pull/1702))


### PR DESCRIPTION
### Description

`@opensearch-project/oui@1.24.0` cannot be installed. Its published tarball is missing the whole `scripts/` directory, but `package.json` still declares install hooks that live there, so every install dies immediately:

```
error .../node_modules/@elastic/eui: Command failed.
Command: node ./scripts/preinstall.js
Error: Cannot find module '.../node_modules/@elastic/eui/scripts/preinstall.js'
```

| Version | files under `scripts/` in the published tarball |
|---|---|
| 1.22.1 | 2 (`preinstall.js`, `postinstall.js`) |
| 1.23.0 | 2 |
| **1.24.0** | **0** ❌ |

**No source file changed.** `.npmignore` is byte-identical between the `1.23.0` and `1.24.0` tags. What changed is *how the package gets published*.

### The gap between 1.23.0 and 1.24.0

1.24.0 is the first release published by the rewritten release workflow.

| | up to 1.23.0 | 1.24.0 |
|---|---|---|
| Did the release workflow publish to npm? | **No.** It only built `oui.tar.gz` and attached it to a *draft GitHub release*. npm publishing happened by some other, non-workflow route. | **Yes** — `npm publish` in CI |
| npm version doing the packing | n/a in CI; whatever published 1.23.0 honoured the `.npmignore` pattern | **npm 11.x** (the workflow pins Node 24, overriding `.nvmrc`, since trusted publishing needs npm ≥ 11.5.1) |
| `scripts/` in the resulting tarball | 2 files ✅ | 0 files ❌ |

That's the whole gap: **the npm tarball started being produced by `npm publish`, and npm's packer does not honour the pattern `.npmignore` uses.**

### Why that breaks it

`.npmignore` keeps the two install hooks with a shell *extglob* negation:

```
scripts/!(postinstall.js|preinstall.js)
```

npm's packer stopped honouring extglob negation in **npm 8.12.0**, and it does not degrade gracefully — it prunes the *entire* directory. Bisected with `npm pack --dry-run` on a fixture holding `preinstall.js`, `postinstall.js`, and one other file:

| Packer | `scripts/` in tarball |
|---|---|
| npm 6.14.18, 7.24.2, 8.0.0, 8.3.2, 8.5.5, 8.11.0 | both hooks kept ✅ |
| **npm 8.12.0** and everything after (8.12.2 … 8.19.4, 9.9.4, 10.9.8, 11.6.4) | whole dir dropped ❌ |
| yarn 1.22.22 | both hooks kept ✅ |

Two conditions had to line up, and **neither alone breaks anything**:

1. `.npmignore` relies on extglob negation — latent for years.
2. The release started using `npm publish` (npm ≥ 8.12) — which exposed it.

The release infra work did not introduce the defect; it stopped hiding it. This PR fixes condition 1, so the outcome no longer depends on which packer runs.

<details>
<summary>Notes on the npm 8.12.0 regression, and what this is <em>not</em></summary>

`npm-packlist` (5.1.0) and `ignore-walk` (5.0.1) are byte-identical between npm 8.11.0 and 8.12.0, so this is a change in npm's own code, not those deps. I did not pin the exact commit. It is *not* minimatch's `noext` option — `noext: true` makes the pattern match nothing, which would keep everything, the opposite of what happens.

The same workflow rewrite also deleted a `yarn pack --filename oui.tar.gz` step, which is easy to misread as the cause. It isn't. `npm publish` does its own packing and never consumed that output — the yarn tarball was only attached to a GitHub release, never sent to the registry. Proof: #1708 added `npm publish` while leaving `yarn pack` in place, and both coexisted (`yarn pack` at line 43, `npm publish` at line 51). A release cut there would have broken *with `yarn pack` still present*. The removal (#1753) is inert here.

Also not a factor: the `.nvmrc` bump `18.16.0` → `22.22.0`. The publish step overrides `.nvmrc` with Node 24 anyway, and Node 18 already ships npm 9.5.1, which is equally affected.
</details>

### The fix

Replace the extglob with gitignore-style negation, honoured by every packer tested (npm 6 → 11, yarn 1):

```
scripts/*
!scripts/preinstall.js
!scripts/postinstall.js
```

A comment is included so it isn't "simplified" back to an extglob later.

Fixing `.npmignore` is preferred over reverting the publish tooling: reverting to a yarn-based publish would also unblock the release, but it forfeits trusted publishing and leaves the trap armed for whoever next runs `npm publish`.

### Why `--ignore-scripts` is not a consumer workaround

`scripts/postinstall.js` generates the OUI→EUI theme aliases, and `src/themes/eui/` is not shipped in the tarball — it is created at install time. Skipping scripts trades the install failure for a broken SCSS build:

| Install | `src/themes/` contents |
|---|---|
| 1.23.0 (postinstall ran) | `charts, eui, eui-next, oui, oui-next, v9` |
| 1.24.0 with `--ignore-scripts` | `charts, oui, oui-next, v9` — no `eui/` |

OpenSearch Dashboards imports those aliases directly from its core stylesheets (all four `_globals_v{7,8}{light,dark}.scss`), e.g. `@import "@elastic/eui/src/themes/eui/eui_colors_light";`. So 1.24.0 is unusable by any route, and a patch release is needed once this merges.

### Verification

`npm pack --dry-run` in this repo now yields exactly the two hooks and nothing else from `scripts/`:

```
scripts/postinstall.js
scripts/preinstall.js
```

Confirmed on the fixture that the new pattern keeps both hooks — while still excluding everything else under `scripts/` — on npm 6.14.18, 7.24.2, 8.11.0, 8.12.0, 9.9.4, 10.9.8, **11.6.4** (the version the publish workflow actually uses), and yarn 1.22.22.

Original failure, end to end:

```bash
mkdir /tmp/oui-124 && cd /tmp/oui-124
printf '{"name":"v","version":"1.0.0","private":true,"dependencies":{"@elastic/eui":"npm:@opensearch-project/oui@1.24.0"}}' > package.json
yarn install   # fails; switching to 1.23.0 installs cleanly
```

### Note on branches

Release tags are cut from `1.x`, not `main`, so **#1810 is the PR needed to unblock the release**; this one keeps `main` consistent. Merging either does not republish — a **1.24.1 from `1.x`** is still required.

### Issues Resolved

Fixes #1808

### Check List
- [x] New functionality includes testing.
  - n/a — packaging metadata fix with no runtime surface; verified by inspecting `npm pack` / `yarn pack` output across npm 6–11 and yarn 1 as tabulated above.
- [x] New functionality has been documented.
  - n/a — no API change. An explanatory comment was added in `.npmignore`.
- [ ] All tests pass
  - [ ] `yarn lint` — fails on `main` **before and after** this change, with the same 6 errors, all in `src-docs/src/views/icon/icon_example.js` (3 `prettier/prettier`, 3 `react/no-unescaped-entities`). `tsc --noEmit` passes.
  - [ ] `yarn test-unit` — `Test Suites: 1 failed, 1 skipped, 306 passed`; `Tests: 15 failed, 6 skipped, 3237 passed`. The only failing suite is `packages/eslint-plugin/rules/href_or_on_click.test.js`, failing with `ESLint configuration in rule-tester is invalid: Unexpected top-level property "languageOptions"`.

  Both reproduce identically on unmodified `main` (verified by stashing this change and re-running), so they are pre-existing and unrelated. `.npmignore` is not matched by the eslint glob `{src,src-docs,scripts}/**/*.{ts,tsx,js}` and is not read by Jest, so it cannot influence either result. Happy to rebase once those are addressed on `main`.
- [x] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
