### PR TITLE
fix: scope overlay offset vars to below-header masks only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@
 
 ### 🐛 Bug Fixes
 
+
+- Scope overlay offset CSS custom properties to below-header masks only, keeping above-header masks (modals, fullscreen views) at full viewport width ([#1824](https://github.com/opensearch-project/oui/pull/1824))
 ### 🚞 Infrastructure
 
 - Ship `scripts/preinstall.js` and `scripts/postinstall.js` by replacing the extglob negation in `.npmignore`, which npm's packer ignores ([#1809](https://github.com/opensearch-project/oui/pull/1809))

--- a/src/components/overlay_mask/_overlay_mask.scss
+++ b/src/components/overlay_mask/_overlay_mask.scss
@@ -12,12 +12,8 @@
 .ouiOverlayMask {
   position: fixed;
   top: 0;
-  // Respect any docked panel (e.g. a chat sidecar) that a consumer
-  // application has reserved space for by setting these custom properties.
-  // Shrinking the mask (rather than only shifting its content) keeps the
-  // mask's own flex-centering correct within the remaining viewport.
-  left: var(--oui-overlay-offset-left, 0px);
-  right: var(--oui-overlay-offset-right, 0px);
+  left: 0;
+  right: 0;
   bottom: 0;
   display: flex;
   align-items: center;
@@ -45,4 +41,10 @@
 
 .ouiOverlayMask--belowHeader {
   z-index: $ouiZMaskBelowHeader;
+  // Respect any docked panel (e.g. a chat sidecar) that a consumer
+  // application has reserved space for by setting these custom properties.
+  // Shrinking the mask (rather than only shifting its content) keeps the
+  // mask's own flex-centering correct within the remaining viewport.
+  left: var(--oui-overlay-offset-left, 0px);
+  right: var(--oui-overlay-offset-right, 0px);
 }


### PR DESCRIPTION
## Description

Moves `--oui-overlay-offset-left/right` CSS custom properties from the base `.ouiOverlayMask` rule to `.ouiOverlayMask--belowHeader` only.

### Rationale

Above-header masks (used by modals, fullscreen code blocks, fullscreen images) should always cover the full viewport — they take over the entire screen and should not be influenced by a docked sidecar panel.

Below-header masks (used by flyouts) coexist with the header and visible app content, so they should respect the offset to avoid overlapping a docked panel.

### What changed

- `.ouiOverlayMask`: reverts to plain `left: 0; right: 0`
- `.ouiOverlayMask--belowHeader`: gains `left: var(--oui-overlay-offset-left, 0px); right: var(--oui-overlay-offset-right, 0px)`

### Testing

The default fallback (`0px`) means no visual change unless a consumer application sets the custom properties.